### PR TITLE
Platform: fix a memory leak

### DIFF
--- a/src/util/platform/FFPlatform.c
+++ b/src/util/platform/FFPlatform.c
@@ -52,6 +52,7 @@ void ffPlatformDestroy(FFPlatform* platform)
     FF_LIST_FOR_EACH(FFstrbuf, dir, platform->dataDirs)
         ffStrbufDestroy(dir);
     ffListDestroy(&platform->dataDirs);
+    ffStrbufDestroy(&platform->exePath);
 
     ffStrbufDestroy(&platform->userName);
     ffStrbufDestroy(&platform->hostName);


### PR DESCRIPTION
"exePath" was allocated but not destroyed.