### PR TITLE
CI: add Winget Releaser workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,3 +599,13 @@ jobs:
           commit: ${{ github.sha }}
           bodyFile: fastfetch-release-notes.md
           allowUpdates: true
+
+      - name: publish to winget
+        if: needs.linux-amd64.outputs.ffversion != steps.get_version_release.outputs.release
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Fastfetch-cli.Fastfetch
+          version: ${{ needs.linux-amd64.outputs.ffversion }}
+          release-tag: ${{ needs.linux-amd64.outputs.ffversion }}
+          installers-regex: '-windows-\w+\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
- Continuation of https://github.com/fastfetch-cli/fastfetch/issues/320#issuecomment-1404822340

[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Fastfetch has been added to Winget (https://github.com/microsoft/winget-pkgs/pull/154718), and this workflow will be used to update it.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @fastfetch-cli. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).
