### PR TITLE
Terminal: fix nixos wrapped process name

### DIFF
--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -482,14 +482,15 @@ static void setShellInfoDetails(FFShellResult* result)
 
 static void setTerminalInfoDetails(FFTerminalResult* result)
 {
-    if(result->exeName[0] == '.' && ffStrEndsWith(result->exeName, "-wrapped"))
+    if(ffStrbufStartsWithC(&result->processName, '.') && ffStrbufEndsWithS(&result->processName, "-wrapped"))
     {
         // For NixOS. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
         // We use processName when detecting version and font, overriding it for simplification
         ffStrbufSetNS(
             &result->processName,
-            (uint32_t) (strlen(result->exeName) - strlen(".-wrapped")),
-            result->exeName + 1);
+            (uint32_t) (strlen(result->processName.chars) - strlen(".-wrapped")),
+            result->processName.chars + 1
+        );
     }
 
     if(ffStrbufEqualS(&result->processName, "wezterm-gui"))


### PR DESCRIPTION
The program currently checks the `exeName` for the NixOS wrapper name, however the command line name appears normal, while the process name is the one which is in `.*-wrapped` format. For example, on my system `exeName` is `kgx` while `processName` is `.kgx-wrapped`.

Currently broken:
![image](https://github.com/fastfetch-cli/fastfetch/assets/38849891/f468164b-aba4-44e0-8985-89ddcf7c0060)
![image](https://github.com/fastfetch-cli/fastfetch/assets/38849891/53002edf-7c95-4077-bd11-b7d818f594f3)

After fix:
![image](https://github.com/fastfetch-cli/fastfetch/assets/38849891/227ccf64-2c7c-4e15-ae8c-bad611da05e2)
![Screenshot from 2024-04-26 16-33-17](https://github.com/fastfetch-cli/fastfetch/assets/38849891/6f010f1a-0275-4475-90bb-a623d34fa462)
