### PR TITLE
Add Android basic support

### DIFF
--- a/src/common/settings.c
+++ b/src/common/settings.c
@@ -391,3 +391,11 @@ uint32_t ffSettingsGetSQLiteColumnCount(FFinstance* instance, const char* fileNa
     return 0;
 }
 #endif //FF_HAVE_SQLITE3
+
+#ifdef __ANDROID__
+#include <sys/system_properties.h>
+void ffSettingsGetAndroidProperty(const char* propName, FFstrbuf* result) {
+    ffStrbufEnsureCapacity(result, PROP_VALUE_MAX);
+    result->length = __system_property_get(propName, result->chars);
+}
+#endif

--- a/src/fastfetch.h
+++ b/src/fastfetch.h
@@ -340,6 +340,10 @@ FFvariant ffSettingsGetXFConf(FFinstance* instance, const char* channelName, con
 
 uint32_t ffSettingsGetSQLiteColumnCount(FFinstance* instance, const char* fileName, const char* tableName);
 
+#ifdef __ANDROID__
+void ffSettingsGetAndroidProperty(const char* propName, FFstrbuf* result);
+#endif
+
 //common/detectPlasma.c
 const FFPlasmaResult* ffDetectPlasma(FFinstance* instance);
 

--- a/src/modules/cpu.c
+++ b/src/modules/cpu.c
@@ -63,14 +63,17 @@ void ffPrintCPU(FFinstance* instance)
 
     while(getline(&line, &len, cpuinfo) != -1)
     {
-        ffGetPropValue(line, "model name :", &name);
-        ffGetPropValue(line, "vendor_id :", &vendor);
-        ffGetPropValue(line, "cpu cores :", &physicalCoresString);
-        ffGetPropValue(line, "cpu MHz :", &procGhzString);
-
         //Stop after the first CPU
-        if(strstr(line, "flags") != NULL)
+        if(name.length > 0 && (*line == '\0' || *line == '\n'))
             break;
+
+        (void)(
+            ffGetPropValue(line, "model name :", &name) ||
+            ffGetPropValue(line, "vendor_id :", &vendor) ||
+            ffGetPropValue(line, "cpu cores :", &physicalCoresString) ||
+            ffGetPropValue(line, "cpu MHz :", &procGhzString) ||
+            (name.length == 0 && ffGetPropValue(line, "Hardware :", &name)) //For Android devices
+        );
     }
 
     if(line != NULL)

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -57,6 +57,11 @@ void ffPrintPackages(FFinstance* instance)
 {
     uint32_t pacman = getNumElements("/var/lib/pacman/local", DT_DIR);
     uint32_t dpkg = getNumStrings("/var/lib/dpkg/status", "Status: ");
+
+#if __ANDROID__
+    dpkg += getNumStrings("/data/data/com.termux/files/usr/var/lib/dpkg/status", "Status: ");
+#endif
+
     uint32_t rpm = ffSettingsGetSQLiteColumnCount(instance, "/var/lib/rpm/rpmdb.sqlite", "Packages");
     uint32_t xbps = getNumElements("/var/db/xbps", DT_REG);
     uint32_t flatpak = getNumElements("/var/lib/flatpak/app", DT_DIR);


### PR DESCRIPTION
When building for Android device, we are now able to

1. Print OS name ( hard coded `Android` )
2. Print OS version ( Android version )
3. Print package count ( a customized dpkg of termux )
4. Print CPU name

Screenshot ( sshed from my PC )
![image](https://user-images.githubusercontent.com/6134068/138071911-ffe73634-587a-47ae-abeb-621393dccfe8.png)

Note `/proc/cpuinfo` prints little information on my phone ( maybe Qualcomm SOC specific )

```
processor       : 7
BogoMIPS        : 38.40
Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x1
CPU part        : 0xd44
CPU revision    : 0

Hardware        : Venus based on Qualcomm Technologies, Inc SM8350
```

So I adjusted the logic in `cpu.c` a bit to use `Hardware` ( shown at the end of the file ) instead of `model name`