### PR TITLE
Fix unitialized variables

### DIFF
--- a/src/modules/cpuusage/cpuusage.c
+++ b/src/modules/cpuusage/cpuusage.c
@@ -180,6 +180,7 @@ void ffInitCPUUsageOptions(FFCPUUsageOptions* options)
         ffGenerateCPUUsageJsonConfig
     );
     ffOptionInitModuleArg(&options->moduleArgs);
+    options->separate = false;
 }
 
 void ffDestroyCPUUsageOptions(FFCPUUsageOptions* options)

--- a/src/modules/wm/wm.c
+++ b/src/modules/wm/wm.c
@@ -148,6 +148,7 @@ void ffInitWMOptions(FFWMOptions* options)
         ffGenerateWMJsonConfig
     );
     ffOptionInitModuleArg(&options->moduleArgs);
+    options->detectPlugin = false;
 }
 
 void ffDestroyWMOptions(FFWMOptions* options)


### PR DESCRIPTION
Compiling with gcc 13 and `-O3 -flto` found two possibly unitialized variables.

See also: https://bugs.gentoo.org/916722

```
/var/tmp/portage/app-misc/fastfetch-2.2.1/work/fastfetch-2.2.1/src/modules/wm/wm.c: In function 'ffGenerateWMJsonConfig':
/var/tmp/portage/app-misc/fastfetch-2.2.1/work/fastfetch-2.2.1/src/modules/wm/wm.c:103:48: error: 'defaultOptions.detectPlugin' is used uninitialized [-Werror=uninitialized]
  103 |     if (options->detectPlugin != defaultOptions.detectPlugin)
      |                                                ^
/var/tmp/portage/app-misc/fastfetch-2.2.1/work/fastfetch-2.2.1/src/modules/wm/wm.c:98:66: note: 'defaultOptions' declared here
   98 |     __attribute__((__cleanup__(ffDestroyWMOptions))) FFWMOptions defaultOptions;
      |                                                                  ^
/var/tmp/portage/app-misc/fastfetch-2.2.1/work/fastfetch-2.2.1/src/modules/cpuusage/cpuusage.c: In function 'ffGenerateCPUUsageJsonConfig':
/var/tmp/portage/app-misc/fastfetch-2.2.1/work/fastfetch-2.2.1/src/modules/cpuusage/cpuusage.c:138:44: error: 'defaultOptions.separate' is used uninitialized [-Werror=uninitialized]
  138 |     if (options->separate != defaultOptions.separate)
      |                                            ^
/var/tmp/portage/app-misc/fastfetch-2.2.1/work/fastfetch-2.2.1/src/modules/cpuusage/cpuusage.c:133:78: note: 'defaultOptions' declared here
  133 |     __attribute__((__cleanup__(ffDestroyCPUUsageOptions))) FFCPUUsageOptions defaultOptions;
      |                                                                              ^
lto1: some warnings being treated as errors
```