### PR TITLE
Fix procfs reading

### DIFF
--- a/src/common/io/io.h
+++ b/src/common/io/io.h
@@ -11,6 +11,10 @@
     #include <unistd.h>
     #include <dirent.h>
     typedef int FFNativeFD;
+    // procfs's file can be changed between read calls such as /proc/meminfo and /proc/uptime.
+    // one safe way to read correct data is reading the whole file in a single read syscall
+    // 8192 comes from procps-ng: https://gitlab.com/procps-ng/procps/-/blob/master/library/meminfo.c?ref_type=heads#L39
+    #define PROC_FILE_BUFFSIZ 8192
 #endif
 
 static inline FFNativeFD FFUnixFD2NativeFD(int unixfd)

--- a/src/detection/cpuusage/cpuusage_linux.c
+++ b/src/detection/cpuusage/cpuusage_linux.c
@@ -41,7 +41,7 @@ const char* ffGetCpuUsageInfo(FFlist* cpuTimes)
             };
         }
         else
-            break; // because we read the whole /proc/stat, we can safely quit when the line does not start with "cpuN" 
+            break;
         start = token + 1;
     }
 

--- a/src/detection/cpuusage/cpuusage_linux.c
+++ b/src/detection/cpuusage/cpuusage_linux.c
@@ -7,30 +7,42 @@
 
 const char* ffGetCpuUsageInfo(FFlist* cpuTimes)
 {
-    FF_AUTO_CLOSE_FILE FILE* procStat = fopen("/proc/stat", "r");
-    if(procStat == NULL)
+    char buf[PROC_FILE_BUFFSIZ];
+    ssize_t nRead = ffReadFileData("/proc/stat", sizeof(buf) - 1, buf);
+    if(nRead < 0)
     {
         #ifdef __ANDROID__
         return "Accessing \"/proc/stat\" is restricted on Android O+";
         #else
-        return "fopen(\"""/proc/stat\", \"r\") == NULL";
+        return "ffReadFileData(\"/proc/stat\", sizeof(buf) - 1, buf) failed";
         #endif
     }
+    buf[nRead] = '\0';
+
     // Skip first line
-    if (fscanf(procStat, "cpu%*[^\n]\n") < 0)
-        return "fscanf() first line failed";
+    char *start = NULL;
+    if((start = strchr(buf, '\n')) == NULL)
+        return "skip first line failed";
+    ++start;
 
     uint64_t user = 0, nice = 0, system = 0, idle = 0, iowait = 0, irq = 0, softirq = 0;
-    while (fscanf(procStat, "cpu%*d%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%*[^\n]\n", &user, &nice, &system, &idle, &iowait, &irq, &softirq) == 7)
+    char *token = NULL;
+    while ((token = strchr(start, '\n')))
     {
-        uint64_t inUse = user + nice + system;
-        uint64_t total = inUse + idle + iowait + irq + softirq;
+        if(sscanf(start, "cpu%*d%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%" PRIu64 "%*[^\n]\n", &user, &nice, &system, &idle, &iowait, &irq, &softirq) == 7)
+        {
+            uint64_t inUse = user + nice + system;
+            uint64_t total = inUse + idle + iowait + irq + softirq;
 
-        FFCpuUsageInfo* info = (FFCpuUsageInfo*) ffListAdd(cpuTimes);
-        *info = (FFCpuUsageInfo) {
-            .inUseAll = (uint64_t)inUse,
-            .totalAll = (uint64_t)total,
-        };
+            FFCpuUsageInfo* info = (FFCpuUsageInfo*) ffListAdd(cpuTimes);
+            *info = (FFCpuUsageInfo) {
+                .inUseAll = (uint64_t)inUse,
+                .totalAll = (uint64_t)total,
+            };
+        }
+        else
+            break; // because we read the whole /proc/stat, we can safely quit when the line does not start with "cpuN" 
+        start = token + 1;
     }
 
     return NULL;

--- a/src/detection/memory/memory_linux.c
+++ b/src/detection/memory/memory_linux.c
@@ -21,22 +21,22 @@ const char* ffDetectMemory(FFMemoryResult* ram)
     
     char *token = NULL;
     if((token = strstr(buf, "MemTotal:")) != NULL)
-        sscanf(token, "MemTotal: %" PRIu64, &memTotal);
+        memTotal = strtoul(token + strlen("MemTotal:"), NULL, 10);
 
     if((token = strstr(buf, "MemFree:")) != NULL)
-        sscanf(token, "MemFree: %" PRIu64, &memFree);
+        memFree = strtoul(token + strlen("MemFree:"), NULL, 10);
 
     if((token = strstr(buf, "Buffers:")) != NULL)
-        sscanf(token, "Buffers: %" PRIu64, &buffers);
+        buffers = strtoul(token + strlen("Buffers:"), NULL, 10);
     
     if((token = strstr(buf, "Cached:")) != NULL)
-        sscanf(token, "Cached: %" PRIu64, &cached);
+        cached = strtoul(token + strlen("Cached:"), NULL, 10);
     
     if((token = strstr(buf, "Shmem:")) != NULL)
-        sscanf(token, "Shmem: %" PRIu64, &shmem);
+        shmem = strtoul(token + strlen("Shmem:"), NULL, 10);
     
     if((token = strstr(buf, "SReclaimable:")) != NULL)
-        sscanf(token, "SReclaimable: %" PRIu64, &sReclaimable);
+        sReclaimable = strtoul(token + strlen("SReclaimable:"), NULL, 10);
 
     ram->bytesTotal = memTotal * 1024lu;
     ram->bytesUsed = (memTotal + shmem - memFree - buffers - cached - sReclaimable) * 1024lu;

--- a/src/detection/swap/swap_linux.c
+++ b/src/detection/swap/swap_linux.c
@@ -8,25 +8,21 @@
 const char* ffDetectSwap(FFSwapResult* swap)
 {
     // #620
-    FF_AUTO_CLOSE_FILE FILE* meminfo = fopen("/proc/meminfo", "r");
-    if (!meminfo) return "fopen(\"/proc/meminfo\", \"r\") failed";
+    char buf[PROC_FILE_BUFFSIZ];
+    ssize_t nRead = ffReadFileData("/proc/meminfo", sizeof(buf) - 1, buf);
+    if(nRead < 0)
+        return "ffReadFileData(\"/proc/meminfo\", sizeof(buf)-1, buf)";
+    buf[nRead] = '\0';
 
     uint64_t swapTotal = 0, swapFree = 0;
 
-    char* FF_AUTO_FREE line = NULL;
-    size_t len = 0;
-    uint8_t count = 0;
+    char *token = NULL;
+    if ((token = strstr(buf, "SwapTotal:")) != NULL)
+        sscanf(token, "SwapTotal: %" PRIu64, &swapTotal);
+    
+    if ((token = strstr(buf, "SwapFree:")) != NULL)
+        sscanf(token, "SwapFree: %" PRIu64, &swapFree);
 
-    while (getline(&line, &len, meminfo) != EOF)
-    {
-        if (line[0] == 'S')
-        {
-            if(sscanf(line, "SwapTotal: %" PRIu64, &swapTotal) > 0 || sscanf(line, "SwapFree: %" PRIu64, &swapFree) > 0)
-                if (++count >= 2) goto done;
-        }
-    }
-
-done:
     swap->bytesTotal = swapTotal * 1024lu;
     swap->bytesUsed = (swapTotal - swapFree) * 1024lu;
 

--- a/src/detection/swap/swap_linux.c
+++ b/src/detection/swap/swap_linux.c
@@ -18,10 +18,10 @@ const char* ffDetectSwap(FFSwapResult* swap)
 
     char *token = NULL;
     if ((token = strstr(buf, "SwapTotal:")) != NULL)
-        sscanf(token, "SwapTotal: %" PRIu64, &swapTotal);
+        swapTotal = strtoul(token + strlen("SwapTotal:"), NULL, 10);
     
     if ((token = strstr(buf, "SwapFree:")) != NULL)
-        sscanf(token, "SwapFree: %" PRIu64, &swapFree);
+        swapFree = strtoul(token + strlen("SwapFree:"), NULL, 10);
 
     swap->bytesTotal = swapTotal * 1024lu;
     swap->bytesUsed = (swapTotal - swapFree) * 1024lu;

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -74,19 +74,19 @@ static const char* getProcessNameAndPpid(pid_t pid, char* name, pid_t* ppid)
 
     char statFilePath[64];
     snprintf(statFilePath, sizeof(statFilePath), "/proc/%d/stat", (int)pid);
-    FILE* stat = fopen(statFilePath, "r");
-    if(stat == NULL)
-        return "fopen(statFilePath, \"r\") failed";
+    char buf[PROC_FILE_BUFFSIZ];
+    ssize_t nRead = ffReadFileData(statFilePath, sizeof(buf) - 1, buf);
+    if(nRead < 0)
+        return "ffReadFileData(statFilePath, sizeof(buf)-1, buf)";
+    buf[nRead] = '\0';
 
     *ppid = 0;
     if(
-        fscanf(stat, "%*s (%255[^)]) %*c %d", name, ppid) != 2 || //stat (comm) state ppid
+        sscanf(buf, "%*s (%255[^)]) %*c %d", name, ppid) != 2 || //stat (comm) state ppid
         !ffStrSet(name) ||
         *ppid == 0
     )
-        error = "fscanf(stat) failed";
-
-    fclose(stat);
+        error = "sscanf(stat) failed";
 
     #elif defined(__APPLE__)
 

--- a/src/detection/uptime/uptime_linux.c
+++ b/src/detection/uptime/uptime_linux.c
@@ -7,14 +7,17 @@
 const char* ffDetectUptime(FFUptimeResult* result)
 {
     // #620
-    FF_AUTO_CLOSE_FILE FILE* uptime = fopen("/proc/uptime", "r");
-    if (!uptime) return "fopen(\"/proc/uptime\", \"r\") failed";
+    char buf[64];
+    ssize_t nRead = ffReadFileData("/proc/uptime", sizeof(buf) - 1, buf);
+    if(nRead < 0)
+        return "ffReadFileData(\"/proc/uptime\", sizeof(buf) - 1, buf) failed";
+    buf[nRead] = '\0';
 
     double sec;
-    if (fscanf(uptime, "%lf", &sec) > 0)
+    if(sscanf(buf, "%lf", &sec) > 0)
         result->uptime = (uint64_t) (sec * 1000);
     else
-        return "fscanf(\"%lf\", &sec) failed";
+        return "sscanf(buf.chars, \"%lf\", &sec) failed";
 
     result->bootTime = ffTimeGetNow() + result->uptime;
 

--- a/src/detection/uptime/uptime_linux.c
+++ b/src/detection/uptime/uptime_linux.c
@@ -13,11 +13,12 @@ const char* ffDetectUptime(FFUptimeResult* result)
         return "ffReadFileData(\"/proc/uptime\", sizeof(buf) - 1, buf) failed";
     buf[nRead] = '\0';
 
-    double sec;
-    if(sscanf(buf, "%lf", &sec) > 0)
+    char *err = NULL;
+    double sec = strtod(buf, &err);
+    if(err != buf)
         result->uptime = (uint64_t) (sec * 1000);
     else
-        return "sscanf(buf.chars, \"%lf\", &sec) failed";
+        return "strtod(buf, &err) failed";
 
     result->bootTime = ffTimeGetNow() + result->uptime;
 


### PR DESCRIPTION
Files in procfs are always changed by kernel. For example: The contents of `/proc/meminfo` and `/proc/stat`  are changed frequently to show the "real-time" status in the system.

It means if we read the data with more than one read syscall, we could get an incorrect data which was broken by kernel.

A typical case about this problem was reported by psutil in https://github.com/giampaolo/psutil/issues/2050

Using an big buffer let read reads the whole file can fix this.

psutil uses a 32K buffer while procps-ng uses a 8K buffer, I think a 8K buffer is enough.

Since we read the whole file's data, parsing can be simpler than before.

Using of stack buffers and getting rid of stdio also saves about 30 heap allocations.

Files like `/proc/cpuinfo`, `/proc/mounts` whose contents don't get changed very often don't need to be fixed, although psutils best practices tell us we should read all the data we need in one read syscall.