### PR TITLE
Editor: fix the Vim version detection

### DIFF
--- a/src/detection/editor/editor.c
+++ b/src/detection/editor/editor.c
@@ -95,7 +95,7 @@ const char* ffDetectEditor(FFEditorResult* result)
 
     if (ffStrbufEqualS(&result->exe, "nvim"))
         ffBinaryExtractStrings(result->path.chars, extractNvimVersionFromBinary, &result->version, (uint32_t) strlen("NVIM v0.0.0"));
-    else if (ffStrbufEqualS(&result->exe, "vim"))
+    else if (ffStrbufEqualS(&result->exe, "vim") || ffStrbufStartsWithS(&result->exe, "vim."))
         ffBinaryExtractStrings(result->path.chars, extractVimVersionFromBinary, &result->version, (uint32_t) strlen("VIM - Vi IMproved 0.0"));
     else if (ffStrbufEqualS(&result->exe, "nano"))
         ffBinaryExtractStrings(result->path.chars, extractNanoVersionFromBinary, &result->version, (uint32_t) strlen("GNU nano 0.0"));
@@ -106,6 +106,7 @@ const char* ffDetectEditor(FFEditorResult* result)
     if (
         ffStrbufEqualS(&result->exe, "nano") ||
         ffStrbufEqualS(&result->exe, "vim") ||
+        ffStrbufStartsWithS(&result->exe, "vim.") || // vim.basic/vim.tiny
         ffStrbufEqualS(&result->exe, "nvim") ||
         ffStrbufEqualS(&result->exe, "micro") ||
         ffStrbufEqualS(&result->exe, "emacs") ||


### PR DESCRIPTION
On Ubuntu, Vim's real name is 'vim.basic' (or 'vim.tiny', can be switched by update-alternatives):
![vim](https://github.com/user-attachments/assets/8ef4e2b9-5f6c-49e7-bbd7-925b219e609c)

The editor version detection can not handle this name and returns an empty version string:
![empty-vim-version](https://github.com/user-attachments/assets/4c6b21a7-8eec-4788-a2cc-8effdb64bdbd)


P.S. Dont use `startWith("vim")` because there're many commands have prefix 'vim' (e.g., vimdiff, vimtutor, vimdot, ...) but they are not editors and have completely different version formats (or even not support version options).
