### PR TITLE
Remove shebangs from completions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1157,13 +1157,13 @@ install(
 )
 
 install(
-    FILES "${CMAKE_SOURCE_DIR}/completions/bash"
+    FILES "${CMAKE_SOURCE_DIR}/completions/${CMAKE_PROJECT_NAME}.bash"
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions"
     RENAME "${CMAKE_PROJECT_NAME}"
 )
 
 install(
-    FILES "${CMAKE_SOURCE_DIR}/completions/fish"
+    FILES "${CMAKE_SOURCE_DIR}/completions/${CMAKE_PROJECT_NAME}.fish"
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/fish/vendor_completions.d"
     RENAME "${CMAKE_PROJECT_NAME}.fish"
 )

--- a/completions/fastfetch.bash
+++ b/completions/fastfetch.bash
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 __fastfetch_complete_help()
 {
     local __ff_helps=(

--- a/completions/fastfetch.fish
+++ b/completions/fastfetch.fish
@@ -1,5 +1,3 @@
-#!/usr/bin/env fish
-
 if not type -q fastfetch
     exit
 end


### PR DESCRIPTION
Shebangs are only used for scripts that are intended to be executed, but completions are meant to be sourced by the shell, and so shebangs are not required.

I've also renamed the completions so that editors can continue to detect the correct file format.