### PR TITLE
Fastfetch: fix memory leaks when passing informative options

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -863,6 +863,7 @@ static void writeConfigFile(FFdata* data, const FFstrbuf* filename)
 int main(int argc, char** argv)
 {
     ffInitInstance();
+    atexit(ffDestroyInstance);
 
     //Data stores things only needed for the configuration of fastfetch
     FFdata data = {
@@ -888,6 +889,4 @@ int main(int argc, char** argv)
         ffStrbufDestroy(&customValue->value);
     }
     ffListDestroy(&data.customValues);
-
-    ffDestroyInstance();
 }


### PR DESCRIPTION
Informative options (e.g. "--help", "--list-module") make fastfetch exit before calling ffDestroyInstance. Using "atexit" to avoid this kind of leak.