### PR TITLE
Added newline after modules print

### DIFF
--- a/src/common/init.c
+++ b/src/common/init.c
@@ -130,6 +130,9 @@ void ffFinish(void)
     if(instance.config.logo.printRemaining)
         ffLogoPrintRemaining();
 
+    // Newline to separate module output from terminal greeting or prompt
+    printf("\n");
+
     resetConsole();
 }
 


### PR DESCRIPTION
World's simplest pull request...

Feature enhancement issue was created by me that has all the details: https://github.com/fastfetch-cli/fastfetch/issues/989

Not sure why, but the newline was not working in `flashfetch.c` after module printing, but worked in `init.c`s `ffFinish()` method.

Built and tested on macOS, attached is a screenshot with the behavior showing the newline: 
![fastfetch after change](https://github.com/fastfetch-cli/fastfetch/assets/6226450/2333509c-3952-4b3b-8233-d654d4282764)
