### PR TITLE
Use Coordinated Universal Time rather than timezone-varying local date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if(APPLE)
     configure_file(src/util/apple/Info.plist.in Info.plist @ONLY)
 endif()
 
-string(TIMESTAMP FASTFETCH_BUILD_DATE "%d %B %Y")
+string(TIMESTAMP FASTFETCH_BUILD_DATE "%d %B %Y" UTC)
 configure_file(doc/fastfetch.1.in fastfetch.1 @ONLY)
 
 ####################


### PR DESCRIPTION
As per docs:
https://cmake.org/cmake/help/v3.0/command/string.html

> The optional UTC flag requests the current date/time representation to be in Coordinated Universal Time (UTC) rather 
than local time which is the default behaviour.

Changing this will make your builds independent of your local or CI/CD time zone. This will allow to perform Reproducible builds, also known as deterministic compilation, the process of compiling software which ensures the resulting binary code can be reproduced. Source code compiled using deterministic compilation will always output the same binary. 