### PR TITLE
fix linux bootTime

### DIFF
--- a/src/detection/uptime/uptime_linux.c
+++ b/src/detection/uptime/uptime_linux.c
@@ -20,7 +20,7 @@ const char* ffDetectUptime(FFUptimeResult* result)
         if(err != buf)
         {
             result->uptime = (uint64_t) (sec * 1000);
-            result->bootTime = ffTimeGetNow() + result->uptime;
+            result->bootTime = ffTimeGetNow() - result->uptime;
             return NULL;
         }
     }
@@ -32,7 +32,7 @@ const char* ffDetectUptime(FFUptimeResult* result)
         return "clock_gettime(CLOCK_BOOTTIME) failed";
 
     result->uptime = (uint64_t) uptime.tv_sec * 1000 + (uint64_t) uptime.tv_nsec / 1000000;
-    result->bootTime = ffTimeGetNow() + result->uptime;
+    result->bootTime = ffTimeGetNow() - result->uptime;
 
     return NULL;
 }


### PR DESCRIPTION
the previous implementation was adding the elapsed time since boot to the current time instead of subtracting it.

previous implementation:

```sh
$ fastfetch
    Uptime: 8 days, 13 hours, 48 mins
$ fastfetch --uptime-format '{6}'
    Uptime: Uptime: 2024-09-13 17:16:04
```

where the bootTime (`--upstream-format '{6}'`) is ~8 days in the future

new implementation:

```sh
$ fastfetch
    Uptime: 8 days, 13 hours, 52 mins
$ fastfetch --uptime-format '{6}'
    Uptime: 2024-08-27 13:34:13
```

see also https://github.com/fastfetch-cli/fastfetch/blob/8371920c6bc89bb77ded4c110196391a0815e5f2/src/detection/uptime/uptime_windows.c#L9