### PR TITLE
Allow the generation of either deb or rpm package only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1147,16 +1147,20 @@ endif()
 
 if(LINUX)
     find_program(HAVE_DPKG "dpkg")
-    find_program(HAVE_RPMBUILD "rpmbuild")
-    if(HAVE_DPKG AND HAVE_RPMBUILD)
-        set(CPACK_GENERATOR "${CPACK_GENERATOR};DEB;RPM")
+    if(HAVE_DPKG)
+        set(CPACK_GENERATOR "${CPACK_GENERATOR};DEB")
+
+        set(CPACK_DEBIAN_PACKAGE_SECTION, "utils")
+        set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6")
     endif()
 
-    set(CPACK_DEBIAN_PACKAGE_SECTION, "utils")
-    set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6")
+    find_program(HAVE_RPMBUILD "rpmbuild")
+    if(HAVE_RPMBUILD)
+        set(CPACK_GENERATOR "${CPACK_GENERATOR};RPM")
 
-    set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+        set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+    endif()
 endif()
 
 set(CPACK_SET_DESTDIR ON)


### PR DESCRIPTION
Currently, a deb and rpm package is only generated if **both** can be generated:

```cmake
if(HAVE_DPKG AND HAVE_RPMBUILD)
    set(CPACK_GENERATOR "${CPACK_GENERATOR};DEB;RPM")
endif()
```

Ideally, one would only generate a package for their system. For example, I use fastfetch on a Raspberry pi 3B+, which is armhf (32 bit), which isn't prebuilt, thus I always build the deb package from source, and I don't care about the rpm package at all.

Until version 2.10.x the deb (and rpm) package generations were incorrectly attempted even if they were not possible:

```cmake
if(LINUX)
    set(CPACK_GENERATOR "${CPACK_GENERATOR};DEB;RPM") # <--- here

    find_program(HAVE_DPKG "dpkg")
    find_program(HAVE_RPMBUILD "rpmbuild")
    if(HAVE_DPKG AND HAVE_RPMBUILD)
        set(CPACK_GENERATOR "${CPACK_GENERATOR};DEB;RPM")
    endif()
```

This would fail to generate an rpm, but, at least for me, it would still generate a deb package, so for me that was a feature, not a bug :)