### PR TITLE
Add support for old MacOS version

### DIFF
--- a/src/detection/camera/camera_apple.m
+++ b/src/detection/camera/camera_apple.m
@@ -48,6 +48,7 @@ const char* ffDetectCamera(FFlist* result)
         camera->width = size.width < 0 ? 0 : (uint32_t) size.width;
         camera->height = size.height < 0 ? 0 : (uint32_t) size.height;
     }
+    #else
+    return "No support for old MacOS version";
     #endif
-    return NULL;
 }

--- a/src/detection/camera/camera_apple.m
+++ b/src/detection/camera/camera_apple.m
@@ -8,6 +8,7 @@
 
 const char* ffDetectCamera(FFlist* result)
 {
+    #ifdef MAC_OS_X_VERSION_10_15
     FF_SUPPRESS_IO(); // #822
 
     AVCaptureDeviceType deviceType;
@@ -47,6 +48,6 @@ const char* ffDetectCamera(FFlist* result)
         camera->width = size.width < 0 ? 0 : (uint32_t) size.width;
         camera->height = size.height < 0 ? 0 : (uint32_t) size.height;
     }
-
+    #endif
     return NULL;
 }

--- a/src/detection/camera/camera_apple.m
+++ b/src/detection/camera/camera_apple.m
@@ -48,6 +48,7 @@ const char* ffDetectCamera(FFlist* result)
         camera->width = size.width < 0 ? 0 : (uint32_t) size.width;
         camera->height = size.height < 0 ? 0 : (uint32_t) size.height;
     }
+    return NULL;
     #else
     return "No support for old MacOS version";
     #endif

--- a/src/detection/disk/disk_bsd.c
+++ b/src/detection/disk/disk_bsd.c
@@ -76,7 +76,11 @@ void detectFsInfo(struct statfs* fs, FFDisk* disk)
 {
     if(fs->f_flags & MNT_DONTBROWSE)
         disk->type = FF_DISK_VOLUME_TYPE_HIDDEN_BIT;
-    else if(fs->f_flags & MNT_REMOVABLE || !(fs->f_flags & MNT_LOCAL))
+    #ifndef MAC_OS_X_VERSION_10_15
+    else if(!(fs->f_flags & MNT_LOCAL))
+    #else
+    else if(fs->f_flags & MNT_REMOVABLE || !(fs->f_flags & MNT_LOCAL))  
+    #endif
         disk->type = FF_DISK_VOLUME_TYPE_EXTERNAL_BIT;
     else
         disk->type = FF_DISK_VOLUME_TYPE_REGULAR_BIT;

--- a/src/detection/disk/disk_bsd.c
+++ b/src/detection/disk/disk_bsd.c
@@ -80,7 +80,7 @@ void detectFsInfo(struct statfs* fs, FFDisk* disk)
 {
     if(fs->f_flags & MNT_DONTBROWSE)
         disk->type = FF_DISK_VOLUME_TYPE_HIDDEN_BIT;
-    else if(fs->f_flags & MNT_REMOVABLE || !(fs->f_flags & MNT_LOCAL))  
+    else if(fs->f_flags & MNT_REMOVABLE || !(fs->f_flags & MNT_LOCAL))
         disk->type = FF_DISK_VOLUME_TYPE_EXTERNAL_BIT;
     else
         disk->type = FF_DISK_VOLUME_TYPE_REGULAR_BIT;

--- a/src/detection/disk/disk_bsd.c
+++ b/src/detection/disk/disk_bsd.c
@@ -66,6 +66,10 @@ static void detectFsInfo(struct statfs* fs, FFDisk* disk)
 #include <sys/attr.h>
 #include <unistd.h>
 
+#ifndef MAC_OS_X_VERSION_10_15
+    #define MNT_REMOVABLE 0x00000200
+#endif
+
 struct CmnAttrBuf {
     uint32_t       length;
     attrreference_t nameRef;
@@ -76,11 +80,7 @@ void detectFsInfo(struct statfs* fs, FFDisk* disk)
 {
     if(fs->f_flags & MNT_DONTBROWSE)
         disk->type = FF_DISK_VOLUME_TYPE_HIDDEN_BIT;
-    #ifndef MAC_OS_X_VERSION_10_15
-    else if(!(fs->f_flags & MNT_LOCAL))
-    #else
     else if(fs->f_flags & MNT_REMOVABLE || !(fs->f_flags & MNT_LOCAL))  
-    #endif
         disk->type = FF_DISK_VOLUME_TYPE_EXTERNAL_BIT;
     else
         disk->type = FF_DISK_VOLUME_TYPE_REGULAR_BIT;

--- a/src/detection/font/font_apple.m
+++ b/src/detection/font/font_apple.m
@@ -25,7 +25,11 @@ const char* ffDetectFontImpl(FFFontResult* result)
 {
     ffStrbufAppendS(&result->fonts[0], [NSFont systemFontOfSize:12].familyName.UTF8String);
     ffStrbufAppendS(&result->fonts[1], [NSFont userFontOfSize:12].familyName.UTF8String);
+    #ifdef MAC_OS_X_VERSION_10_15
     ffStrbufAppendS(&result->fonts[2], [NSFont monospacedSystemFontOfSize:12 weight:400].familyName.UTF8String);
+    #else
+    ffStrbufAppendS(&result->fonts[2], "");
+    #endif
     ffStrbufAppendS(&result->fonts[3], [NSFont userFixedPitchFontOfSize:12].familyName.UTF8String);
     generateString(result);
 

--- a/src/detection/gpu/gpu_apple.m
+++ b/src/detection/gpu/gpu_apple.m
@@ -8,7 +8,7 @@
 
 const char* ffGpuDetectMetal(FFlist* gpus)
 {
-    if (@available(macOS 10.15, *))
+    if (@available(macOS 10.13, *))
     {
         for (id<MTLDevice> device in MTLCopyAllDevices())
         {
@@ -23,6 +23,15 @@ const char* ffGpuDetectMetal(FFlist* gpus)
             }
             if (!gpu) continue;
 
+            #ifdef MAC_OS_X_VERSION_10_13
+            #define MTLFeatureSet_macOS_GPUFamily2_v1 ((MTLFeatureSet) 10005)
+            if ([device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily2_v1])
+                ffStrbufSetStatic(&gpu->platformApi, "Metal Featrureset 2");
+            else if ([device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v1])
+                ffStrbufSetStatic(&gpu->platformApi, "Metal Featrureset 1");
+            #endif
+
+            #ifdef MAC_OS_X_VERSION_10_15
             if ([device supportsFamily:MTLGPUFamilyMetal3])
                 ffStrbufSetStatic(&gpu->platformApi, "Metal 3");
             else if ([device supportsFamily:MTLGPUFamilyCommon3])
@@ -39,6 +48,7 @@ const char* ffGpuDetectMetal(FFlist* gpus)
                 gpu->shared.used = device.currentAllocatedSize;
             }
             else
+            #endif
             {
                 gpu->type = FF_GPU_TYPE_DISCRETE;
                 gpu->dedicated.total = device.recommendedMaxWorkingSetSize;

--- a/src/detection/monitor/monitor_apple.m
+++ b/src/detection/monitor/monitor_apple.m
@@ -9,11 +9,20 @@
 
 extern CFDictionaryRef CoreDisplay_DisplayCreateInfoDictionary(CGDirectDisplayID display) __attribute__((weak_import));
 
+#ifndef MAC_OS_X_VERSION_10_15
+#import <IOKit/graphics/IOGraphicsLib.h>
+extern CFDictionaryRef CoreDisplay_IODisplayCreateInfoDictionary(io_service_t framebuffer, IOOptionBits options)  __attribute__((weak_import));
+#endif
+
 static bool detectHdrSupportWithNSScreen(FFDisplayResult* display)
 {
     NSScreen* mainScreen = NSScreen.mainScreen;
     if (display->primary)
+        #ifdef MAC_OS_X_VERSION_10_15 
         return mainScreen.maximumPotentialExtendedDynamicRangeColorComponentValue > 1;
+        #else
+        return mainScreen.maximumExtendedDynamicRangeColorComponentValue > 1;
+        #endif
     else
     {
         for (NSScreen* screen in NSScreen.screens)
@@ -22,7 +31,11 @@ static bool detectHdrSupportWithNSScreen(FFDisplayResult* display)
             NSNumber* screenNumber = [screen.deviceDescription valueForKey:@"NSScreenNumber"];
             if (screenNumber && screenNumber.longValue == (long) display->id)
             {
+                #ifdef MAC_OS_X_VERSION_10_15
                 return screen.maximumPotentialExtendedDynamicRangeColorComponentValue > 1;
+                #else
+                return screen.maximumExtendedDynamicRangeColorComponentValue > 1;
+                #endif
             }
         }
     }
@@ -31,13 +44,19 @@ static bool detectHdrSupportWithNSScreen(FFDisplayResult* display)
 
 const char* ffDetectMonitor(FFlist* results)
 {
+    #ifdef MAC_OS_X_VERSION_10_15
     if(!CoreDisplay_DisplayCreateInfoDictionary) return "CoreDisplay_DisplayCreateInfoDictionary is not available";
-
+    #endif
     const FFDisplayServerResult* displayServer = ffConnectDisplayServer();
 
     FF_LIST_FOR_EACH(FFDisplayResult, display, displayServer->displays)
     {
+        #ifdef MAC_OS_X_VERSION_10_15
         CFDictionaryRef FF_CFTYPE_AUTO_RELEASE displayInfo = CoreDisplay_DisplayCreateInfoDictionary((CGDirectDisplayID) display->id);
+        #else
+        io_service_t servicePort = CGDisplayIOServicePort((CGDirectDisplayID) display->id);
+        CFDictionaryRef FF_CFTYPE_AUTO_RELEASE displayInfo = CoreDisplay_IODisplayCreateInfoDictionary(servicePort, kIODisplayOnlyPreferredName);
+        #endif
         if(!displayInfo) continue;
 
         bool isVirtual = false;

--- a/src/detection/monitor/monitor_apple.m
+++ b/src/detection/monitor/monitor_apple.m
@@ -18,11 +18,13 @@ static bool detectHdrSupportWithNSScreen(FFDisplayResult* display)
 {
     NSScreen* mainScreen = NSScreen.mainScreen;
     if (display->primary)
+    {
         #ifdef MAC_OS_X_VERSION_10_15 
         return mainScreen.maximumPotentialExtendedDynamicRangeColorComponentValue > 1;
         #else
         return mainScreen.maximumExtendedDynamicRangeColorComponentValue > 1;
         #endif
+    }
     else
     {
         for (NSScreen* screen in NSScreen.screens)

--- a/src/detection/os/os_apple.m
+++ b/src/detection/os/os_apple.m
@@ -97,8 +97,7 @@ void ffDetectOSImpl(FFOSResult* os)
 {
     parseSystemVersion(os);
 
-    if(ffStrbufStartsWithIgnCaseS(&os->name, "MacOS")||ffStrbufStartsWithIgnCaseS(&os->name, "Mac OS X"))
-        ffStrbufSetStatic(&os->id, "macos");
+    ffStrbufSetStatic(&os->id, "macos");
 
     if(os->version.length == 0)
         ffSysctlGetString("kern.osproductversion", &os->version);

--- a/src/detection/os/os_apple.m
+++ b/src/detection/os/os_apple.m
@@ -97,7 +97,7 @@ void ffDetectOSImpl(FFOSResult* os)
 {
     parseSystemVersion(os);
 
-    if(ffStrbufStartsWithIgnCaseS(&os->name, "MacOS"))
+    if(ffStrbufStartsWithIgnCaseS(&os->name, "MacOS")||ffStrbufStartsWithIgnCaseS(&os->name, "Mac OS X"))
         ffStrbufSetStatic(&os->id, "macos");
 
     if(os->version.length == 0)

--- a/src/detection/physicaldisk/physicaldisk_apple.c
+++ b/src/detection/physicaldisk/physicaldisk_apple.c
@@ -7,17 +7,22 @@
 #include <IOKit/storage/IOBlockStorageDriver.h>
 #include <IOKit/storage/IOStorageDeviceCharacteristics.h>
 #include <IOKit/storage/IOStorageProtocolCharacteristics.h>
-#include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
+#ifdef MAC_OS_X_VERSION_10_15
+    #include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
+#endif
 
+#ifdef MAC_OS_X_VERSION_10_15
 static inline void wrapIoDestroyPlugInInterface(IOCFPlugInInterface*** pluginInf)
 {
     assert(pluginInf);
     if (*pluginInf)
         IODestroyPlugInInterface(*pluginInf);
 }
+#endif 
 
 static const char* detectSsdTemp(io_service_t entryPhysical, double* temp)
 {
+    #ifdef MAC_OS_X_VERSION_10_15
     __attribute__((__cleanup__(wrapIoDestroyPlugInInterface))) IOCFPlugInInterface** pluginInf = NULL;
     int32_t score;
     if (IOCreatePlugInInterfaceForService(entryPhysical, kIONVMeSMARTUserClientTypeID, kIOCFPlugInInterfaceID, &pluginInf, &score) != kIOReturnSuccess)
@@ -36,6 +41,9 @@ static const char* detectSsdTemp(io_service_t entryPhysical, double* temp)
 
     (*pluginInf)->Release(smartInf);
     return error;
+    #else
+    return "No support for old MacOS version";
+    #endif
 }
 
 const char* ffDetectPhysicalDisk(FFlist* result, FFPhysicalDiskOptions* options)
@@ -117,12 +125,14 @@ const char* ffDetectPhysicalDisk(FFlist* result, FFPhysicalDiskOptions* options)
                 }
             }
 
+            #ifdef MAC_OS_X_VERSION_10_15 
             if (options->temp)
             {
                 FF_CFTYPE_AUTO_RELEASE CFBooleanRef nvmeSMARTCapable = IORegistryEntryCreateCFProperty(entryPhysical, CFSTR(kIOPropertyNVMeSMARTCapableKey), kCFAllocatorDefault, kNilOptions);
                 if (nvmeSMARTCapable && CFBooleanGetValue(nvmeSMARTCapable))
                     detectSsdTemp(entryPhysical, &device->temperature);
             }
+            #endif
         }
     }
 

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -56,6 +56,10 @@ static void getProcessInformation(pid_t pid, FFstrbuf* processName, FFstrbuf* ex
     int mibs[] = { CTL_KERN, KERN_PROCARGS2, pid };
     if (sysctl(mibs, sizeof(mibs) / sizeof(*mibs), NULL, &len, NULL, 0) == 0)
     {
+        #ifndef MAC_OS_X_VERSION_10_15
+        //don't know why if don't let len longer, proArgs2 and len will change during the following sysctl() in old MacOS version.
+        len++;
+        #endif
         FF_AUTO_FREE char* const procArgs2 = malloc(len);
         if (sysctl(mibs, sizeof(mibs) / sizeof(*mibs), procArgs2, &len, NULL, 0) == 0)
         {

--- a/src/detection/wifi/wifi_apple.m
+++ b/src/detection/wifi/wifi_apple.m
@@ -135,17 +135,15 @@ const char* ffDetectWifi(FFlist* result)
             case kCWSecurityEnterprise:
                 ffStrbufSetStatic(&item->conn.security, "Enterprise");
                 break;
-            #ifdef MAC_OS_X_VERSION_10_15
-            case kCWSecurityWPA3Personal:
+            case 11 /*kCWSecurityWPA3Personal*/:
                 ffStrbufSetStatic(&item->conn.security, "WPA3 Personal");
                 break;
-            case kCWSecurityWPA3Enterprise:
+            case 12 /*kCWSecurityWPA3Enterprise*/:
                 ffStrbufSetStatic(&item->conn.security, "WPA3 Enterprise");
                 break;
-            case kCWSecurityWPA3Transition:
+            case 13 /*kCWSecurityWPA3Transition*/:
                 ffStrbufSetStatic(&item->conn.security, "WPA3 Transition");
                 break;
-            #endif
             case 14 /*kCWSecurityOWE*/:
                 ffStrbufSetStatic(&item->conn.security, "OWE");
                 break;

--- a/src/detection/wifi/wifi_apple.m
+++ b/src/detection/wifi/wifi_apple.m
@@ -135,6 +135,7 @@ const char* ffDetectWifi(FFlist* result)
             case kCWSecurityEnterprise:
                 ffStrbufSetStatic(&item->conn.security, "Enterprise");
                 break;
+            #ifdef MAC_OS_X_VERSION_10_15
             case kCWSecurityWPA3Personal:
                 ffStrbufSetStatic(&item->conn.security, "WPA3 Personal");
                 break;
@@ -144,6 +145,7 @@ const char* ffDetectWifi(FFlist* result)
             case kCWSecurityWPA3Transition:
                 ffStrbufSetStatic(&item->conn.security, "WPA3 Transition");
                 break;
+            #endif
             case 14 /*kCWSecurityOWE*/:
                 ffStrbufSetStatic(&item->conn.security, "OWE");
                 break;


### PR DESCRIPTION
Have tested in 10.13 High Sierra.


![1716062793363](https://github.com/fastfetch-cli/fastfetch/assets/3370897/45bb7945-59ec-4324-91ec-36ddcf753cf1)

It seems monitor module still do not work because DisplayID does not return correct  I/O Kit service port in my 10.13 machine but it works in my MacOS 12 Macbook although [CGDisplayIOServicePort](https://developer.apple.com/documentation/coregraphics/1543516-cgdisplayioserviceport?language=objc)  is warning to be deprecated.