### PR TITLE
CPU: properly detect CPU on POWER

### DIFF
--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -29,7 +29,8 @@ static const char* parseCpuInfo(FFCPUResult* cpu, FFstrbuf* physicalCoresBuffer,
             ffParsePropLine(line, "cpu MHz :", cpuMHz) ||
             ffParsePropLine(line, "isa :", cpuIsa) ||
             ffParsePropLine(line, "uarch :", cpuUarch) ||
-            (cpu->name.length == 0 && ffParsePropLine(line, "Hardware :", &cpu->name)) //For Android devices
+            (cpu->name.length == 0 && ffParsePropLine(line, "Hardware :", &cpu->name)) || //For Android devices
+            (cpu->name.length == 0 && ffParsePropLine(line, "cpu     :", &cpu->name)) //For POWER
         );
     }
 


### PR DESCRIPTION
Excerpt for a thread from /proc/cpuinfo:
processor       : 0
cpu             : POWER9, altivec supported
clock           : 3800.000000MHz
revision        : 2.2 (pvr 004e 1202)

Without this patch, the following is printed for a CPU:
CPU: CPU (64) @ 3.8 GHz

With it, there is:
CPU: POWER9, altivec supported (64) @ 3.8 GHz
