### PR TITLE
Netif (Linux): fix unused-result warning

### DIFF
--- a/src/common/netif/netif_linux.c
+++ b/src/common/netif/netif_linux.c
@@ -13,7 +13,7 @@ bool ffNetifGetDefaultRouteImpl(char iface[IF_NAMESIZE + 1], uint32_t* ifIndex)
     if (!netRoute) return false;
 
     // skip first line
-    fscanf(netRoute, "%*[^\n]\n");
+    FF_UNUSED(fscanf(netRoute, "%*[^\n]\n"));
 
     unsigned long long destination; //, gateway, flags, refCount, use, metric, mask, mtu,
     while (fscanf(netRoute, "%" FF_STR(IF_NAMESIZE) "s%llx%*[^\n]", iface, &destination) == 2)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/41a5747c-04d1-4a07-a2a2-f90acdc50e14)

GCC warns almost all the functions in the stdio.h excepts printf-like ones if we dont use its result. And here the result is useless.