### PR TITLE
fix: fix trailing space

### DIFF
--- a/src/detection/battery/battery_linux.c
+++ b/src/detection/battery/battery_linux.c
@@ -14,6 +14,7 @@ static void parseBattery(FFstrbuf* dir, const char* id, FFBatteryOptions* option
     //type must exist and be "Battery"
     ffStrbufAppendS(dir, "/type");
     ffReadFileBuffer(dir->chars, &testBatteryBuffer);
+    ffStrbufTrimRightSpace(&testBatteryBuffer);
     ffStrbufSubstrBefore(dir, dirLength);
 
     if(ffStrbufIgnCaseCompS(&testBatteryBuffer, "Battery") != 0)
@@ -22,6 +23,7 @@ static void parseBattery(FFstrbuf* dir, const char* id, FFBatteryOptions* option
     //scope may not exist or must not be "Device"
     ffStrbufAppendS(dir, "/scope");
     ffReadFileBuffer(dir->chars, &testBatteryBuffer);
+    ffStrbufTrimRightSpace(&testBatteryBuffer);
     ffStrbufSubstrBefore(dir, dirLength);
 
     if(ffStrbufIgnCaseCompS(&testBatteryBuffer, "Device") == 0)
@@ -48,25 +50,30 @@ static void parseBattery(FFstrbuf* dir, const char* id, FFBatteryOptions* option
     ffStrbufInit(&result->manufacturer);
     ffStrbufAppendS(dir, "/manufacturer");
     ffReadFileBuffer(dir->chars, &result->manufacturer);
+    ffStrbufTrimRightSpace(&result->manufacturer);
     ffStrbufSubstrBefore(dir, dirLength);
 
     ffStrbufInit(&result->modelName);
     ffStrbufAppendS(dir, "/model_name");
     ffReadFileBuffer(dir->chars, &result->modelName);
+    ffStrbufTrimRightSpace(&result->modelName);
     ffStrbufSubstrBefore(dir, dirLength);
 
     ffStrbufInit(&result->technology);
     ffStrbufAppendS(dir, "/technology");
     ffReadFileBuffer(dir->chars, &result->technology);
+    ffStrbufTrimRightSpace(&result->technology);
     ffStrbufSubstrBefore(dir, dirLength);
 
     ffStrbufInit(&result->status);
     ffStrbufAppendS(dir, "/status");
     ffReadFileBuffer(dir->chars, &result->status);
+    ffStrbufTrimRightSpace(&result->status);
     ffStrbufSubstrBefore(dir, dirLength);
 
     ffStrbufAppendS(dir, "/cycle_count");
     ffReadFileBuffer(dir->chars, &testBatteryBuffer);
+    ffStrbufTrimRightSpace(&testBatteryBuffer);
     ffStrbufSubstrBefore(dir, dirLength);
     if(dir->length)
         result->cycleCount = (uint32_t) ffStrbufToUInt(&testBatteryBuffer, 0);

--- a/src/detection/displayserver/linux/wayland.c
+++ b/src/detection/displayserver/linux/wayland.c
@@ -50,6 +50,7 @@ static void waylandDetectWM(int fd, FFDisplayServerResult* result)
     FF_STRBUF_AUTO_DESTROY procPath = ffStrbufCreate();
     ffStrbufAppendF(&procPath, "/proc/%d/cmdline", ucred.pid); //We check the cmdline for the process name, because it is not trimmed.
     ffReadFileBuffer(procPath.chars, &result->wmProcessName);
+    ffStrbufTrimRightSpace(&result->wmProcessName);
     ffStrbufSubstrBeforeFirstC(&result->wmProcessName, '\0'); //Trim the arguments
     ffStrbufSubstrAfterLastC(&result->wmProcessName, '/'); //Trim the path
 }

--- a/src/detection/displayserver/linux/wmde.c
+++ b/src/detection/displayserver/linux/wmde.c
@@ -326,6 +326,7 @@ static const char* getFromProcesses(FFDisplayServerResult* result)
         //We check the cmdline for the process name, because it is not trimmed.
         ffStrbufAppendS(&procPath, "/cmdline");
         ffReadFileBuffer(procPath.chars, &processName);
+        ffStrbufTrimRightSpace(&processName);
         ffStrbufSubstrBeforeFirstC(&processName, '\0'); //Trim the arguments
         ffStrbufSubstrAfterLastC(&processName, '/');
 

--- a/src/detection/netio/netio_linux.c
+++ b/src/detection/netio/netio_linux.c
@@ -9,7 +9,7 @@
 static void getData(FFstrbuf* buffer, const char* ifName, bool isDefaultRoute, FFstrbuf* path, FFlist* result)
 {
     ffStrbufSetF(path, "/sys/class/net/%s/operstate", ifName);
-    if(!ffReadFileBuffer(path->chars, buffer) || !ffStrbufEqualS(buffer, "up"))
+    if(!ffReadFileBuffer(path->chars, buffer) || !ffStrbufEqualS(buffer, "up\n"))
         return;
 
     FFNetIOResult* counters = (FFNetIOResult*) ffListAdd(result);

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -126,6 +126,7 @@ static void getDebianVersion(FFOSResult* result)
 {
     FF_STRBUF_AUTO_DESTROY debianVersion = ffStrbufCreate();
     ffAppendFileBuffer("/etc/debian_version", &debianVersion);
+    ffStrbufTrimRightSpace(&debianVersion);
     if (!debianVersion.length) return;
     ffStrbufSet(&result->version, &debianVersion);
     ffStrbufSet(&result->versionID, &debianVersion);

--- a/src/detection/temps/temps_linux.c
+++ b/src/detection/temps/temps_linux.c
@@ -26,6 +26,7 @@ static bool parseHwmonDir(FFstrbuf* dir, FFTempValue* value)
 
     ffStrbufAppendS(dir, "name");
     ffReadFileBuffer(dir->chars, &value->name);
+    ffStrbufTrimRightSpace(&value->name);
     ffStrbufSubstrBefore(dir, dirLength);
 
     ffStrbufAppendS(dir, "device/class");
@@ -35,6 +36,7 @@ static bool parseHwmonDir(FFstrbuf* dir, FFTempValue* value)
         ffStrbufAppendS(dir, "device/device/class");
         ffReadFileBuffer(dir->chars, &valueBuffer);
     }
+    ffStrbufTrimRightSpace(&valueBuffer);
     if(valueBuffer.length)
         value->deviceClass = (uint32_t) strtoul(valueBuffer.chars, NULL, 16);
 

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -37,6 +37,7 @@ static void getProcessInformation(pid_t pid, FFstrbuf* processName, FFstrbuf* ex
 
     if(ffAppendFileBuffer(cmdlineFilePath, exe))
     {
+        ffStrbufTrimRightSpace(exe);
         ffStrbufSubstrBeforeFirstC(exe, '\0'); //Trim the arguments
         ffStrbufTrimLeft(exe, '-'); //Happens in TTY
     }

--- a/src/detection/wifi/wifi_linux.c
+++ b/src/detection/wifi/wifi_linux.c
@@ -248,7 +248,7 @@ static const char* detectWifiWithIoctls(FFlist* result)
         item->conn.txRate = 0.0/0.0;
 
         ffStrbufSetF(&path, "/sys/class/net/%s/operstate", i->if_name);
-        if(!ffAppendFileBuffer(path.chars, &item->inf.status) || !ffStrbufEqualS(&item->inf.status, "up"))
+        if (!ffAppendFileBuffer(path.chars, &item->inf.status) || !ffStrbufEqualS(&item->inf.status, "up\n"))
             continue;
 
         FF_AUTO_CLOSE_FD int sock = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);


### PR DESCRIPTION
I have checked all calls of ffAppendFDBuffer and fix most of the trailing space problems.

Some data just passed to the parser(e.g. strtoul), trailing space in these cases are not problems, stay as is.

The contents of some sysfs files have a fixed format(like /sys/class/net/*/operstate), so instead of removing trailing spaces and newlines, the contents being compared are updated.

Code under `src/logo` I didn't change because there is no trailing space problem here, but I'm not 100% sure. This shoule be checked in reviewing.