### PR TITLE
fix isDir condition checking in io_unix.c

### DIFF
--- a/completions/fastfetch.zsh
+++ b/completions/fastfetch.zsh
@@ -22,11 +22,11 @@ def main():
                 continue
 
             if "short" in flag:
-                command_prefix = f"""-{flag["short"]}[{flag["desc"]}]"""
+                command_prefix = f"-{flag["short"]}[{flag["desc"]}]"
                 print_command(command_prefix, flag)
 
             if "long" in flag:
-                command_prefix = f"""--{flag["long"]}[{flag["desc"]}]"""
+                command_prefix = f"--{flag["long"]}[{flag["desc"]}]"
                 print_command(command_prefix, flag)
 
 
@@ -40,16 +40,16 @@ def print_command(command_prefix: str, flag: dict):
         elif type == "command":
             print(f"{command_prefix}:module:->modules")
         elif type == "config":
-            print(f"{command_prefix}:presets:->presets")
+            print(f"{command_prefix}:preset:->presets")
         elif type == "enum":
             temp: str = " ".join(flag["arg"]["enum"])
             print(f'{command_prefix}:type:( {temp} )')
         elif type == "logo":
-            print(f"{command_prefix}:logo:->logo")
+            print(f"{command_prefix}:logo:->logos")
         elif type == "structure":
-            print(f"{command_prefix}:structure:->structure")
+            print(f"{command_prefix}:structure:->structures")
         elif type == "path":
-            print(f"{command_prefix}:path:_files -/")
+            print(f"{command_prefix}:path:_files")
         else:
             print(f"{command_prefix}:")
     else:
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 EOF
   )"})
 
-  _arguments -C "$opts[@]"
+  _arguments "$opts[@]"
 
   case $state in
     modules)
@@ -74,16 +74,16 @@ EOF
       ;;
     presets)
       local -a presets=(
-        ${$(fastfetch --list-presets autocompletion):#.*}
+        $(fastfetch --list-presets autocompletion)
         "none:Disable loading config file"
       )
       _describe 'preset' presets
       ;;
-    structure)
+    structures)
       local -a structures=( ${(f)"$(fastfetch --list-modules autocompletion)"} )
       _describe 'structure' structures
       ;;
-    logo)
+    logos)
       local -a logos=(
         $(fastfetch --list-logos autocompletion)
         "none:Don't print logo"

--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -236,15 +236,12 @@ void listFilesRecursively(uint32_t baseLength, FFstrbuf* folder, uint8_t indenta
 #ifdef _DIRENT_HAVE_D_TYPE
         if(entry->d_type != DT_UNKNOWN && entry->d_type != DT_LNK)
             isDir = entry->d_type == DT_DIR;
-        else
 #else
-        {
-            struct stat stbuf;
-            if (fstatat(dfd, entry->d_name, &stbuf, 0) < 0)
-                isDir = false;
-            else
-                isDir = S_ISDIR(stbuf.st_mode);
-        }
+        struct stat stbuf;
+        if (fstatat(dfd, entry->d_name, &stbuf, 0) < 0)
+            isDir = false;
+        else
+            isDir = S_ISDIR(stbuf.st_mode);
 #endif
         if (isDir)
         {


### PR DESCRIPTION
the condition was failing to set `isDir` because of miss placed `else`. causing `fastfetch --list-presets` to include directories

![image](https://github.com/user-attachments/assets/4f7ff171-c062-4090-af77-ca72925cd995)

here you can see `.` `..` and `examples` directory alongside other presets

with the fix:
![image](https://github.com/user-attachments/assets/7f63748e-90f5-4c63-9b0d-1d8afc020b15)

i also updated zsh-completion to reflect upon this change