### PR TITLE
Completions (zsh, fish): check for python3

### DIFF
--- a/completions/fastfetch.fish
+++ b/completions/fastfetch.fish
@@ -2,6 +2,11 @@ if not type -q fastfetch
     exit
 end
 
+command -q python3
+if test $status -ne 0
+    exit
+end
+
 complete -c fastfetch -f
 
 function __fastfetch_complete_bool

--- a/completions/fastfetch.zsh
+++ b/completions/fastfetch.zsh
@@ -1,6 +1,13 @@
 #compdef fastfetch
 
 function _fastfetch() {
+
+  whence python3 &> /dev/null
+  if [ $? -ne 0 ]
+  then
+    return
+  fi
+
   local state
 
   local -a opts=("${(f)$(


### PR DESCRIPTION
Both the zsh and fish completions depend on python3. When the completitions kick in with those shells where no python3 is found it throws errors.

Check python3 is installed, otherwise return no completitions to avoid throwing errors