### PR TITLE
Fix typo in config parsing for --color-title

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -1002,7 +1002,7 @@ static void parseOption(FFdata* data, const char* key, const char* value)
             optionCheckString(key, value, &instance.config.colorKeys);
             ffOptionParseColor(value, &instance.config.colorKeys);
         }
-        else if(ffStrEqualsIgnCase(key, "-title"))
+        else if(ffStrEqualsIgnCase(subkey, "-title"))
         {
             optionCheckString(key, value, &instance.config.colorTitle);
             ffOptionParseColor(value, &instance.config.colorTitle);


### PR DESCRIPTION
Having `--color-title` set in the config currently causes fastfetch to error with `Error: unknown option: --color-title`.