### PR TITLE
Add installation instructions for even more Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ There are [screenshots on different platforms](https://github.com/fastfetch-cli/
 ### Linux
 
 * Debian / Ubuntu: Download `fastfetch-<version>-Linux.deb` from [Github release page](https://github.com/fastfetch-cli/fastfetch/releases/latest) and `dpkg -i fastfetch-<version>-Linux.deb`
-* Arch Linux: `sudo pacman -S fastfetch`
+* Arch Linux: `sudo pacman -S fastfetch`. You can also find fastfetch [on the AUR](https://aur.archlinux.org/packages/fastfetch-git).
 * Fedora: `sudo dnf install fastfetch`
 * Gentoo: `sudo emerge --ask app-misc/fastfetch`
+* Alpine: `apk add --upgrade fastfetch`
 * NixOS: `sudo nix-shell -p fastfetch`
 * openSUSE: `sudo zypper install fastfetch`
+* ALT Linux: `sudo apt-get install fastfetch`
 
 Replace sudo with doas depending on what you use.
 


### PR DESCRIPTION
Added Alpine (now with the right command), ALT Linux and Arch AUR to the installation instructions.