### PR TITLE
Chore: fix some unused paramater/function warnings

### DIFF
--- a/src/detection/bios/bios_nosupport.c
+++ b/src/detection/bios/bios_nosupport.c
@@ -1,6 +1,6 @@
 #include "bios.h"
 
-const char* ffDetectBios(FFBiosResult* bios)
+const char* ffDetectBios(FF_MAYBE_UNUSED FFBiosResult* bios)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/bluetoothradio/bluetoothradio_linux.c
+++ b/src/detection/bluetoothradio/bluetoothradio_linux.c
@@ -202,6 +202,7 @@ const char* ffDetectBluetoothRadio(FFlist* devices /* FFBluetoothRadioResult */)
     #ifdef FF_HAVE_DBUS
         return detectBluetooth(devices);
     #else
+        FF_UNUSED(devices) 
         return "Fastfetch was compiled without DBus support";
     #endif
 }

--- a/src/detection/cpu/cpu_nosupport.c
+++ b/src/detection/cpu/cpu_nosupport.c
@@ -1,6 +1,6 @@
 #include "cpu.h"
 
-const char* ffDetectCPUImpl(const FFCPUOptions* options, FFCPUResult* cpu)
+const char* ffDetectCPUImpl(FF_MAYBE_UNUSED const FFCPUOptions* options, FF_MAYBE_UNUSED FFCPUResult* cpu)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/cpuusage/cpuusage_nosupport.c
+++ b/src/detection/cpuusage/cpuusage_nosupport.c
@@ -1,7 +1,7 @@
 #include "fastfetch.h"
 #include "detection/cpuusage/cpuusage.h"
 
-const char* ffGetCpuUsageInfo(FFlist* cpuTimes)
+const char* ffGetCpuUsageInfo(FF_MAYBE_UNUSED FFlist* cpuTimes)
 {
     return "Not support on this platform";
 }

--- a/src/detection/disk/disk_nosupport.c
+++ b/src/detection/disk/disk_nosupport.c
@@ -1,6 +1,6 @@
 #include "disk.h"
 
-const char* ffDetectDisksImpl(FFDiskOptions* options, FFlist* disks)
+const char* ffDetectDisksImpl(FF_MAYBE_UNUSED FFDiskOptions* options, FF_MAYBE_UNUSED FFlist* disks)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/diskio/diskio_nosupport.c
+++ b/src/detection/diskio/diskio_nosupport.c
@@ -1,6 +1,6 @@
 #include "diskio.h"
 
-const char* ffDiskIOGetIoCounters(FFlist* result, FFDiskIOOptions* options)
+const char* ffDiskIOGetIoCounters(FF_MAYBE_UNUSED FFlist* result, FF_MAYBE_UNUSED FFDiskIOOptions* options)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/gpu/gpu_linux.c
+++ b/src/detection/gpu/gpu_linux.c
@@ -78,7 +78,7 @@ static bool pciDetectDriver(FFstrbuf* result, FFstrbuf* pciDir, FFstrbuf* buffer
     return true;
 }
 
-static const char* drmFindRenderFromCard(const char* drmCardKey, FFstrbuf* result)
+FF_MAYBE_UNUSED static const char* drmFindRenderFromCard(const char* drmCardKey, FFstrbuf* result)
 {
     char path[PATH_MAX];
     sprintf(path, "/sys/class/drm/%s/device/drm", drmCardKey);
@@ -395,6 +395,7 @@ static const char* drmDetectIntelSpecific(FFGPUResult* gpu, const char* drmKey, 
     }
     return NULL;
     #else
+    FF_UNUSED(gpu, drmKey, buffer);
     return "Fastfetch is not compiled with drm support";
     #endif
 }

--- a/src/detection/host/host_nosupport.c
+++ b/src/detection/host/host_nosupport.c
@@ -1,6 +1,6 @@
 #include "host.h"
 
-const char* ffDetectHost(FFHostResult* host)
+const char* ffDetectHost(FF_MAYBE_UNUSED FFHostResult* host)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/memory/memory_nosupport.c
+++ b/src/detection/memory/memory_nosupport.c
@@ -1,6 +1,6 @@
 #include "memory.h"
 
-const char* ffDetectMemory(FFMemoryResult* ram)
+const char* ffDetectMemory(FF_MAYBE_UNUSED FFMemoryResult* ram)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/netio/netio_nosupport.c
+++ b/src/detection/netio/netio_nosupport.c
@@ -1,6 +1,6 @@
 #include "netio.h"
 
-const char* ffNetIOGetIoCounters(FFlist* result, FFNetIOOptions* options)
+const char* ffNetIOGetIoCounters(FF_MAYBE_UNUSED FFlist* result, FF_MAYBE_UNUSED FFNetIOOptions* options)
 {
     return "Not supported on this platform";
 }

--- a/src/detection/packages/packages_nosupport.c
+++ b/src/detection/packages/packages_nosupport.c
@@ -1,5 +1,5 @@
 #include "packages.h"
 
-void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options)
+void ffDetectPackagesImpl(FF_MAYBE_UNUSED FFPackagesResult* result, FF_MAYBE_UNUSED FFPackagesOptions* options)
 {
 }


### PR DESCRIPTION
Fix warnings like these:

![Warning1](https://github.com/user-attachments/assets/ad29def2-659c-42b3-a148-faa7abb8393c)

![Warning2](https://github.com/user-attachments/assets/37de1770-06fc-453c-a112-8524efa310dc)

