### PR TITLE
optimize(IO): speed up createSubfolders

### DIFF
--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -16,12 +16,12 @@ static void createSubfolders(const char* fileName)
 {
     FF_STRBUF_AUTO_DESTROY path = ffStrbufCreate();
 
-    while(*fileName != '\0')
+    char *token = NULL;
+    while((token = strchr(fileName, '/')) != NULL)
     {
-        ffStrbufAppendC(&path, *fileName);
-        if(*fileName == '/')
-            mkdir(path.chars, S_IRWXU | S_IRGRP | S_IROTH);
-        ++fileName;
+        ffStrbufAppendNS(&path, (uint32_t)(token - fileName + 1), fileName);
+        mkdir(path.chars, S_IRWXU | S_IRGRP | S_IROTH);
+        fileName = token + 1;
     }
 }
 

--- a/src/common/io/io_windows.c
+++ b/src/common/io/io_windows.c
@@ -6,12 +6,12 @@
 static void createSubfolders(const char* fileName)
 {
     FF_STRBUF_AUTO_DESTROY path = ffStrbufCreate();
-    while(*fileName != '\0')
+    char *token = NULL;
+    while((token = strchr(fileName, '/')) != NULL)
     {
-        ffStrbufAppendC(&path, *fileName);
-        if(*fileName == '/')
-            CreateDirectoryA(path.chars, NULL);
-        ++fileName;
+        ffStrbufAppendNS(&path, (uint32_t)(token - fileName + 1), fileName);
+        CreateDirectoryA(path.chars, NULL);
+        fileName = token + 1;
     }
 }
 


### PR DESCRIPTION
Avoiding unnecessary ffStrbufAppendC calls to speed up createSubfolders.

Now it finds and adds a subdirectory at a time instead of just appending a char.