### PR TITLE
CPU (Linux): skip cpu model smbios detection

### DIFF
--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -383,6 +383,12 @@ const char* ffDetectCPUImpl(const FFCPUOptions* options, FFCPUResult* cpu)
                 }
 
                 pstart = pend + 1;
+
+                if (strstr(pstart, "BIOS Model name:")) {
+                    pstart = strstr(pstart, "BIOS Model name:");
+                    pstart += strlen("BIOS Model name:");
+                }
+
                 if (pstart >= buffer.chars + buffer.length)
                     return NULL;
             }


### PR DESCRIPTION
`lscpu` added support for SMBIOS detection of model name in version 2.37 (https://github.com/util-linux/util-linux/commit/8014104bea78f6f82cb82e16329b562e60ecdc87).
So `lscpu` now will have two entries: "Model name" and "BIOS Model name".
This commit skips "BIOS Model name" to avoid duplicate detections and incorrect SMBIOS informations.
