### PR TITLE
Add support for Manjaro ARM to logo detection

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -2576,7 +2576,7 @@ static const FFlogo M[] = {
     },
     // Manjaro
     {
-        .names = {"manjaro", "manjaro-linux", "manjarolinux"},
+        .names = {"manjaro", "manjaro-linux", "manjarolinux", "manjaro-arm"},
         .lines = FASTFETCH_DATATEXT_LOGO_MANJARO,
         .colors = {
             FF_COLOR_FG_GREEN,


### PR DESCRIPTION
This change adds "manjaro-arm" to the list of recognized distribution names, allowing fastfetch to display the correct logo for Manjaro ARM installations instead of the generic Linux one.

With change
![immagine](https://github.com/fastfetch-cli/fastfetch/assets/35270366/86ea326e-4951-496a-bba4-41ae5ace60ae)

Without change
![immagine](https://github.com/fastfetch-cli/fastfetch/assets/35270366/8e920336-1a51-4f86-b93b-a9f72ce5dbdf)
