### PR TITLE
Add more Linux distributions to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ There are [screenshots on different platforms](https://github.com/fastfetch-cli/
 * Arch Linux: `sudo pacman -S fastfetch`
 * Fedora: `sudo dnf install fastfetch`
 * Gentoo: `sudo emerge --ask app-misc/fastfetch`
+* Alpine: `sudo pkg install fastfetch`
+* NixOS: `sudo nix-shell -p fastfetch`
+* openSUSE: `sudo zypper install fastfetch`
+
+Replace sudo with doas depending on what you use.
 
 [See also if fastfetch has been packaged for your favorite Linux distro](#Packaging)
 


### PR DESCRIPTION
I added Alpine Linux, NixOS and openSUSE to the installation guide and a warning to use doas if using it instead of sudo.