### PR TITLE
Physicalmemory: Fix incorrect size value for large memory sticks

### DIFF
--- a/src/detection/physicalmemory/physicalmemory_linux.c
+++ b/src/detection/physicalmemory/physicalmemory_linux.c
@@ -113,6 +113,12 @@ const char* ffDetectPhysicalMemory(FFlist* result)
             }
         }
 
+        if (data->Header.Length > offsetof(FFSmbiosMemoryDevice, ExtendedSize)) // 2.7+
+        {
+            if (data->ExtendedSize != 0 && data->Size == 0x7FFF)
+                device->size = data->ExtendedSize * 1024ULL * 1024ULL;
+        }
+
         ffStrbufSetF(&device->locator, "%s/%s", ffSmbiosLocateString(strings, data->BankLocator), ffSmbiosLocateString(strings, data->DeviceLocator));
 
         switch (data->FormFactor)


### PR DESCRIPTION
Fixes an issue with large memory sticks value parsing (**>32GB**). 
This code most likely needs further tweaking as C isn't exactly my forte, but it does the job for now  

Also, not really sure if those lines should be left as is, given this tweak
https://github.com/fastfetch-cli/fastfetch/blob/0e597a2ded2a241f0ec5c75a0a1b3f31501df580/src/detection/physicalmemory/physicalmemory_linux.c#L102-L103

Example FF output before the fix:
<details>
<summary>Click to expand</summary>

```
$ fastfetch -v
fastfetch 2.16.0 (x86_64)
```

``` json
$ fastfetch --format json -s PhysicalMemory`
[
  {
    "type": "PhysicalMemory",
    "result": [
      {
        "size": 0,
        "maxSpeed": 6800,
        "runningSpeed": 6800,
        "type": "DDR5",
        "locator": "BANK 0/Controller0-DIMM1",
        "formFactor": "DIMM",
        "vendor": "G Skill Intl",
        "serial": "F655ECFA",
        "partNumber": "F5-6800J3446F48G",
        "ecc": false
      },
      {
        "size": 0,
        "maxSpeed": 6800,
        "runningSpeed": 6800,
        "type": "DDR5",
        "locator": "BANK 0/Controller1-DIMM1",
        "formFactor": "DIMM",
        "vendor": "G Skill Intl",
        "serial": "615B6FF5",
        "partNumber": "F5-6800J3446F48G",
        "ecc": false
      }
    ]
  }
]
```

</details>

After the fix:
<details>
<summary>Click to expand</summary>

```json
$ ./fastfetch.exe --format json -s PhysicalMemory
[
  {
    "type": "PhysicalMemory",
    "result": [
      {
        "size": 51539607552,
        "maxSpeed": 6800,
        "runningSpeed": 6800,
        "type": "DDR5",
        "locator": "BANK 0/Controller0-DIMM1",
        "formFactor": "DIMM",
        "vendor": "G Skill Intl",
        "serial": "F655ECFA",
        "partNumber": "F5-6800J3446F48G",
        "ecc": false
      },
      {
        "size": 51539607552,
        "maxSpeed": 6800,
        "runningSpeed": 6800,
        "type": "DDR5",
        "locator": "BANK 0/Controller1-DIMM1",
        "formFactor": "DIMM",
        "vendor": "G Skill Intl",
        "serial": "615B6FF5",
        "partNumber": "F5-6800J3446F48G",
        "ecc": false
      }
    ]
  }
]
```

```
$ ./fastfetch.exe -c all
[...]
Physical Memory 1: 48,00 GiB - DDR5-6800 (G Skill Intl)
Physical Memory 2: 48,00 GiB - DDR5-6800 (G Skill Intl)
[...]
```
![image](https://github.com/fastfetch-cli/fastfetch/assets/80201134/6d272dd0-30ec-4012-89cb-ade3e74c3d38)
</details>

SMBIOS Dump, if relevant
<details>
<summary>Click to expand</summary>

```
[...]
-=======================================================-
==========            Memory Device            ==========
Length: 0x5C
Total Width: 64bits
Data Width: 64bits
Size: 32767
Extended Size: 49152
Device Locator: Controller1-DIMM1
Bank Locator: BANK 0
Speed: 6800
Manufacturer: G Skill Intl
Serial Number: 615B6FF5
Asset Tag Number: 9876543210
Part Number: F5-6800J3446F48G
-=======================================================-
==========     Memory Array Mapped Address     ==========
Length: 0x1F
Starting Address: 0x00000000
Ending Address: 0x05FFFFFF
Memory Array Handle: 0xC
Partition Width: 0x2
-=======================================================-
[...]
```

</details>

