### PR TITLE
fastfetch: fixes #778

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -9,6 +9,7 @@
 
 #include <stdlib.h>
 #include <ctype.h>
+#include <errno.h>
 #include <string.h>
 
 #ifdef WIN32
@@ -821,6 +822,7 @@ static void run(FFdata* data)
     if (instance.state.resultDoc)
     {
         yyjson_mut_write_fp(stdout, instance.state.resultDoc, YYJSON_WRITE_INF_AND_NAN_AS_NULL | YYJSON_WRITE_PRETTY_TWO_SPACES, NULL, NULL);
+        //TODO should use YYJSON_WRITE_NEWLINE_AT_END when it is available
         putchar('\n');
     }
     else
@@ -840,24 +842,29 @@ static void writeConfigFile(FFdata* data, const FFstrbuf* filename)
     ffOptionsGenerateLibraryJsonConfig(&instance.config.library, doc);
     ffMigrateCommandOptionToJsonc(data, doc);
 
-    if (ffStrbufEqualS(filename, "-"))
-        yyjson_mut_write_fp(stdout, doc, YYJSON_WRITE_INF_AND_NAN_AS_NULL | YYJSON_WRITE_PRETTY_TWO_SPACES, NULL, NULL);
-    else
+    FILE *fp = stdout;
+    bool writeToStdout = ffStrbufEqualS(filename, "-");
+    if (!writeToStdout)
     {
-        size_t len;
-        FF_AUTO_FREE const char* str = yyjson_mut_write(doc, YYJSON_WRITE_INF_AND_NAN_AS_NULL | YYJSON_WRITE_PRETTY_TWO_SPACES, &len);
-        if (!str)
+        if ((fp = fopen(filename->chars, "w")) == NULL)
         {
-            printf("Error: failed to generate config file\n");
+            fprintf(stderr, "can not create config file in %s: %s\n", filename->chars, strerror(errno));
             exit(1);
         }
-        if (ffWriteFileData(filename->chars, len, str))
-            printf("The generated config file has been written in `%s`\n", filename->chars);
-        else
-        {
-            printf("Error: failed to write file in `%s`\n", filename->chars);
-            exit(1);
-        }
+    }
+
+    bool ok = yyjson_mut_write_fp(fp, doc, YYJSON_WRITE_INF_AND_NAN_AS_NULL | YYJSON_WRITE_PRETTY_TWO_SPACES, NULL, NULL);
+    //TODO should use YYJSON_WRITE_NEWLINE_AT_END when it is available
+    fputc('\n', fp);
+    if (!ok)
+    {
+        fprintf(stderr, "Error: failed to generate config in `%s`\n", writeToStdout ? "stdout" : filename->chars);
+        exit(1);
+    }
+    if (ok && !writeToStdout)
+    {
+        fclose(fp);
+        printf("The generated config file has been written in `%s`\n", filename->chars);
     }
 
     yyjson_mut_doc_free(doc);


### PR DESCRIPTION
Updates #778 

Check the result of `fopen`.

PS: A more general approach is to check during the initialization phase whether the configuration directory exists and automatically create it if it does not exist. I think this should be implemented in another PR.