### PR TITLE
Host (Linux): devicetree path for OBP hosts

### DIFF
--- a/src/detection/host/host_linux.c
+++ b/src/detection/host/host_linux.c
@@ -28,6 +28,10 @@ static void getHostProductName(FFstrbuf* name)
     if(ffIsSmbiosValueSet(name))
         return;
 
+    ffReadFileBuffer("/sys/firmware/devicetree/base/banner-name", name);
+    if(ffIsSmbiosValueSet(name))
+        return;
+
     //does a clear before the read
     ffReadFileBuffer("/tmp/sysinfo/model", name);
     if(ffIsSmbiosValueSet(name))


### PR DESCRIPTION
At least SPARC devices have their model name in this devicetree node and do not have a "model" node.  Possibly also POWER Macs, do not have one to test though.