### PR TITLE
refactor(IO): clean up ffAppendFDBuffer

### DIFF
--- a/src/util/FFstrbuf.c
+++ b/src/util/FFstrbuf.c
@@ -54,6 +54,7 @@ void ffStrbufEnsureFree(FFstrbuf* strbuf, uint32_t free)
     strbuf->allocated = allocate;
 }
 
+// for an empty buffer, free + 1 length memory will be allocated(+1 for the NUL)
 void ffStrbufEnsureFixedLengthFree(FFstrbuf* strbuf, uint32_t free)
 {
     uint32_t oldFree = ffStrbufGetFree(strbuf);
@@ -64,7 +65,7 @@ void ffStrbufEnsureFixedLengthFree(FFstrbuf* strbuf, uint32_t free)
 
     if(strbuf->allocated == 0)
     {
-        newCap += strbuf->length + 1; // +1 for the NUL
+        newCap += strbuf->length + 1;
         char* newbuf = malloc(sizeof(*strbuf->chars) * newCap);
         if(strbuf->length == 0)
             *newbuf = '\0';


### PR DESCRIPTION
for 2 reasons:

- Simplify the Code.
- ffAppendFDBuffer can't make assumptions about how the read data will be processed, so the trim calls are inappropriate. All callers currently handle whitespace and newlines at the end of files themselves. So these trims are also redundant and can simply be removed.