### PR TITLE
Locale (Linux): prioritize $LANG and then /etc/*.conf

### DIFF
--- a/src/detection/locale/locale_linux.c
+++ b/src/detection/locale/locale_linux.c
@@ -33,6 +33,14 @@ static void getLocaleFromStdFn(FFstrbuf* locale)
 
 void ffDetectLocale(FFstrbuf* result)
 {
+    #ifndef _WIN32
+
+        getLocaleFromEnv(result);
+        if(result->length > 0)
+            return;
+
+    #endif
+
     #if !(defined(__APPLE__) || defined(_WIN32))
 
         //Ubuntu (and deriviates) use a non standard locale file.
@@ -44,14 +52,6 @@ void ffDetectLocale(FFstrbuf* result)
             return;
 
         ffParsePropFile(FASTFETCH_TARGET_DIR_ETC"/locale.conf", "LANG =", result);
-        if(result->length > 0)
-            return;
-
-    #endif
-
-    #ifndef _WIN32
-
-        getLocaleFromEnv(result);
         if(result->length > 0)
             return;
 


### PR DESCRIPTION
/etc/locale.conf default LANG= and LC_*= environment variables for all programs, but users may overriden these variables to customize per-user or per-program settings[0]. Most programs just read LANG env var instead of parsing /etc/locale.conf themselves. Currently, fastfetch prioritizes /etc/locale.conf and other configuration files instead of $LANG, so it reports the system-wide default locale instead of what programs actually use. In my setup, I have `LANG=en_US.UTF-8` in /etc/locale.conf, but my per-user environment variable has `LANG=zh_CN.UTF-8`. Most of my programs display Chinese, while other users are still English. In this case, fastfecth still reports `Locale: en_US.UTF-8`, but it should be `zh_CN`.

This patch changes the order or locale detection. It firstly reads LANG and LC_* env vars, and it then reads /etc/*.conf if these variables are not set (very rare). In most cases, these variables will just equal to the system-wide default in /etc/*.conf.

[0]: locale.conf(5): The locale settings configured in /etc/locale.conf are system-wide and are inherited by every service or user, unless overridden or unset by individual programs or users.