### PR TITLE
src: logo: builtin: Fix TorizonCore logo colors

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -4075,10 +4075,9 @@ static const FFlogo T[] = {
         .names = {"TorizonCore"},
         .lines = FASTFETCH_DATATEXT_LOGO_TORIZONCORE,
         .colors = {
+            FF_COLOR_FG_LIGHT_WHITE,
             FF_COLOR_FG_YELLOW,
-            FF_COLOR_FG_BLUE,
-            FF_COLOR_FG_LIGHT_BLACK,
-            FF_COLOR_FG_MAGENTA,
+            FF_COLOR_FG_BLUE
         },
     },
     // Trisquel


### PR DESCRIPTION
You can verify the colors of the logo from https://www.torizon.io/