### PR TITLE
Small typo corrected in man page

### DIFF
--- a/doc/fastfetch.1.in
+++ b/doc/fastfetch.1.in
@@ -98,7 +98,7 @@ config files, see the CONFIGURATION section
 
 .B \-\-gen\-config \fI[file]
 Generate a config file with options specified on the command line.
-If \fIfile\fR is specified, the configuration will written to the
+If \fIfile\fR is specified, the configuration will be written to the
 file, otherwise it will be written to stdout.
 .TP
 


### PR DESCRIPTION
Description for `--gen-config` had a typo: "If file is specified, the configuration will written to the file, otherwise it will be  written to stdout." -> "If file is specified, the configuration will **be** written to the file, otherwise it will be written to stdout."

I added the "be" that was lost.