### PR TITLE
src: end va_list before returning

### DIFF
--- a/src/util/FFstrbuf.c
+++ b/src/util/FFstrbuf.c
@@ -167,8 +167,11 @@ void ffStrbufSetF(FFstrbuf* strbuf, const char* format, ...)
     va_list arguments;
     va_start(arguments, format);
 
-    if(strbuf->allocated == 0)
-        return ffStrbufInitVF(strbuf, format, arguments);
+    if(strbuf->allocated == 0) {
+        ffStrbufInitVF(strbuf, format, arguments);
+        va_end(arguments);
+        return;
+    }
 
     ffStrbufClear(strbuf);
     ffStrbufAppendVF(strbuf, format, arguments);


### PR DESCRIPTION
Explicitly end the `va_list` before returning in the `ffStrbufSetF()` function as `va_list`s are not ended implicitly.