### PR TITLE
Minor fixes

### DIFF
--- a/src/common/io/io.h
+++ b/src/common/io/io.h
@@ -10,6 +10,7 @@
 #else
     #include <unistd.h>
     #include <dirent.h>
+    #include <errno.h>
     typedef int FFNativeFD;
     // procfs's file can be changed between read calls such as /proc/meminfo and /proc/uptime.
     // one safe way to read correct data is reading the whole file in a single read syscall

--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -106,7 +106,13 @@ bool ffAppendFileBuffer(const char* fileName, FFstrbuf* buffer)
 bool ffPathExists(const char* path, FFPathType type)
 {
     struct stat fileStat;
-    if(stat(path, &fileStat) != 0)
+    int statRet = -1;
+    if (type & FF_PATHTYPE_LINK)
+        statRet = lstat(path, &fileStat);
+    else
+        statRet = stat(path, &fileStat);
+
+    if(statRet != 0)
         return false;
 
     unsigned int mode = fileStat.st_mode & S_IFMT;

--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -31,7 +31,7 @@ bool ffWriteFileData(const char* fileName, size_t dataSize, const void* data)
     int openFlagsRights = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 
     int FF_AUTO_CLOSE_FD fd = open(fileName, openFlagsModes, openFlagsRights);
-    if(fd == -1)
+    if(fd == -1 && errno == ENOENT)
     {
         createSubfolders(fileName);
         fd = open(fileName, openFlagsModes, openFlagsRights);

--- a/src/detection/diskio/diskio_linux.c
+++ b/src/detection/diskio/diskio_linux.c
@@ -24,8 +24,11 @@ const char* ffDiskIOGetIoCounters(FFlist* result, FFDiskIOOptions* options)
         char pathSysBlock[PATH_MAX];
         snprintf(pathSysBlock, PATH_MAX, "/sys/block/%s", devName);
 
-        char pathSysDeviceReal[PATH_MAX] = "";
-        readlink(pathSysBlock, pathSysDeviceReal, sizeof(pathSysDeviceReal) - 1);
+        char pathSysDeviceReal[PATH_MAX];
+        ssize_t pathLength = readlink(pathSysBlock, pathSysDeviceReal, sizeof(pathSysDeviceReal) - 1);
+        if (pathLength < 0)
+            continue;
+        pathSysDeviceReal[pathLength] = '\0';
 
         if (strstr(pathSysDeviceReal, "/virtual/")) // virtual device
             continue;


### PR DESCRIPTION
- fix ffPathExists: only using stat makes FF_PATHTYPE_LINK never work under *nix systems. Some symlinks are linked to directories, so keep use stat when FF_PATHTYPE_LINK is not contained in `type` paramater for backward compatibility.
- ffWriteFileData only retries when error is ENOENT. Other errors such as EACCESS, ELOOP or EDQUOT also fail mkdir(), retrying after these errors is useless.
- fix readlink usage: readlink won't append a NUL, we should check the return value and add a NUL handly.