### PR TITLE
optimize(Packages): use mmap to read large files

### DIFF
--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -42,25 +42,18 @@ static uint32_t getNumElements(FFstrbuf* baseDir, const char* dirname, unsigned 
 
 static uint32_t getNumStringsImpl(const char* filename, const char* needle)
 {
-    FILE* file = fopen(filename, "r");
-    if(file == NULL)
+    FF_STRBUF_AUTO_DESTROY content = ffStrbufCreate();
+    if (!ffReadFileBuffer(filename, &content))
         return 0;
 
     uint32_t count = 0;
-
-    char* line = NULL;
-    size_t len = 0;
-
-    while(getline(&line, &len, file) != EOF)
+    char *iter = content.chars;
+    size_t needleLength = strlen(needle);
+    while ((iter = memmem(iter, content.length - (size_t)(iter - content.chars), needle, needleLength)) != NULL)
     {
-        if(strstr(line, needle) != NULL)
-            ++count;
+        ++count;
+        iter += needleLength;
     }
-
-    if(line != NULL)
-        free(line);
-
-    fclose(file);
 
     return count;
 }


### PR DESCRIPTION
Using less syscalls and processing data in memory makes getNumStringsImpl ~400% faster.

Some benchmark highlights:

On my Ubuntu 22.04 laptop, with 1408 dpkg packages.

```text
Run on (8 X 2400.01 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.12, 0.06, 0.01
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_getNumStringsImpl           256691 ns       256694 ns         2517
BM_getNumStringsLegacyImpl    1080674 ns      1080676 ns          636
```