### PR TITLE
Terminal (macOS): fix compatibility with CodeWhisperer for CLI

### DIFF
--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -181,7 +181,7 @@ static void getTerminalShell(FFTerminalShellResult* result, pid_t pid)
 
     #ifdef __APPLE__
     // https://github.com/fastfetch-cli/fastfetch/discussions/501
-    if (ffStrEndsWith(name, " (figterm)"))
+    if (ffStrEndsWith(name, " (figterm)") || ffStrEndsWith(name, " (cwterm)"))
         getProcessNameAndPpid(ppid, name, &ppid);
     #endif
 


### PR DESCRIPTION
Ignore `cwterm` as well as `figterm`
Since CodeWhisperer overrides the terminal environment.

Same idea with https://github.com/fastfetch-cli/fastfetch/commit/eea70020c30029fd8fccc63a431ad75c7462fa8f.