### PR TITLE
Add Bedrock Linux version by parsing /bedrock/etc/os-release

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -150,8 +150,11 @@ static void detectOS(FFOSResult* os)
 
         if(os->prettyName.length == 0)
             ffStrbufAppendS(&os->prettyName, "Bedrock Linux");
+        
+        parseFile("/bedrock"FASTFETCH_TARGET_DIR_ETC"/os-release", os);
 
-        return;
+        if(allRelevantValuesSet(os))
+            return;
     }
 
     parseFile(FASTFETCH_TARGET_DIR_ETC"/os-release", os);


### PR DESCRIPTION
![image](https://github.com/fastfetch-cli/fastfetch/assets/130178512/488cf686-b082-4be1-841f-7fc38dc430de)
