### PR TITLE
JsonConfig: Added `brightness` properties and `dim_` colors

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -1003,6 +1003,21 @@
                                         "minimum": 0,
                                         "maximum": 400,
                                         "default": 10
+                                    },
+                                    "key": {
+                                        "$ref": "#/$defs/key"
+                                    },
+                                    "keyColor": {
+                                        "$ref": "#/$defs/keyColor"
+                                    },
+                                    "outputColor": {
+                                        "$ref": "#/$defs/outputColor"
+                                    },
+                                    "keyWidth": {
+                                        "$ref": "#/$defs/keyWidth"
+                                    },
+                                    "format": {
+                                        "$ref": "#/$defs/format"
                                     }
                                 }
                             },

--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -6,7 +6,8 @@
             "enum": [
                 "reset_", "bright_", "dim_",
                 "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "default",
-                "bright_black", "bright_red", "bright_green", "bright_yellow", "bright_blue", "bright_magenta", "bright_cyan", "bright_white"
+                "bright_black", "bright_red", "bright_green", "bright_yellow", "bright_blue", "bright_magenta", "bright_cyan", "bright_white",
+                "dim_black", "dim_red", "dim_green", "dim_yellow", "dim_blue", "dim_magenta", "dim_cyan", "dim_white"
             ]
         },
         "key": {


### PR DESCRIPTION
I was making a custom config in VScode and noticed issues with Intellisense.

First, most of the properties for the `brightness` module weren't valid according to the template.

Second, when using colors, I noticed that `bright_` colors are returning the same color as the base ones. I then tried with the `dim_` prefix which did give me the other shades which were the darker ones.  I got this behavior on both Fedora 40 GNOME 46 and Ubuntu 22.04 GNOME 42.9.  I am not sure if the issue is GNOME or Linux-specific which is why I only added `dim_` variants to the color list instead of replacing the `bright_` ones.