### PR TITLE
Fix "AVCaptureDeviceTypeExternal is deprecated for Continuity Cameras"

### DIFF
--- a/src/detection/camera/camera_apple.m
+++ b/src/detection/camera/camera_apple.m
@@ -6,9 +6,19 @@
 const char* ffDetectCamera(FFlist* result)
 {
     FF_SUPPRESS_IO(); // #822
-    AVCaptureDeviceDiscoverySession* session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
-                                                                                mediaType:AVMediaTypeVideo
-                                                                                position:AVCaptureDevicePositionUnspecified];
+
+    AVCaptureDeviceDiscoverySession* session = NULL;
+    if (@available(macOS 10.15, *)) {
+        session =  [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternal]
+                                                                          mediaType:AVMediaTypeVideo
+                                                                           position:AVCaptureDevicePositionUnspecified];
+
+    } else {
+        session =  [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
+                                                                          mediaType:AVMediaTypeVideo
+                                                                           position:AVCaptureDevicePositionUnspecified];
+    }
+
     if (!session)
         return "Failed to create AVCaptureDeviceDiscoverySession";
 

--- a/src/detection/camera/camera_apple.m
+++ b/src/detection/camera/camera_apple.m
@@ -8,7 +8,7 @@ const char* ffDetectCamera(FFlist* result)
     FF_SUPPRESS_IO(); // #822
 
     AVCaptureDeviceDiscoverySession* session = NULL;
-    if (@available(macOS 10.15, *)) {
+    if (@available(macOS 14.0, *)) {
         session =  [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternal]
                                                                           mediaType:AVMediaTypeVideo
                                                                            position:AVCaptureDevicePositionUnspecified];


### PR DESCRIPTION
 Fixes #859 