### PR TITLE
misc Qt improvements

### DIFF
--- a/src/detection/gtk_qt/qt.c
+++ b/src/detection/gtk_qt/qt.c
@@ -135,6 +135,13 @@ static void detectLXQt(FFQtResult* result)
     ffParsePropFileConfig("pcmanfm-qt/lxqt/settings.conf", "Wallpaper=", &result->wallpaper);
 }
 
+static void detectKvantum(FFQtResult* result)
+{
+    ffParsePropFileConfigValues("Kvantum/kvantum.kvconfig", 1, (FFpropquery[]) {
+        {"theme=", &result->widgetStyle},
+    });
+}
+
 const FFQtResult* ffDetectQt(void)
 {
     static FFQtResult result;
@@ -156,6 +163,12 @@ const FFQtResult* ffDetectQt(void)
         detectPlasma(&result);
     else if(ffStrbufIgnCaseEqualS(&wmde->dePrettyName, FF_DE_PRETTY_LXQT))
         detectLXQt(&result);
+
+    if(ffStrbufEqualS(&result.widgetStyle, "kvantum") || ffStrbufEqualS(&result.widgetStyle, "kvantum-dark"))
+    {
+        ffStrbufClear(&result.widgetStyle);
+        detectKvantum(&result);
+    }
 
     return &result;
 }

--- a/src/detection/gtk_qt/qt.c
+++ b/src/detection/gtk_qt/qt.c
@@ -135,6 +135,22 @@ static void detectLXQt(FFQtResult* result)
     ffParsePropFileConfig("pcmanfm-qt/lxqt/settings.conf", "Wallpaper=", &result->wallpaper);
 }
 
+static void detectQtCt(char qver, FFQtResult* result)
+{
+    // qt5ct and qt6ct are technically separate applications, but they're both
+    // by the same author and qt6ct understands qt5ct in qt6 applications as well.
+    char file[] = "qtXct/qtXct.conf";
+    file[2] = file[8] = qver;
+    ffParsePropFileConfigValues(file, 3, (FFpropquery[]) {
+        {"style=", &result->widgetStyle},
+        {"icon_theme=", &result->icons},
+        // FIXME: on older versions this was hex-encoded binary format
+        // (See QVariant notes on https://doc.qt.io/qt-5/qsettings.html)
+        // Thankfully, newer versions use the more common font encoding.
+        {"general=", &result->font}
+    });
+}
+
 static void detectKvantum(FFQtResult* result)
 {
     ffParsePropFileConfigValues("Kvantum/kvantum.kvconfig", 1, (FFpropquery[]) {
@@ -158,11 +174,14 @@ const FFQtResult* ffDetectQt(void)
     ffStrbufInit(&result.wallpaper);
 
     const FFDisplayServerResult* wmde = ffConnectDisplayServer();
+    const char *qplatformtheme = getenv("QT_QPA_PLATFORMTHEME");
 
     if(ffStrbufIgnCaseEqualS(&wmde->dePrettyName, FF_DE_PRETTY_PLASMA))
         detectPlasma(&result);
     else if(ffStrbufIgnCaseEqualS(&wmde->dePrettyName, FF_DE_PRETTY_LXQT))
         detectLXQt(&result);
+    else if(ffStrSet(qplatformtheme) && (ffStrEquals(qplatformtheme, "qt5ct") || ffStrEquals(qplatformtheme, "qt6ct")))
+        detectQtCt(qplatformtheme[2], &result);
 
     if(ffStrbufEqualS(&result.widgetStyle, "kvantum") || ffStrbufEqualS(&result.widgetStyle, "kvantum-dark"))
     {


### PR DESCRIPTION
First commit add supports for [Kvantum](https://github.com/tsujan/Kvantum/), a sort of meta-widgetstyle for Qt. When it's being used, it makes sense to source the style from Kvantum's configuration instead of just printing `kvantum`/`kvantum-dark`.

The second adds support for qt5ct and qt6ct, which are often used to configure Qt graphically in environments where Qt is not native.