### PR TITLE
OS (Linux): prioritize `prettyName` over `name`

### DIFF
--- a/src/modules/os/os.c
+++ b/src/modules/os/os.c
@@ -12,10 +12,10 @@
 static void buildOutputDefault(const FFOSResult* os, FFstrbuf* result)
 {
     //Create the basic output
-    if(os->name.length > 0)
-        ffStrbufAppend(result, &os->name);
-    else if(os->prettyName.length > 0)
+    if(os->prettyName.length > 0)
         ffStrbufAppend(result, &os->prettyName);
+    else if(os->name.length > 0)
+        ffStrbufAppend(result, &os->name);
     else if(os->id.length > 0)
         ffStrbufAppend(result, &os->id);
     else


### PR DESCRIPTION
PR title pretty much says all about changes in code. Currently fastfetch uses `os-release`'s `name` over `prettyName`, which are not always equal (for example Gentoo's `name` is `Gentoo`, but `prettyName` is `Gentoo Linux`)

This change just swaps order of `name` and `prettyName` in if-else if-else chain