### PR TITLE
Update flashfetch.c

### DIFF
--- a/src/flashfetch.c
+++ b/src/flashfetch.c
@@ -21,6 +21,7 @@ int main(void)
         &options->title,
         &options->separator,
         &options->os,
+        &options->host,
         &options->kernel,
         &options->uptime,
         &options->packages,


### PR DESCRIPTION
add the skipped "host" option from "Flashfetch: simplify implementation" (in #645)