### PR TITLE
disk_bsd: minor fix for a type, fixes calculation of disk usage on 32 bit

### DIFF
--- a/src/detection/disk/disk_bsd.c
+++ b/src/detection/disk/disk_bsd.c
@@ -123,7 +123,7 @@ const char* ffDetectDisksImpl(FFDiskOptions* options, FFlist* disks)
 
         FFDisk* disk = ffListAdd(disks);
 
-        disk->bytesTotal = fs->f_blocks * fs->f_bsize;
+        disk->bytesTotal = (uint64_t)fs->f_blocks * fs->f_bsize;
         disk->bytesFree = (uint64_t)fs->f_bfree * fs->f_bsize;
         disk->bytesAvailable = (uint64_t)fs->f_bavail * fs->f_bsize;
         disk->bytesUsed = 0; // To be filled in ./disk.c


### PR DESCRIPTION
@CarterLi This was breaking size calculation :) 