### PR TITLE
CPU (Linux): quirks for MIPS platforms

### DIFF
--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -47,7 +47,8 @@ static const char* parseCpuInfo(FFCPUResult* cpu, FFstrbuf* physicalCoresBuffer,
             ffParsePropLine(line, "isa :", cpuIsa) ||
             ffParsePropLine(line, "uarch :", cpuUarch) ||
             (cpu->name.length == 0 && ffParsePropLine(line, "Hardware :", &cpu->name)) || //For Android devices
-            (cpu->name.length == 0 && ffParsePropLine(line, "cpu     :", &cpu->name)) //For POWER
+            (cpu->name.length == 0 && ffParsePropLine(line, "cpu     :", &cpu->name)) || //For POWER
+            (cpu->name.length == 0 && ffParsePropLine(line, "cpu model               :", &cpu->name)) //For MIPS
         );
     }
 
@@ -114,6 +115,10 @@ static void parseIsa(FFstrbuf* cpuIsa)
             cpuIsa->chars[4] = 'g';
         }
         // The final ISA output of the above example is "rv64gch".
+    }
+    if(ffStrbufStartsWithS(cpuIsa, "mips"))
+    {
+        ffStrbufSubstrAfterLastC(cpuIsa, ' ');
     }
 }
 


### PR DESCRIPTION
CPU name is in "cpu model" field on MIPS.  Also, /proc/cpuinfo contains an "isa" field, but rather than being a single string like RISC-V it is instead a space-separated list of every ISA flavor that the chip is compatible with.  Since these are mostly incremental, just make the cpuISA value set to the last one.

Before:
```
$ fastfetch --structure "cpu" --logo none
CPU: mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2 (16)
```

After:
```
$ fastfetch --structure "cpu" --logo none
CPU: Cavium Octeon II V0.10 mips64r2 (16)
```