### PR TITLE
Fix double free memory error

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -634,7 +634,6 @@ static void parseConfigFile(FFinstance* instance, FFdata* data, FILE* file)
         if(firstSpace >= line.length)
         {
             parseOption(instance, data, line.chars, NULL);
-            ffStrbufDestroy(&line);
             continue;
         }
 


### PR DESCRIPTION
`line` should always be freed by the bottom `ffStrbufDestroy(&line)`