### PR TITLE
Spellchecking

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,4 @@
 check-filenames =
 builtin = clear,rare,usage,informal
 skip = */.git,*/cmake-build-*,*/.idea,*/completions,*/presets,*/screenshots,*/tests,*/3rdparty,*/logo/ascii
-ignore-words-list = iterm,compiletime,intergrated,unknwn,pengwin,siduction,master
+ignore-words-list = iterm,compiletime,intergrated,unknwn,pengwin,siduction,master,sur,doas

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,4 @@
 check-filenames =
 builtin = clear,rare,usage,informal
 skip = */.git,*/cmake-build-*,*/.idea,*/completions,*/presets,*/screenshots,*/tests,*/3rdparty,*/logo/ascii
-ignore-words-list = iterm,compiletime,intergrated,unknwn,pengwin,siduction,master,sur,doas
+ignore-words-list = iterm,compiletime,unknwn,pengwin,siduction,master,sur,doas

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+check-filenames =
+builtin = clear,rare,usage,informal
+skip = */.git,*/cmake-build-*,*/.idea,*/completions,*/presets,*/screenshots,*/tests,*/3rdparty,*/logo/ascii
+ignore-words-list = iterm,compiletime,intergrated,unknwn,pengwin,siduction,master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,20 @@ on:
   - pull_request
 
 jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install codespell
+        shell: bash
+        run: sudo apt update && sudo apt install -y codespell
+
+      - name: Run Spellchecker
+        run: codespell
+
   linux-buildtest:
     name: Linux build test
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Config related changes:
 * The undocumented flag `--load-user-config` is removed. As an alternative, `--config none` can be used to disable loading config files.
 * `--config` (previously named `--load-config`) is now supported for command line arguments only. If specified, other config files won't be loaded, which works like other programs.
 * Config files will always be loaded before other command line flags being parsed. That is to say, command line flags will always override options defined in config files.
+* the value of GPUType `integrated` contained a typo and was fixed. Existing config files may need to be updated.
 
 We are deprecating flags based config files (will be removed in v3.0.0). We suggest you migrate to json based config files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Config related changes:
 * The deprecated flag `--gen-config conf` is removed
 * Flag `--gen-config` now does the same thing as `--migrate-config`, which can be used as config migration and default config file generation. Flag `--migrate-config` is removed
-* Fastfetch now searchs for config files in the order of `fastfetch --list-config-paths`, and won't load other config if one is found.
+* Fastfetch now searches for config files in the order of `fastfetch --list-config-paths`, and won't load other config if one is found.
 * The undocumented flag `--load-user-config` is removed. As an alternative, `--config none` can be used to disable loading config files.
 * `--config` (previously named `--load-config`) is now supported for command line arguments only. If specified, other config files won't be loaded, which works like other programs.
 * Config files will always be loaded before other command line flags being parsed. That is to say, command line flags will always override options defined in config files.
@@ -35,11 +35,11 @@ Features:
 * Improve detection of `Battery`
     * Detect cycle count on supported platforms
     * Detect temperature on Linux when supported
-    * Status detection on macOS has been adjusted to be consistant with other platforms
+    * Status detection on macOS has been adjusted to be consistent with other platforms
 * Linux binaries are built with imagemagick7 support
 
 Bugfixes:
-* Fix unitialized variables (#609)
+* Fix uninitialized variables (#609)
 * Fix spelling of `--preserve-aspect-ratio` (#614)
 
 Logos:
@@ -65,7 +65,7 @@ Changes:
 * Display keys `percent*` and `size*` in JSON config are restructured. e.g. `{ "sizeNdigits": 1 }` is now `{ "size": { "ndigits": 1 } }`
 * With the introduction of `--migrate-config`, the old flag based config file is deprecated, and will be removed in 3.0.0 (next major version)
 * Support of `--gen-config conf` is deprecated accordingly, and will be removed in 2.3.0 (next minor version)
-* The global flag `--allow-slow-operations` is splitted into some explicit flags in differnet modules
+* The global flag `--allow-slow-operations` is split into some explicit flags in different modules
     * `--packages-winget`: control whether `winget` packages count should be detected. Note it's a very slow operation, please enable it with caution.
     * `--chassis-use-wmi`: control whether `WMI` query should be used to detect chassis type, which detects more information, but slower. This flag only affects `--chassis-format` and `--format json`.
     * `--battery-use-setup-api`: control whether `SetupAPI` should be used on Windows to detect battery info, which supports multi batteries, but slower.
@@ -138,9 +138,9 @@ This release introduces a new output format: JSON result
 
 Changes:
 * Users module detects and prints user login time by default. Specifying `--users-compact` to disable it
-* Fastfetch now requires yyjson 0.8.0 or later, which is embeded in fastfetch source tree. If you build fastfetch with `-DENABLE_SYSTEM_YYJSON` cmake option, you must upgrade your yyjson package
+* Fastfetch now requires yyjson 0.8.0 or later, which is embedded in fastfetch source tree. If you build fastfetch with `-DENABLE_SYSTEM_YYJSON` cmake option, you must upgrade your yyjson package
 * Reduced information supported by `--terminal-format`, `--shell-format`
-* Some config presets (`devinfo` and `verbose`) are obseleted and removed. They are barely maintained and can be replaced with `--format json` now.
+* Some config presets (`devinfo` and `verbose`) are obsolete and removed. They are barely maintained and can be replaced with `--format json` now.
 * Custom strings in `--module-key` and `--module-format` are no longer trimmed.
 * `/boot` is hidden by default (FreeBSD, Disk)
 
@@ -220,7 +220,7 @@ Features:
 # 2.0.2
 
 Bugfixes:
-* Workarund [a compiler bug of GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282) (Windows)
+* Workaround [a compiler bug of GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282) (Windows)
 * Fix presets not detected by file name (#529)
 
 Logo:
@@ -232,7 +232,7 @@ First stable release of Fastfetch V2
 
 Changes:
 * Unescape strings only when parsing `.conf` files
-    * Previously: `$ NO_CONFIG=1 fastfetch --os-key \\\\ -s os -l none` prints `\: *`. Note the backslashs are unescaped twice (once by shell and once by fastfetch).
+    * Previously: `$ NO_CONFIG=1 fastfetch --os-key \\\\ -s os -l none` prints `\: *`. Note the backslashes are unescaped twice (once by shell and once by fastfetch).
     * Now: `$ NO_CONFIG=1 fastfetch --os-key \\\\ -s os -l none` prints `\\: *`
 * Remove option shortcut `-c` (alias of `--color`), which is more commonly used as alias of `--config`
 * Rename `--recache` to `--logo-recache` (which is used for regenerate image logo cache). Remove option shortcut `-r` (alias of `--recache`).
@@ -288,7 +288,7 @@ Features:
 * Better CPU and Host detection for Android (Android)
 * Support yakuake terminal version & font detection (Terminal, Linux)
 * Add new option `--bright-color` which can be used to disable the default bright color of keys, title and ASCII logo.
-* Add module `Monitor` which prints physical parameters (native resolutions and demensions) of connected monitors
+* Add module `Monitor` which prints physical parameters (native resolutions and dimensions) of connected monitors
 * Support path with environment variables for `--logo-source` and `--load-config`.
 
 Bugfixes:
@@ -376,7 +376,7 @@ Bugfixes:
 * Fix Windows drives detection in WSL (Disk)
 
 Changes:
-* In order to make Icons module consistant between different platforms, `--icons-format` no longer supports individual GTK / QT icon params.
+* In order to make Icons module consistent between different platforms, `--icons-format` no longer supports individual GTK / QT icon params.
 * `--theme-format` no longer supports individual GTK / plasma theme params.
 * `--local-ip-*` and `--public-ip-*` have been changed to `--localip-*` and `--publicip-*`
 * `--localip-compact-type` is no longer supported. Fastfetch now display IPs as `--localip-compat-type multiline` by default, with `--local-compact true` can be set as an alias of `--localip-compact-type oneline`
@@ -399,7 +399,7 @@ Bugfixes:
 * Fix iTerm being detected as iTermServer-* sometimes
 * Fix sound device volume being incorrectly detected as muted sometimes (Sound)
 * Fix memleaks reported by LeakSanitizer (Linux)
-* Fix potential memory curruption bug in unicode.c (Windows)
+* Fix potential memory corruption bug in unicode.c (Windows)
 
 Logo:
 * Update Windows 11 ASCII logo to look more visually consistent (#445)
@@ -435,7 +435,7 @@ Bugfixes:
 * Fix compiling errors (Windows)
 
 Improvements:
-* Improve preformance (WmTheme amd Font, Windows and macOS)
+* Improve performance (WmTheme amd Font, Windows and macOS)
 * Enable nonblocking public-ip / weather detection (Android)
 
 # 1.10.2
@@ -480,7 +480,7 @@ Other:
 
 * Simplified wmtheme output format (Windows)
 * Improved GPU detection performance on Windows 11
-* Lastest Mac model identifier support (macOS)
+* Latest Mac model identifier support (macOS)
 
 # 1.9.1
 
@@ -562,7 +562,7 @@ Bugfixes:
 This release introduces Windows support! Fastfetch now fully support all major desktop OSes (Linux, macOS, Windows and FreeBSD)
 
 Notable Changes:
-* Bios / Board / Chassis modules are splitted against Host module for performance reasons
+* Bios / Board / Chassis modules are split against Host module for performance reasons
 * Caching is removed. Option `--nocache` is removed accordingly
 
 Features:
@@ -571,7 +571,7 @@ Features:
 * Adds a new flag `--stat`, which prints time usage for individual modules
 * Adds Wifi module which supports Windows and macOS
 * Adds data source option for logo printing
-* Detects Homebrew Cellar and Cask seperately
+* Detects Homebrew Cellar and Cask separately
 * Detects WSL version
 * Detects disk based on mount point
 * Exposes more chafa configs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ cmake_dependent_option(ENABLE_DIRECTX_HEADERS "Enable DirectX headers for WSL" O
 cmake_dependent_option(ENABLE_THREADS "Enable multithreading" ON "Threads_FOUND" OFF)
 cmake_dependent_option(ENABLE_PCI_MEMORY "Enable detecting GPU memory size with libpci" OFF "LINUX OR BSD" OFF)
 
-option(ENABLE_SYSTEM_YYJSON "Use system provided (instead of fastfetch embeded) yyjson library" OFF)
+option(ENABLE_SYSTEM_YYJSON "Use system provided (instead of fastfetch embedded) yyjson library" OFF)
 option(ENABLE_ASAN "Build fastfetch with ASAN (address sanitizer)" OFF)
 option(BUILD_TESTS "Build tests" OFF) # Also create test executables
 option(SET_TWEAK "Add tweak to project version" ON) # This is set to off by github actions for release builds

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ Here i just add things that are easy to forget.
 - [ ] ZSH completions
 - [ ] Fish completions
 - [ ] Make CPU usage detection much faster and more accurate
-- [ ] Detect CPU usage in a common detection methode and expose it both to the cpuUsage module and the cpu format string
+- [ ] Detect CPU usage in a common detection method and expose it both to the cpuUsage module and the cpu format string
 - [ ] Per session caching
 
 ### General

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Logos can be heavily customized too; see the [logo documentation](https://github
 ## FAQ
 
 Q: Why do you need a very performant version of neofetch?
-> I like putting neofetch in my ~/.bashrc to have a system overwiew whenever I use the terminal, but the slow speed annoyed me, so I created this. Also neofetch didn't output everything correctly (e.g Font is displayed as "[Plasma], Noto Sans, 10 [GTK2/3]") and writing my own tool gave me the possibility to fine tune it to run perfectly on at least my configuration.
+> I like putting neofetch in my ~/.bashrc to have a system overview whenever I use the terminal, but the slow speed annoyed me, so I created this. Also neofetch didn't output everything correctly (e.g Font is displayed as "[Plasma], Noto Sans, 10 [GTK2/3]") and writing my own tool gave me the possibility to fine tune it to run perfectly on at least my configuration.
 
 Q: It does not display [*] correctly for me, what can I do?
 > This is most likely because your system is not implemented (yet). At the moment I am focusing more on making the core app better, than adding more configurations. Feel free to open a pull request if you want to add support for your configuration

--- a/doc/fastfetch.1.in
+++ b/doc/fastfetch.1.in
@@ -18,7 +18,7 @@ Currently, Linux, Android, FreeBSD, MacOS and Windows 7+ are supported.
 
 .SH "EXIT STATUS"
 
-On successfull execution, fastfetch returns zero. If any error happened,
+On successful execution, fastfetch returns zero. If any error happened,
 the exit code will be non\-zero.
 
 .SH OPTIONS

--- a/src/common/format.c
+++ b/src/common/format.c
@@ -203,7 +203,7 @@ void ffParseFormatString(FFstrbuf* buffer, const FFstrbuf* formatstr, uint32_t n
             }
 
             // fastforward to the end of the if without printing the in between
-            i = ffStrbufNextIndexS(formatstr, i, "{?}") + 2; // 2 is the length of "{?}" - 1 because the loop will increament it again directly after continue
+            i = ffStrbufNextIndexS(formatstr, i, "{?}") + 2; // 2 is the length of "{?}" - 1 because the loop will increment it again directly after continue
             continue;
         }
 
@@ -229,7 +229,7 @@ void ffParseFormatString(FFstrbuf* buffer, const FFstrbuf* formatstr, uint32_t n
             }
 
             // fastforward to the end of the if without printing the in between
-            i = ffStrbufNextIndexS(formatstr, i, "{/}") + 2; // 2 is the length of "{/}" - 1 because the loop will increament it again directly after continue
+            i = ffStrbufNextIndexS(formatstr, i, "{/}") + 2; // 2 is the length of "{/}" - 1 because the loop will increment it again directly after continue
             continue;
         }
 

--- a/src/common/io/io.h
+++ b/src/common/io/io.h
@@ -49,11 +49,11 @@ static inline ssize_t ffReadFDData(FFNativeFD fd, size_t dataSize, void* data)
     #ifndef _WIN32
         return read(fd, data, dataSize);
     #else
-        DWORD readed;
-        if(!ReadFile(fd, data, (DWORD)dataSize, &readed, NULL))
+        DWORD bytesRead;
+        if(!ReadFile(fd, data, (DWORD)dataSize, &bytesRead, NULL))
             return -1;
 
-        return (ssize_t)readed;
+        return (ssize_t)bytesRead;
     #endif
 }
 

--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -44,7 +44,7 @@ bool ffWriteFileData(const char* fileName, size_t dataSize, const void* data)
 
 bool ffAppendFDBuffer(int fd, FFstrbuf* buffer)
 {
-    ssize_t readed = 0;
+    ssize_t bytesRead = 0;
 
     struct stat fileInfo;
     if(fstat(fd, &fileInfo) != 0)
@@ -54,10 +54,10 @@ bool ffAppendFDBuffer(int fd, FFstrbuf* buffer)
     uint32_t free = ffStrbufGetFree(buffer);
 
     while(
-        (readed = read(fd, buffer->chars + buffer->length, free)) > 0
+        (bytesRead = read(fd, buffer->chars + buffer->length, free)) > 0
     ) {
-        buffer->length += (uint32_t) readed;
-        if((uint32_t) readed == free)
+        buffer->length += (uint32_t) bytesRead;
+        if((uint32_t) bytesRead == free)
             ffStrbufEnsureFree(buffer, buffer->allocated - 1); // Doubles capacity every round. -1 for the null byte.
         free = ffStrbufGetFree(buffer);
     }
@@ -153,14 +153,14 @@ const char* ffGetTerminalResponse(const char* request, const char* format, ...)
     }
 
     char buffer[512];
-    ssize_t readed = read(STDIN_FILENO, buffer, sizeof(buffer) - 1);
+    ssize_t bytesRead = read(STDIN_FILENO, buffer, sizeof(buffer) - 1);
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldTerm);
 
-    if(readed <= 0)
+    if(bytesRead <= 0)
         return "read(STDIN_FILENO, buffer, sizeof(buffer) - 1) failed";
 
-    buffer[readed] = '\0';
+    buffer[bytesRead] = '\0';
 
     va_list args;
     va_start(args, format);

--- a/src/common/io/io_windows.c
+++ b/src/common/io/io_windows.c
@@ -32,7 +32,7 @@ bool ffWriteFileData(const char* fileName, size_t dataSize, const void* data)
 
 bool ffAppendFDBuffer(HANDLE handle, FFstrbuf* buffer)
 {
-    DWORD readed = 0;
+    DWORD bytesRead = 0;
 
     LARGE_INTEGER fileSize;
     if(!GetFileSizeEx(handle, &fileSize))
@@ -43,11 +43,11 @@ bool ffAppendFDBuffer(HANDLE handle, FFstrbuf* buffer)
 
     bool success;
     while(
-        (success = !!ReadFile(handle, buffer->chars + buffer->length, free, &readed, NULL)) &&
-        readed > 0
+        (success = !!ReadFile(handle, buffer->chars + buffer->length, free, &bytesRead, NULL)) &&
+        bytesRead > 0
     ) {
-        buffer->length += (uint32_t) readed;
-        if((uint32_t) readed == free)
+        buffer->length += (uint32_t) bytesRead;
+        if((uint32_t) bytesRead == free)
             ffStrbufEnsureFree(buffer, buffer->allocated - 1); // Doubles capacity every round. -1 for the null byte.
         free = ffStrbufGetFree(buffer);
     }

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -6,7 +6,7 @@ void ffPrintLogoAndKey(const char* moduleName, uint8_t moduleIndex, const FFModu
 {
     ffLogoPrintLine();
 
-    //This is used by --set-keyless, in this case we wan't neither the module name nor the separator
+    //This is used by --set-keyless, in this case we want neither the module name nor the separator
     if(moduleName == NULL)
         return;
 

--- a/src/common/properties.c
+++ b/src/common/properties.c
@@ -91,7 +91,7 @@ bool ffParsePropLines(const char* lines, const char* start, FFstrbuf* buffer)
 
 // The following functions return true if the file was found, independently if start was found
 // Buffers which already contain content are not overwritten
-// The last occurence of start in the first file will be the one used
+// The last occurrence of start in the first file will be the one used
 
 bool ffParsePropFileValues(const char* filename, uint32_t numQueries, FFpropquery* queries)
 {

--- a/src/data/help.txt
+++ b/src/data/help.txt
@@ -15,7 +15,7 @@ Informative options:
     --print-structure:          Print the default structure
 
 Config options:
-    -c, --config <config>:      Specify the config file or preset to be loaded. If "none", disable futher config loading (+)
+    -c, --config <config>:      Specify the config file or preset to be loaded. If "none", disable further config loading (+)
     --gen-config <?path>:       Generate a config file (or print it if <path> is "-"), with options specified in the command line (if any)
     --gen-config-force <?path>: Generate a config file. Overwrite the existing one
 

--- a/src/data/help_format.txt
+++ b/src/data/help_format.txt
@@ -1,7 +1,7 @@
 A format string is a string that contains placeholders for values.
 These placeholders begin with a '{', containing the index of the value, and end with a '}'.
 For example the format string "Values: {1} ({2})", with the values "First" and "My second val", will produce
-The format string can contain placeholders in any order and have multiple occurences.
+The format string can contain placeholders in any order and have multiple occurrences.
 To include spaces when setting from the command line, surround the whole string with double quotes (").
 
 If the value index is missing, meaning the placeholder is "{}", an internal counter sets the value index.

--- a/src/detection/disk/disk_linux.c
+++ b/src/detection/disk/disk_linux.c
@@ -20,7 +20,7 @@
 
 static bool isPhysicalDevice(const struct mntent* device)
 {
-    #ifndef __ANDROID__ //On Android, `/dev` is not accessable, so that the following checks always fail
+    #ifndef __ANDROID__ //On Android, `/dev` is not accessible, so that the following checks always fail
 
     //Always show the root path
     if(ffStrEquals(device->mnt_dir, "/"))

--- a/src/detection/diskio/diskio_linux.c
+++ b/src/detection/diskio/diskio_linux.c
@@ -24,7 +24,7 @@ const char* ffDiskIOGetIoCounters(FFlist* result, FFDiskIOOptions* options)
         if (part && isdigit(part[strlen("-part")]))
             continue;
 
-        if (ffStrStartsWith(entry->d_name, "nvme-eui.")) // NVMe drive indentifier
+        if (ffStrStartsWith(entry->d_name, "nvme-eui.")) // NVMe drive identifier
             continue;
 
         // Other exceptions?

--- a/src/detection/displayserver/linux/displayserver_linux.c
+++ b/src/detection/displayserver/linux/displayserver_linux.c
@@ -89,7 +89,7 @@ void ffConnectDisplayServerImpl(FFDisplayServerResult* ds)
 
     if (!instance.config.general.dsForceDrm)
     {
-        //We try wayland as our prefered display server, as it supports the most features.
+        //We try wayland as our preferred display server, as it supports the most features.
         //This method can't detect the name of our WM / DE
         ffdsConnectWayland(ds);
 

--- a/src/detection/displayserver/linux/wmde.c
+++ b/src/detection/displayserver/linux/wmde.c
@@ -333,7 +333,7 @@ void ffdsDetectWMDE(FFDisplayServerResult* result)
     applyPrettyNameIfDE(result, env);
 
     //If WM was found by connection to the sever, and DE in the environment, we can return
-    //This way we never call getFromProcDir(), which has slow initalization time
+    //This way we never call getFromProcDir(), which has slow initialization time
     if(result->dePrettyName.length > 0 && result->wmPrettyName.length > 0)
         return;
 

--- a/src/detection/displayserver/linux/xlib.c
+++ b/src/detection/displayserver/linux/xlib.c
@@ -388,7 +388,7 @@ void ffdsConnectXrandr(FFDisplayServerResult* result)
 
 void ffdsConnectXrandr(FFDisplayServerResult* result)
 {
-    //Do nothing here. There are more x11 implementaions to come.
+    //Do nothing here. There are more x11 implementations to come.
     FF_UNUSED(result);
 }
 

--- a/src/detection/gamepad/gamepad_bsd.c
+++ b/src/detection/gamepad/gamepad_bsd.c
@@ -20,9 +20,9 @@ const char* ffDetectGamepad(FFlist* devices /* List of FFGamepadDevice */)
         report_desc_t repDesc = hid_get_report_desc(fd);
         if (!repDesc) continue;
 
-        int repId = hid_get_report_id(fd);
+        int reportId = hid_get_report_id(fd);
 
-        struct hid_data* hData = hid_start_parse(repDesc, 0, repId);
+        struct hid_data* hData = hid_start_parse(repDesc, 0, reportId);
         if (hData)
         {
             struct hid_item hItem;

--- a/src/detection/os/os_windows.cpp
+++ b/src/detection/os/os_windows.cpp
@@ -58,7 +58,7 @@ void ffDetectOSImpl(FFOSResult* os)
 
     ffStrbufTrimRight(&os->variant, ' ');
 
-    //WMI returns the "Microsoft" prefix while BrandingFormatString doesn't. Make them consistant.
+    //WMI returns the "Microsoft" prefix while BrandingFormatString doesn't. Make them consistent.
     if(ffStrbufStartsWithS(&os->variant, "Microsoft "))
         ffStrbufSubstrAfter(&os->variant, strlen("Microsoft ") - 1);
 

--- a/src/detection/temps/temps_windows.cpp
+++ b/src/detection/temps/temps_windows.cpp
@@ -7,7 +7,7 @@ extern "C"
 extern "C"
 const char* ffDetectSmbiosTemp(double* current, double* critical)
 {
-    // Requires Administrator priviledges
+    // Requires Administrator privileges
     // https://wutils.com/wmi/root/wmi/msacpi_thermalzonetemperature/#properties
     FFWmiQuery query(L"SELECT CurrentTemperature, CriticalTripPoint FROM MSAcpi_ThermalZoneTemperature WHERE Active = TRUE", nullptr, FFWmiNamespace::WMI);
     if(!query)

--- a/src/detection/terminalfont/terminalfont_linux.c
+++ b/src/detection/terminalfont/terminalfont_linux.c
@@ -45,7 +45,7 @@ static void detectKgx(FFTerminalFontResult* terminalFont)
         if(ffStrSet(fontName))
             ffFontInitPango(&terminalFont->font, fontName);
         else
-            ffStrbufAppendS(&terminalFont->error, "Could't get system monospace font name from GSettings / DConf");
+            ffStrbufAppendS(&terminalFont->error, "Couldn't get system monospace font name from GSettings / DConf");
     }
 }
 
@@ -77,7 +77,7 @@ static void detectFromGSettings(const char* profilePath, const char* profileList
         if(ffStrSet(fontName))
             ffFontInitPango(&terminalFont->font, fontName);
         else
-            ffStrbufAppendS(&terminalFont->error, "Could't get system monospace font name from GSettings / DConf");
+            ffStrbufAppendS(&terminalFont->error, "Couldn't get system monospace font name from GSettings / DConf");
     }
 }
 

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -368,7 +368,7 @@ const FFTerminalShellResult* ffDetectTerminalShell()
     if(result.terminalExeName[0] == '.' && ffStrEndsWith(result.terminalExeName, "-wrapped"))
     {
         // For NixOS. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
-        // We use terminalProcessName when detecting version and font, overriding it for simplication
+        // We use terminalProcessName when detecting version and font, overriding it for simplification
         ffStrbufSetNS(
             &result.terminalProcessName,
             (uint32_t) (strlen(result.terminalExeName) - strlen(".-wrapped")),

--- a/src/detection/terminalshell/terminalshell_windows.c
+++ b/src/detection/terminalshell/terminalshell_windows.c
@@ -235,7 +235,7 @@ static bool detectDefaultTerminal(FFTerminalShellResult* result)
     {
         if(wcscmp(uuid, L"{00000000-0000-0000-0000-000000000000}") == 0)
         {
-            // Let Windows deside
+            // Let Windows decide
             return false;
         }
         if(wcscmp(uuid, L"{B23D10C0-E52E-411E-9D5B-C09FDF709C7D}") == 0)

--- a/src/detection/vulkan/vulkan.c
+++ b/src/detection/vulkan/vulkan.c
@@ -55,7 +55,7 @@ static const char* detectVulkan(FFVulkanResult* result)
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE2(vulkan, vkEnumeratePhysicalDevices, vkEnumeratePhysicalDevices@12)
 
     //Some drivers (nvdc) print messages to stdout
-    //and thats the best way i found to disable that
+    //and that is the best way I found to disable that
     FF_SUPPRESS_IO();
 
     FFVersion instanceVersion = FF_VERSION_INIT;

--- a/src/detection/wifi/wifi_apple.m
+++ b/src/detection/wifi/wifi_apple.m
@@ -5,7 +5,7 @@
 
 struct Apple80211; // https://code.google.com/archive/p/iphone-wireless/wikis/Apple80211.wiki
 
-// 0 is sucessful; < 0 is failure
+// 0 is successful; < 0 is failure
 int Apple80211Open(struct Apple80211 **handle) __attribute__((weak_import));
 int Apple80211BindToInterface(struct Apple80211 *handle, CFStringRef interface) __attribute__((weak_import));
 int Apple80211GetInfoCopy(struct Apple80211 *handle, CFDictionaryRef *info) __attribute__((weak_import));

--- a/src/detection/wmtheme/wmtheme_linux.c
+++ b/src/detection/wmtheme/wmtheme_linux.c
@@ -194,7 +194,7 @@ bool ffDetectWmTheme(FFstrbuf* themeOrError)
 
     if(wm->wmPrettyName.length == 0)
     {
-        ffStrbufAppendS(themeOrError, "WM Theme needs sucessfull WM detection");
+        ffStrbufAppendS(themeOrError, "WM Theme needs successful WM detection");
         return false;
     }
 

--- a/src/flashfetch.c
+++ b/src/flashfetch.c
@@ -4,7 +4,7 @@
 
 int main(void)
 {
-    ffInitInstance(); //This also applys default configuration to instance.config
+    ffInitInstance(); //This also applies default configuration to instance.config
 
     //Modify instance.config here
     FFOptionsModules* const options = &instance.config.modules;

--- a/src/logo/logo.c
+++ b/src/logo/logo.c
@@ -105,7 +105,7 @@ void ffLogoPrintChars(const char* data, bool doColorReplacement)
             continue;
         }
 
-        //We have an escape sequence direclty as bytes. We print it, but don't increase the line length
+        //We have an escape sequence directly as bytes. We print it, but don't increase the line length
         if(*data == '\e' && *(data + 1) == '[')
         {
             const char* start = data;

--- a/src/modules/colors/colors.c
+++ b/src/modules/colors/colors.c
@@ -29,7 +29,7 @@ void ffPrintColors(FFColorsOptions* options)
             ffPrintCharTimes(' ', options->paddingLeft);
 
         // 1: Set everything to bolt. This causes normal colors on some systems to be bright.
-        // 4%d: Set the backgound to the not bright color
+        // 4%d: Set the background to the not bright color
         // 3%d: Set the foreground to the not bright color
         // 10%d: Set the background to the bright color
         // 9%d: Set the foreground to the bright color

--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -151,7 +151,8 @@ bool ffParseGPUCommandOptions(FFGPUOptions* options, const char* key, const char
     {
         options->hideType = (FFGPUType) ffOptionParseEnum(key, value, (FFKeyValuePair[]) {
             { "none", FF_GPU_TYPE_UNKNOWN },
-            { "intergrated", FF_GPU_TYPE_INTEGRATED },
+            { "intergrated", FF_GPU_TYPE_INTEGRATED }, // for backward compatibility only
+            { "integrated", FF_GPU_TYPE_INTEGRATED },
             { "discrete", FF_GPU_TYPE_DISCRETE },
             {},
         });
@@ -196,7 +197,8 @@ void ffParseGPUJsonObject(FFGPUOptions* options, yyjson_val* module)
             int value;
             const char* error = ffJsonConfigParseEnum(val, &value, (FFKeyValuePair[]) {
                 { "none", FF_GPU_TYPE_UNKNOWN },
-                { "intergrated", FF_GPU_TYPE_INTEGRATED },
+                { "intergrated", FF_GPU_TYPE_INTEGRATED },  // for backward compatibility only
+                { "integrated", FF_GPU_TYPE_INTEGRATED },
                 { "discrete", FF_GPU_TYPE_DISCRETE },
                 {},
             });
@@ -235,7 +237,7 @@ void ffGenerateGPUJsonConfig(FFGPUOptions* options, yyjson_mut_doc* doc, yyjson_
                 yyjson_mut_obj_add_str(doc, module, "hideType", "none");
                 break;
             case FF_GPU_TYPE_INTEGRATED:
-                yyjson_mut_obj_add_str(doc, module, "hideType", "intergrated");
+                yyjson_mut_obj_add_str(doc, module, "hideType", "integrated");
                 break;
             case FF_GPU_TYPE_DISCRETE:
                 yyjson_mut_obj_add_str(doc, module, "hideType", "discrete");

--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -151,7 +151,6 @@ bool ffParseGPUCommandOptions(FFGPUOptions* options, const char* key, const char
     {
         options->hideType = (FFGPUType) ffOptionParseEnum(key, value, (FFKeyValuePair[]) {
             { "none", FF_GPU_TYPE_UNKNOWN },
-            { "intergrated", FF_GPU_TYPE_INTEGRATED }, // for backward compatibility only
             { "integrated", FF_GPU_TYPE_INTEGRATED },
             { "discrete", FF_GPU_TYPE_DISCRETE },
             {},
@@ -197,7 +196,6 @@ void ffParseGPUJsonObject(FFGPUOptions* options, yyjson_val* module)
             int value;
             const char* error = ffJsonConfigParseEnum(val, &value, (FFKeyValuePair[]) {
                 { "none", FF_GPU_TYPE_UNKNOWN },
-                { "intergrated", FF_GPU_TYPE_INTEGRATED },  // for backward compatibility only
                 { "integrated", FF_GPU_TYPE_INTEGRATED },
                 { "discrete", FF_GPU_TYPE_DISCRETE },
                 {},

--- a/src/options/logo.c
+++ b/src/options/logo.c
@@ -291,7 +291,7 @@ const char* ffOptionsParseLogoJsonConfig(FFOptionsLogo* options, yyjson_val* roo
         {
             uint32_t value = (uint32_t) yyjson_get_uint(val);
             if (value == 0)
-                return "Logo width must be a possitive integer";
+                return "Logo width must be a positive integer";
             options->width = value;
             continue;
         }
@@ -299,7 +299,7 @@ const char* ffOptionsParseLogoJsonConfig(FFOptionsLogo* options, yyjson_val* roo
         {
             uint32_t value = (uint32_t) yyjson_get_uint(val);
             if (value == 0)
-                return "Logo height must be a possitive integer";
+                return "Logo height must be a positive integer";
             options->height = value;
             continue;
         }
@@ -313,7 +313,7 @@ const char* ffOptionsParseLogoJsonConfig(FFOptionsLogo* options, yyjson_val* roo
                 if (pos) \
                 { \
                     if (!yyjson_is_uint(pos)) \
-                        return "Logo padding values must be possitive integers"; \
+                        return "Logo padding values must be positive integers"; \
                     options->paddingPos = (uint32_t) yyjson_get_uint(pos); \
                 }
             FF_PARSE_PADDING_POSITON(left, paddingLeft);

--- a/src/util/FFstrbuf.c
+++ b/src/util/FFstrbuf.c
@@ -305,7 +305,7 @@ uint32_t ffStrbufPreviousIndexC(const FFstrbuf* strbuf, uint32_t start, char c)
 {
     assert(start <= strbuf->length);
 
-    //We need to loop one higher than the actual index, because uint32_t is guranteed to be >= 0, so this statement would always be true
+    //We need to loop one higher than the actual index, because uint32_t is guaranteed to be >= 0, so this statement would always be true
     for(uint32_t i = start + 1; i > 0; i--)
     {
         if(strbuf->chars[i - 1] == c)


### PR DESCRIPTION
I fixed some typos in the codebase as reported by codespell. I also added a .codespellrc file as well as a workflow that runs codespell.

The only major typo was in [src/modules/gpu/gpu.c](https://github.com/fastfetch-cli/fastfetch/compare/dev...mame98:spellcheck?expand=1#diff-ea1c87371e97d577afe5254a9f69a72aeac60211eb2541b95517e5f02f75fbd5). I think my fix allows both the wrong-spelled config value and the correct one. What do you think?