### PR TITLE
Add the missing '--users-myself-only' option in bash completions

### DIFF
--- a/completions/fastfetch.bash
+++ b/completions/fastfetch.bash
@@ -347,6 +347,7 @@ __fastfetch_completion()
         "--users-key"
         "--users-format"
         "--users-key-color"
+        "--users-myself-only"
         "--bluetooth-key"
         "--bluetooth-format"
         "--bluetooth-key-color"


### PR DESCRIPTION
The new `--users-myself-only` option released in `v2.16.0` is missing from the bash completions.