### PR TITLE
Fix Slackware colors

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -3522,7 +3522,7 @@ static const FFlogo S[] = {
         .lines = FASTFETCH_DATATEXT_LOGO_SLACKWARE,
         .colors = {
             FF_COLOR_FG_BLUE,
-            FF_COLOR_FG_BLUE,
+            FF_COLOR_FG_WHITE,
         },
         .colorKeys = FF_COLOR_FG_BLUE,
         .colorTitle = FF_COLOR_FG_BLUE,


### PR DESCRIPTION
![image](https://github.com/fastfetch-cli/fastfetch/assets/92590433/571e5c0d-4fd9-4111-b6e4-f429d5782125)

This is how the Slackware ascii looks like in neofetch, it's not fully blue.