### PR TITLE
Add ability to skip installing license with INSTALL_LICENSE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(ENABLE_PROPRIETARY_GPU_DRIVER_API "Enable proprietary GPU driver API (NVM
 option(BUILD_TESTS "Build tests" OFF) # Also create test executables
 option(SET_TWEAK "Add tweak to project version" ON) # This is set to off by github actions for release builds
 option(IS_MUSL "Build with musl libc" OFF) # Used by Github Actions
+option(INSTALL_LICENSE "Install license into /usr/share/licenses" ON)
 
 set(BINARY_LINK_TYPE_OPTIONS dlopen dynamic static)
 set(BINARY_LINK_TYPE dlopen CACHE STRING "How to link fastfetch")
@@ -1173,10 +1174,12 @@ install(
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${CMAKE_PROJECT_NAME}"
 )
 
-install(
-    FILES "${CMAKE_SOURCE_DIR}/LICENSE"
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/${CMAKE_PROJECT_NAME}"
-)
+if(INSTALL_LICENSE)
+    install(
+        FILES "${CMAKE_SOURCE_DIR}/LICENSE"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/${CMAKE_PROJECT_NAME}"
+    )
+endif()
 
 install(
     FILES "${PROJECT_BINARY_DIR}/fastfetch.1"


### PR DESCRIPTION
This is useful for Debian, where the package already includes copyright information and therefore installing the license into /usr/share/licenses is not needed.

Upstream support for an option to disable installing the license is much better than patching it on the packaging side (which needs to be continuously updated).