### PR TITLE
Free all allocated memory before exiting

### DIFF
--- a/src/detection/displayserver/displayserver.c
+++ b/src/detection/displayserver/displayserver.c
@@ -33,9 +33,31 @@ bool ffdsAppendDisplay(
 
 void ffConnectDisplayServerImpl(FFDisplayServerResult* ds);
 
+
+static inline void ffDisplayServerResultDestory(FFDisplayServerResult* result)
+{
+    if (!result) return;
+    ffStrbufDestroy(&result->wmProcessName);
+    ffStrbufDestroy(&result->wmPrettyName);
+    ffStrbufDestroy(&result->wmProtocolName);
+    ffStrbufDestroy(&result->deProcessName);
+    ffStrbufDestroy(&result->dePrettyName);
+    FF_LIST_FOR_EACH(FFDisplayResult, display, result->displays)
+    {
+        ffStrbufDestroy(&display->name);
+    }
+    ffListDestroy(&result->displays);
+}
+
+static FFDisplayServerResult result;
+
+void ffDisplayServerCleanResult(void)
+{
+    ffDisplayServerResultDestory(&result);
+}
+
 const FFDisplayServerResult* ffConnectDisplayServer()
 {
-    static FFDisplayServerResult result;
     if (result.displays.elementSize == 0)
     {
         ffStrbufInit(&result.wmProcessName);
@@ -45,6 +67,7 @@ const FFDisplayServerResult* ffConnectDisplayServer()
         ffStrbufInit(&result.dePrettyName);
         ffListInit(&result.displays, sizeof(FFDisplayResult));
         ffConnectDisplayServerImpl(&result);
+        atexit(ffDisplayServerCleanResult);
     }
     return &result;
 }

--- a/src/detection/gpu/gpu_linux.c
+++ b/src/detection/gpu/gpu_linux.c
@@ -143,6 +143,13 @@ static bool loadPciIds(FFstrbuf* pciids)
     return false;
 }
 
+static FFstrbuf pciids;
+
+static void cleanupPciids(void)
+{
+    ffStrbufDestroy(&pciids);
+}
+
 static const char* detectPci(const FFGPUOptions* options, FFlist* gpus, FFstrbuf* buffer, FFstrbuf* drmDir)
 {
     const uint32_t drmDirPathLength = drmDir->length;
@@ -204,11 +211,11 @@ static const char* detectPci(const FFGPUOptions* options, FFlist* gpus, FFstrbuf
 
     if (gpu->name.length == 0)
     {
-        static FFstrbuf pciids;
         if (pciids.chars == NULL)
         {
             ffStrbufInit(&pciids);
             loadPciIds(&pciids);
+            atexit(cleanupPciids);
         }
         ffGPUParsePciIds(&pciids, subclassId, (uint16_t) vendorId, (uint16_t) deviceId, gpu);
     }

--- a/src/detection/os/os.c
+++ b/src/detection/os/os.c
@@ -2,9 +2,30 @@
 
 void ffDetectOSImpl(FFOSResult* os);
 
+static inline void ffOSResultDestory(FFOSResult* result)
+{
+    if (!result) return;
+    ffStrbufDestroy(&result->name);
+    ffStrbufDestroy(&result->prettyName);
+    ffStrbufDestroy(&result->id);
+    ffStrbufDestroy(&result->idLike);
+    ffStrbufDestroy(&result->variant);
+    ffStrbufDestroy(&result->variantID);
+    ffStrbufDestroy(&result->version);
+    ffStrbufDestroy(&result->versionID);
+    ffStrbufDestroy(&result->codename);
+    ffStrbufDestroy(&result->buildID);
+}
+
+static FFOSResult result;
+
+static void cleanupResult(void)
+{
+    ffOSResultDestory(&result);
+}
+
 const FFOSResult* ffDetectOS(void)
 {
-    static FFOSResult result;
     if (result.name.chars == NULL)
     {
         ffStrbufInit(&result.name);
@@ -18,6 +39,7 @@ const FFOSResult* ffDetectOS(void)
         ffStrbufInit(&result.variant);
         ffStrbufInit(&result.variantID);
         ffDetectOSImpl(&result);
+        atexit(cleanupResult);
     }
     return &result;
 }

--- a/src/detection/terminalshell/terminalshell.h
+++ b/src/detection/terminalshell/terminalshell.h
@@ -15,6 +15,17 @@ typedef struct FFShellResult
     int32_t tty;
 } FFShellResult;
 
+static inline void ffShellResultDestory(FFShellResult *result)
+{
+    if (!result) return;
+    ffStrbufDestroy(&result->processName);
+    result->exeName = NULL;
+    ffStrbufDestroy(&result->exe);
+    ffStrbufDestroy(&result->exePath);
+    ffStrbufDestroy(&result->prettyName);
+    ffStrbufDestroy(&result->version);
+}
+
 typedef struct FFTerminalResult
 {
     FFstrbuf processName;
@@ -27,6 +38,18 @@ typedef struct FFTerminalResult
     uint32_t pid;
     uint32_t ppid;
 } FFTerminalResult;
+
+static inline void ffTerminalResultDestory(FFTerminalResult *result)
+{
+    if (!result) return;
+    ffStrbufDestroy(&result->processName);
+    result->exeName = NULL;
+    ffStrbufDestroy(&result->exe);
+    ffStrbufDestroy(&result->prettyName);
+    ffStrbufDestroy(&result->exePath);
+    ffStrbufDestroy(&result->version);
+    ffStrbufDestroy(&result->tty);
+}
 
 const FFShellResult* ffDetectShell();
 const FFTerminalResult* ffDetectTerminal();


### PR DESCRIPTION
I always get a lot of noise when using memory detecting tools. Most of the noise comes from static variables that called malloc but did not freed. These leaks might be harmless but it's better to clean up all resources when we exit.

I split this into 4 commits so that when some parts run into problems it can be easily reverted.