### PR TITLE
Add packages support for Gentoo Linux

### DIFF
--- a/presets/verbose
+++ b/presets/verbose
@@ -5,7 +5,7 @@
 --kernel-format "Sysname: {}; Release: {}; Version: {}"
 --uptime-format "Days: {}; Hours: {}; Minutes: {}; Seconds: {}"
 --processes-format "Count: {}"
---packages-format "All: {}; pacman: {}; pacman branch: {}; dpkg: {}; rpm: {}; xbps: {}; flatpak: {}; snap: {}"
+--packages-format "All: {}; pacman: {}; pacman branch: {}; dpkg: {}; rpm: {}; xbps: {}; flatpak: {}; snap: {}; emerge: {}"
 --shell-format "Process name: {}; Process path: {}; Process exe: {}; Process version: {}; User path: {}; User exe: {}; User version: {}"
 --resolution-format "Width: {}; Height: {}; Refresh rate: {}"
 --de-format "Session desktop: {}; Process name: {}; Pretty name: {}; Version: {}"


### PR DESCRIPTION
Support for counting installed packages on Gentoo

Caveat: runs an external command, so maybe it would be better to add an ifdef (or not add the support at all).