### PR TITLE
Improve locale detection on Linux by checking `LC_ALL` as well

### DIFF
--- a/src/detection/locale/locale_linux.c
+++ b/src/detection/locale/locale_linux.c
@@ -4,6 +4,10 @@
 
 void ffDetectLocale(FFstrbuf* result)
 {
+    ffStrbufAppendS(result, getenv("LC_ALL"));
+    if(result->length > 0)
+        return;
+
     ffStrbufAppendS(result, getenv("LC_MESSAGES"));
     if(result->length > 0)
         return;


### PR DESCRIPTION
`LC_ALL` should override all other locale environment variables if set (this behaviour is documented in `man 7 locale`)

For instance, invoking fastfetch like this:

`LC_ALL=it_IT.UTF-8 fastfetch`

Results in the locale being detected as `en_US.UTF-8` (or whatever value `LANG` happens to be set to), which is incorrect.
