### PR TITLE
fix(Battery): fix overflow and uninitializations of battery cycle counts

### DIFF
--- a/src/detection/battery/battery_android.c
+++ b/src/detection/battery/battery_android.c
@@ -71,6 +71,7 @@ static const char* parseDumpsys(FFBatteryOptions* options, FFlist* results)
 
     FFBatteryResult* battery = ffListAdd(results);
     battery->temperature = FF_BATTERY_TEMP_UNSET;
+    battery->cycleCount = 0;
     ffStrbufInit(&battery->manufacturer);
     ffStrbufInit(&battery->modelName);
     ffStrbufInit(&battery->status);

--- a/src/detection/battery/battery_apple.c
+++ b/src/detection/battery/battery_apple.c
@@ -56,7 +56,9 @@ const char* ffDetectBattery(FFBatteryOptions* options, FFlist* results)
                 ffStrbufAppendS(&battery->modelName, "Built-in");
         }
 
-        ffCfDictGetInt(properties, CFSTR("CycleCount"), (int32_t*) &battery->cycleCount);
+        int32_t cycleCount = 0;
+        ffCfDictGetInt(properties, CFSTR("CycleCount"), &cycleCount);
+        battery->cycleCount = cycleCount < 0 ? 0 : (uint32_t) cycleCount;
 
         if (!ffCfDictGetBool(properties, CFSTR("ExternalConnected"), &boolValue) && boolValue)
             ffStrbufAppendS(&battery->status, "AC connected, ");

--- a/src/detection/battery/battery_linux.c
+++ b/src/detection/battery/battery_linux.c
@@ -75,8 +75,12 @@ static void parseBattery(FFstrbuf* dir, const char* id, FFBatteryOptions* option
     ffReadFileBuffer(dir->chars, &testBatteryBuffer);
     ffStrbufTrimRightSpace(&testBatteryBuffer);
     ffStrbufSubstrBefore(dir, dirLength);
-    if(dir->length)
-        result->cycleCount = (uint32_t) ffStrbufToUInt(&testBatteryBuffer, 0);
+    if (dir->length)
+    {
+        int64_t cycleCount = 0;
+        cycleCount = (int64_t) strtoll(testBatteryBuffer.chars, NULL, 10);
+        result->cycleCount = cycleCount < 0 || cycleCount > UINT32_MAX ? 0 : (uint32_t) cycleCount;
+    }
 
     result->temperature = FF_BATTERY_TEMP_UNSET;
     if (options->temp)

--- a/src/detection/battery/battery_windows.c
+++ b/src/detection/battery/battery_windows.c
@@ -150,7 +150,7 @@ static const char* detectWithNtApi(FF_MAYBE_UNUSED FFBatteryOptions* options, FF
         ffStrbufInit(&battery->manufacturer);
         ffStrbufInit(&battery->technology);
         ffStrbufInit(&battery->status);
-        battery->temperature = 0.0/0.0;
+        battery->temperature = FF_BATTERY_TEMP_UNSET;
         battery->cycleCount = 0;
 
         battery->capacity = info.RemainingCapacity * 100.0 / info.MaxCapacity;


### PR DESCRIPTION
Fix overflow and uninitializations of `FFBatteryResult.cycleCount`.

For example on WSL:

![Snipaste_2023-12-25_10-06-11](https://github.com/fastfetch-cli/fastfetch/assets/21255940/c5caa4d1-a6f5-4958-8d4e-3b0c2ef24ccb)

MacOS using single integer types may have the same problem, fix it.

Fix a few uninitializations.