### PR TITLE
Packages (Linux): check xdg state home for nix user packages

### DIFF
--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -506,7 +506,6 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options)
         // check if ~/.nix-profile exists
         FF_STRBUF_AUTO_DESTROY profilePath = ffStrbufCreateCopy(&baseDir);
         ffStrbufAppendS(&profilePath, ".nix-profile");
-        printf("%s\n", profilePath.chars);
         if (ffPathExists(profilePath.chars, FF_PATHTYPE_DIRECTORY))
         {
             result->nixUser = getNixPackages(&baseDir, ".nix-profile");
@@ -529,7 +528,6 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options)
  
             ffStrbufSet(&profilePath, &stateDir);
             ffStrbufAppendS(&profilePath, "nix/profile");
-            printf("%s\n", profilePath.chars);
             result->nixUser = getNixPackages(&stateDir, "nix/profile");
         }
     }

--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -502,7 +502,38 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options)
 
     ffStrbufSet(&baseDir, &instance.state.platform.homeDir);
     if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT))
-        result->nixUser = getNixPackages(&baseDir, "/.nix-profile");
+    {
+        // check if ~/.nix-profile exists
+        FF_STRBUF_AUTO_DESTROY profilePath = ffStrbufCreateCopy(&baseDir);
+        ffStrbufAppendS(&profilePath, ".nix-profile");
+        printf("%s\n", profilePath.chars);
+        if (ffPathExists(profilePath.chars, FF_PATHTYPE_DIRECTORY))
+        {
+            result->nixUser = getNixPackages(&baseDir, ".nix-profile");
+        }
+        // check if $XDG_STATE_HOME/nix/profile exists
+        else
+        {
+            FF_STRBUF_AUTO_DESTROY stateDir = ffStrbufCreate();
+            const char* stateHome = getenv("XDG_STATE_HOME");
+            if(ffStrSet(stateHome))
+            {
+                ffStrbufSetS(&stateDir, stateHome);
+                ffStrbufEnsureEndsWithC(&stateDir, '/');
+            }
+            else
+            {
+                ffStrbufSet(&stateDir, &instance.state.platform.homeDir);
+                ffStrbufAppendS(&stateDir, ".local/state/");
+            }
+ 
+            ffStrbufSet(&profilePath, &stateDir);
+            ffStrbufAppendS(&profilePath, "nix/profile");
+            printf("%s\n", profilePath.chars);
+            result->nixUser = getNixPackages(&stateDir, "nix/profile");
+        }
+    }
+ 
     if (!(options->disabled & FF_PACKAGES_FLAG_FLATPAK_BIT))
         result->flatpakUser = getFlatpak(&baseDir, "/.local/share/flatpak");
 }


### PR DESCRIPTION
Check $XDG_STATE_HOME/nix/profile if ~/.nix-profile is not found as addressed in #837.