### PR TITLE
Docs: Add missing "cpuusage" schema property

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -1145,6 +1145,9 @@
                                         "type": "boolean",
                                         "description": "Display CPU usage per CPU logical core, instead of an average result",
                                         "default": false
+                                    },
+                                    "format": {
+                                        "$ref": "#/$defs/format"
                                     }
                                 }
                             },


### PR DESCRIPTION
Adds `format` property to `cpuusage` module, fixes IDE validation warnings:
![image](https://github.com/fastfetch-cli/fastfetch/assets/80201134/52e93872-bea8-480b-bb09-f24e3e059b5c)
