### PR TITLE
GPU: detect GPU index

### DIFF
--- a/src/detection/gpu/gpu.c
+++ b/src/detection/gpu/gpu.c
@@ -55,6 +55,7 @@ const char* detectByOpenGL(FFlist* gpus)
         ffStrbufInitMove(&gpu->name, &result.renderer);
         ffStrbufInitMove(&gpu->driver, &result.vendor);
         ffStrbufInitF(&gpu->platformApi, "OpenGL %s", result.version.chars);
+        gpu->index = FF_GPU_INDEX_UNSET;
         gpu->temperature = FF_GPU_TEMP_UNSET;
         gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
         gpu->frequency = FF_GPU_FREQUENCY_UNSET;

--- a/src/detection/gpu/gpu.h
+++ b/src/detection/gpu/gpu.h
@@ -7,6 +7,7 @@
 #define FF_GPU_VMEM_SIZE_UNSET ((uint64_t)-1)
 #define FF_GPU_FREQUENCY_UNSET 0
 #define FF_GPU_CORE_USAGE_UNSET (0/0.0)
+#define FF_GPU_INDEX_UNSET ((uint8_t)-1)
 
 extern const char* FF_GPU_VENDOR_NAME_APPLE;
 extern const char* FF_GPU_VENDOR_NAME_AMD;
@@ -27,6 +28,7 @@ typedef struct FFGPUMemory
 
 typedef struct FFGPUResult
 {
+    uint8_t index;
     FFGPUType type;
     FFstrbuf vendor;
     FFstrbuf name;

--- a/src/detection/gpu/gpu_apple.m
+++ b/src/detection/gpu/gpu_apple.m
@@ -43,6 +43,7 @@ const char* ffGpuDetectMetal(FFlist* gpus)
                 ffStrbufSetStatic(&gpu->platformApi, "Metal Common 1");
 
             gpu->type = device.hasUnifiedMemory ? FF_GPU_TYPE_INTEGRATED : FF_GPU_TYPE_DISCRETE;
+            gpu->index = (uint8_t)device.locationNumber;
             #endif
         }
         return NULL;

--- a/src/detection/gpu/gpu_bsd.c
+++ b/src/detection/gpu/gpu_bsd.c
@@ -56,6 +56,7 @@ const char* ffDetectGPUImpl(const FFGPUOptions* options, FFlist* gpus)
         ffStrbufInit(&gpu->name);
         ffStrbufInitS(&gpu->driver, pc->pd_name);
         ffStrbufInit(&gpu->platformApi);
+        gpu->index = FF_GPU_INDEX_UNSET;
         gpu->temperature = FF_GPU_TEMP_UNSET;
         gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
         gpu->coreUsage = FF_GPU_CORE_USAGE_UNSET;
@@ -90,6 +91,7 @@ const char* ffDetectGPUImpl(const FFGPUOptions* options, FFlist* gpus)
                     .func = pc->pc_sel.pc_func,
                 },
             }, (FFGpuDriverResult) {
+                .index = &gpu->index,
                 .temp = options->temp ? &gpu->temperature : NULL,
                 .memory = options->driverSpecific ? &gpu->dedicated : NULL,
                 .coreCount = options->driverSpecific ? (uint32_t*) &gpu->coreCount : NULL,

--- a/src/detection/gpu/gpu_driver_specific.h
+++ b/src/detection/gpu/gpu_driver_specific.h
@@ -37,6 +37,7 @@ typedef struct FFGpuDriverCondition
 // detect x if not NULL
 typedef struct FFGpuDriverResult
 {
+    uint8_t* index;
     double* temp;
     FFGPUMemory* memory;
     uint32_t* coreCount;

--- a/src/detection/gpu/gpu_linux.c
+++ b/src/detection/gpu/gpu_linux.c
@@ -295,6 +295,7 @@ static const char* detectPci(const FFGPUOptions* options, FFlist* gpus, FFstrbuf
     ffStrbufInit(&gpu->name);
     ffStrbufInit(&gpu->driver);
     ffStrbufInit(&gpu->platformApi);
+    gpu->index = FF_GPU_INDEX_UNSET;
     gpu->temperature = FF_GPU_TEMP_UNSET;
     gpu->coreUsage = FF_GPU_CORE_USAGE_UNSET;
     gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
@@ -366,6 +367,7 @@ static const char* detectPci(const FFGPUOptions* options, FFlist* gpus, FFstrbuf
                     .func = pciFunc,
                 },
             }, (FFGpuDriverResult) {
+                .index = &gpu->index,
                 .temp = options->temp ? &gpu->temperature : NULL,
                 .memory = options->driverSpecific ? &gpu->dedicated : NULL,
                 .coreCount = options->driverSpecific ? (uint32_t*) &gpu->coreCount : NULL,

--- a/src/detection/gpu/gpu_mthreads.c
+++ b/src/detection/gpu/gpu_mthreads.c
@@ -134,6 +134,13 @@ const char *ffDetectMthreadsGpuInfo(const FFGpuDriverCondition *cond, FFGpuDrive
         }
     }
 
+    if (result.index)
+    {
+        unsigned int value;
+        if (mtmlData.ffmtmlDeviceGetIndex(device, &value) == MTML_SUCCESS)
+            *result.index = (uint8_t)value;
+    }
+
     if (result.temp)
     {
         MtmlGpu *gpu = NULL;

--- a/src/detection/gpu/gpu_nvidia.c
+++ b/src/detection/gpu/gpu_nvidia.c
@@ -14,6 +14,7 @@ struct FFNvmlData {
     FF_LIBRARY_SYMBOL(nvmlDeviceGetMaxClockInfo)
     FF_LIBRARY_SYMBOL(nvmlDeviceGetUtilizationRates)
     FF_LIBRARY_SYMBOL(nvmlDeviceGetBrand)
+    FF_LIBRARY_SYMBOL(nvmlDeviceGetIndex)
     FF_LIBRARY_SYMBOL(nvmlDeviceGetName)
 
     bool inited;
@@ -39,6 +40,7 @@ const char* ffDetectNvidiaGpuInfo(const FFGpuDriverCondition* cond, FFGpuDriverR
         FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(libnvml, nvmlData, nvmlDeviceGetMaxClockInfo)
         FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(libnvml, nvmlData, nvmlDeviceGetUtilizationRates)
         FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(libnvml, nvmlData, nvmlDeviceGetBrand)
+        FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(libnvml, nvmlData, nvmlDeviceGetIndex)
         FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(libnvml, nvmlData, nvmlDeviceGetName)
 
         if (ffnvmlInit_v2() != NVML_SUCCESS)
@@ -104,6 +106,14 @@ const char* ffDetectNvidiaGpuInfo(const FFGpuDriverCondition* cond, FFGpuDriverR
                 break;
         }
     }
+
+    if (result.index)
+    {
+        unsigned int value;
+        if (nvmlData.ffnvmlDeviceGetIndex(device, &value) == NVML_SUCCESS)
+            *result.index = (uint8_t)value;
+    }
+       
 
     if (result.temp)
     {

--- a/src/detection/gpu/gpu_sunos.c
+++ b/src/detection/gpu/gpu_sunos.c
@@ -57,6 +57,7 @@ const char* ffDetectGPUImpl(FF_MAYBE_UNUSED const FFGPUOptions* options, FFlist*
         ffStrbufInit(&gpu->name);
         ffStrbufInit(&gpu->driver);
         ffStrbufInit(&gpu->platformApi);
+        gpu->index = FF_GPU_INDEX_UNSET;
         gpu->temperature = FF_GPU_TEMP_UNSET;
         gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
         gpu->coreUsage = FF_GPU_CORE_USAGE_UNSET;

--- a/src/detection/gpu/gpu_windows.c
+++ b/src/detection/gpu/gpu_windows.c
@@ -38,6 +38,7 @@ const char* ffDetectGPUImpl(FF_MAYBE_UNUSED const FFGPUOptions* options, FFlist*
         ffStrbufInit(&gpu->name);
         ffStrbufInit(&gpu->driver);
         ffStrbufInitStatic(&gpu->platformApi, "SetupAPI");
+        gpu->index = FF_GPU_INDEX_UNSET;
         gpu->temperature = FF_GPU_TEMP_UNSET;
         gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
         gpu->coreUsage = FF_GPU_CORE_USAGE_UNSET;
@@ -157,7 +158,8 @@ const char* ffDetectGPUImpl(FF_MAYBE_UNUSED const FFGPUOptions* options, FFlist*
                         },
                         .luid = gpu->deviceId,
                     },
-                    (FFGpuDriverResult) {
+                    (FFGpuDriverResult){
+                        .index = &gpu->index,
                         .temp = options->temp ? &gpu->temperature : NULL,
                         .memory = options->driverSpecific ? &gpu->dedicated : NULL,
                         .coreCount = options->driverSpecific ? (uint32_t*) &gpu->coreCount : NULL,

--- a/src/detection/gpu/gpu_wsl.cpp
+++ b/src/detection/gpu/gpu_wsl.cpp
@@ -70,6 +70,7 @@ const char* ffGPUDetectByDirectX(FF_MAYBE_UNUSED const FFGPUOptions* options, FF
 
         FFGPUResult* gpu = (FFGPUResult*) ffListAdd(gpus);
         ffStrbufInitS(&gpu->name, desc);
+        gpu->index = FF_GPU_INDEX_UNSET;
         gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
         gpu->coreUsage = FF_GPU_CORE_USAGE_UNSET;
         gpu->temperature = FF_GPU_TEMP_UNSET;
@@ -117,7 +118,8 @@ const char* ffGPUDetectByDirectX(FF_MAYBE_UNUSED const FFGPUOptions* options, FF
                         .revId = hardwareId.revision,
                     },
                 };
-                ffDetectNvidiaGpuInfo(&cond, (FFGpuDriverResult) {
+                ffDetectNvidiaGpuInfo(&cond, (FFGpuDriverResult){
+                    .index = &gpu->index,
                     .temp = options->temp ? &gpu->temperature : NULL,
                     .memory = options->driverSpecific ? &gpu->dedicated : NULL,
                     .coreCount = options->driverSpecific ? (uint32_t*) &gpu->coreCount : NULL,

--- a/src/detection/gpu/nvml.h
+++ b/src/detection/gpu/nvml.h
@@ -132,5 +132,7 @@ extern nvmlReturn_t nvmlDeviceGetMaxClockInfo(nvmlDevice_t device, nvmlClockType
 extern nvmlReturn_t nvmlDeviceGetBrand(nvmlDevice_t device, nvmlBrandType_t* type);
 // Retrieves the current utilization rates for the device
 extern nvmlReturn_t nvmlDeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t *utilization);
+// Retrieves the globally unique immutable UUID associated with this device, as a 5 part hexadecimal string, that augments the immutable, board serial identifier.
+extern nvmlReturn_t nvmlDeviceGetIndex(nvmlDevice_t device, unsigned int *index);
 // Retrieves the name of this device.
 extern nvmlReturn_t nvmlDeviceGetName(nvmlDevice_t device, char *name, unsigned int length);

--- a/src/detection/opencl/opencl.c
+++ b/src/detection/opencl/opencl.c
@@ -75,6 +75,7 @@ static const char* openCLHandleData(OpenCLData* data, FFOpenCLResult* result)
             ffStrbufInit(&gpu->vendor);
             ffStrbufInit(&gpu->driver);
             ffStrbufInit(&gpu->platformApi);
+            gpu->index = FF_GPU_INDEX_UNSET;
             gpu->temperature = FF_GPU_TEMP_UNSET;
             gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
             gpu->type = FF_GPU_TYPE_UNKNOWN;

--- a/src/detection/vulkan/vulkan.c
+++ b/src/detection/vulkan/vulkan.c
@@ -234,6 +234,7 @@ static const char* detectVulkan(FFVulkanResult* result)
         }
 
         //No way to detect those using vulkan
+        gpu->index = FF_GPU_INDEX_UNSET;
         gpu->coreCount = FF_GPU_CORE_COUNT_UNSET;
         gpu->temperature = FF_GPU_TEMP_UNSET;
         gpu->frequency = FF_GPU_FREQUENCY_UNSET;

--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -322,6 +322,15 @@ void ffGenerateGPUJsonResult(FFGPUOptions* options, yyjson_mut_doc* doc, yyjson_
     FF_LIST_FOR_EACH(FFGPUResult, gpu, gpus)
     {
         yyjson_mut_val* obj = yyjson_mut_arr_add_obj(doc, arr);
+
+        if (gpu->index != FF_GPU_INDEX_UNSET){
+            yyjson_mut_obj_add_uint(doc, obj, "index", (uint64_t)gpu->index);
+        }
+        else
+        {
+            yyjson_mut_obj_add_null(doc, obj, "index");
+        }
+
         if (gpu->coreCount != FF_GPU_CORE_COUNT_UNSET)
             yyjson_mut_obj_add_int(doc, obj, "coreCount", gpu->coreCount);
         else


### PR DESCRIPTION
Hi, we have forked your project and made some modifications as [gpustack](https://github.com/gpustack/gpustack) needed. We noticed that your project already supports most of the features we require. We would love to switch back to using the upstream fastfetch, so that we can contribute directly to the project with any future issues or improvements. 

In cases where a machine has multiple discrete GPUs from the same vendor and brand, the GPU names are often identical. GPU vendors provide a GPU index to help users quickly identify each GPU like below. Would it be possible for fastfetch to support retrieving this vendor-provided GPU index during detection, allowing users to easily match the detected GPUs with their respective indices?

<img width="747" alt="image" src="https://github.com/user-attachments/assets/00c3020f-2b29-4f8f-b593-3d8cf5383c5c">


**Output of Json for this PR**
(used configc.json to simplify the output) 
```json
[
  {
    "type": "OS",
    "result": {
      "buildID": "",
      "codename": "",
      "id": "Windows 11",
      "idLike": "Windows",
      "name": "Windows",
      "prettyName": "Windows",
      "variant": "Pro",
      "variantID": "",
      "version": "11",
      "versionID": ""
    }
  },
  {
    "type": "Kernel",
    "result": {
      "architecture": "x86_64",
      "name": "WIN32_NT",
      "release": "10.0.22631.4037",
      "version": "22621.1.amd64fre.ni_release.220506-1250",
      "displayVersion": "23H2",
      "pageSize": 4096
    }
  },
  {
    "type": "GPU",
    "result": [
      {
        "index": 1,
        "coreCount": 10240,
        "coreUsage": 0.0,
        "memory": {
          "dedicated": {
            "total": 16826499072,
            "used": 64249856
          },
          "shared": {
            "total": 34204884992,
            "used": null
          }
        },
        "driver": "31.0.15.5178",
        "name": "NVIDIA GeForce RTX 4080 SUPER",
        "temperature": 32.0,
        "type": "Discrete",
        "vendor": "NVIDIA",
        "platformApi": "Direct3D 12.2",
        "frequency": 3105,
        "deviceId": 73365
      },
      {
        "index": 0,
        "coreCount": 10240,
        "coreUsage": 0.0,
        "memory": {
          "dedicated": {
            "total": 16826499072,
            "used": 0
          },
          "shared": {
            "total": 34204884992,
            "used": null
          }
        },
        "driver": "31.0.15.5178",
        "name": "NVIDIA GeForce RTX 4080 SUPER",
        "temperature": 34.0,
        "type": "Discrete",
        "vendor": "NVIDIA",
        "platformApi": "Direct3D 12.2",
        "frequency": 3105,
        "deviceId": 68246
      },
      {
        "index": null,
        "coreCount": 32,
        "coreUsage": null,
        "memory": {
          "dedicated": {
            "total": 134217728,
            "used": null
          },
          "shared": {
            "total": 34204884992,
            "used": null
          }
        },
        "driver": "31.0.101.5537",
        "name": "Intel(R) UHD Graphics 770",
        "temperature": null,
        "type": "Integrated",
        "vendor": "Intel",
        "platformApi": "Direct3D 12.1",
        "frequency": 1550,
        "deviceId": 72580
      }
    ]
  }
]
```

