### PR TITLE
 Shell (Linux): don't detect hyfetch as shell on NixOS

### DIFF
--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -50,7 +50,7 @@ static pid_t getShellInfo(FFShellResult* result, pid_t pid)
                 ffStrbufEqualS(&result->processName, "perf")                ||
                 ffStrbufEqualS(&result->processName, "guake-wrapped")       ||
                 ffStrbufEqualS(&result->processName, "time")                ||
-                ffStrbufEqualS(&result->processName, "hyfetch")             || //when hyfetch uses fastfetch as backend
+                ffStrbufContainS(&result->processName, "hyfetch")           || //when hyfetch uses fastfetch as backend
                 ffStrbufEqualS(&result->processName, "clifm")               || //https://github.com/leo-arch/clifm/issues/289
                 ffStrbufEqualS(&result->processName, "valgrind")            ||
                 ffStrbufEqualS(&result->processName, "fastfetch")           || //994


### PR DESCRIPTION
On NixOS, Hyfetch has been placed in a "wrapper script" in order to set the correct PATH that it needs to run correctly. As a result, the actual Hyfetch executable has been renamed `.hyfetch-wrapped`, which results in this check failing to detect Hyfetch on NixOS properly.

With this patch the logic has been changed to check if the program name contains the string `hyfetch`, which should work for the NixOS case.