### PR TITLE
Logo: fix logo color of AOSC OS

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -224,7 +224,7 @@ static const FFlogo A[] = {
         .colors = {
             FF_COLOR_FG_BLUE,
             FF_COLOR_FG_BLACK,
-            FF_COLOR_FG_GREEN,
+            FF_COLOR_FG_RED,
             FF_COLOR_FG_YELLOW,
         },
     },


### PR DESCRIPTION
Resolve issue: https://github.com/fastfetch-cli/fastfetch/issues/790