### PR TITLE
run.sh: Improve compatibility with other systems

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,15 +8,23 @@ cd build/
 if [ -z "${CMAKE_BUILD_TYPE}" ]; then
     CMAKE_BUILD_TYPE=Release
 fi
+
 cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" ..
 
-if [ -z "$OSTYPE" ] || [ "$OSTYPE" = "linux-gnu" ]; then
-    cmake_build_args="-j$(nproc)"
-elif [ "$OSTYPE" = "darwin" ]; then
-    cmake_build_args="-j$(sysctl -n hw.ncpu)"
-else
-    cmake_build_args=""
-fi
-cmake --build . --target fastfetch ${cmake_build_args}
+kernel_name="$(uname -s)"
+
+case "${kernel_name}" in
+    "Linux")
+        cmake_build_args="-j$(nproc)"
+        ;;
+    "Darwin" | *"BSD" | "DragonFly")
+        cmake_build_args="-j$(sysctl -n hw.ncpu)"
+        ;;
+    *)
+        cmake_build_args=""
+        ;;
+esac
+
+cmake --build . --target fastfetch "${cmake_build_args}"
 
 ./fastfetch "$@"

--- a/run.sh
+++ b/run.sh
@@ -5,16 +5,12 @@ set -e
 mkdir -p build/
 cd build/
 
-if [ -z "${CMAKE_BUILD_TYPE}" ]; then
-    CMAKE_BUILD_TYPE=Release
-fi
-
-cmake "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" ..
+cmake ..
 
 kernel_name="$(uname -s)"
 
 case "${kernel_name}" in
-    "Linux")
+    "Linux" | "MINGW"*)
         cmake_build_args="-j$(nproc)"
         ;;
     "Darwin" | *"BSD" | "DragonFly")


### PR DESCRIPTION
For example `$OSTYPE` is empty in OpenBSD and the script fallsback to Linux option, with `nproc` isn't present it fails to build.