### PR TITLE
Make format description more clear at json_schema.json

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -23,7 +23,7 @@
             "default": 0
         },
         "format": {
-            "description": "Output format of the module. See `-h module-format` for detail",
+            "description": "Output format of the module. See `-h <module>-format` for detail. I.e: fastfetch -h disk-format",
             "type": "string"
         },
         "outputColor": {


### PR DESCRIPTION
It worths to add `<module>-format` instead `module-format` as it is now, so people might understand that is a fixed string instead of the module name they are willing to check.