### PR TITLE
IO: optimize createSubfolders

### DIFF
--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -23,13 +23,14 @@
 
 static void createSubfolders(const char* fileName)
 {
-    FF_STRBUF_AUTO_DESTROY path = ffStrbufCreate();
-
+    char path[PATH_MAX];
     char *token = NULL;
+    char *pathTail = path;
     while((token = strchr(fileName, '/')) != NULL)
     {
-        ffStrbufAppendNS(&path, (uint32_t)(token - fileName + 1), fileName);
-        mkdir(path.chars, S_IRWXU | S_IRGRP | S_IROTH);
+        uint32_t length = (uint32_t)(token - fileName + 1);
+        pathTail = ffStrCopyN(pathTail, fileName, length);
+        mkdir(path, S_IRWXU | S_IRGRP | S_IROTH);
         fileName = token + 1;
     }
 }

--- a/src/common/io/io_windows.c
+++ b/src/common/io/io_windows.c
@@ -8,12 +8,14 @@
 
 static void createSubfolders(const char* fileName)
 {
-    FF_STRBUF_AUTO_DESTROY path = ffStrbufCreate();
+    char path[MAX_PATH];
     char *token = NULL;
+    char *pathTail = path;
     while((token = strchr(fileName, '/')) != NULL)
     {
-        ffStrbufAppendNS(&path, (uint32_t)(token - fileName + 1), fileName);
-        CreateDirectoryA(path.chars, NULL);
+        uint32_t length = (uint32_t)(token - fileName + 1);
+        pathTail = ffStrCopyN(pathTail, fileName, length);
+        CreateDirectoryA(path, NULL);
         fileName = token + 1;
     }
 }


### PR DESCRIPTION
File names have known max length limits, so we can use a fixed length stack buf rather than heap allocations.

This reduces 2 heap allocations on the path "/home/apocelipes/.config/fastfetch" and makes `createSubfolders` run 8% faster:

![benchmark](https://github.com/user-attachments/assets/1d3e2354-3b91-4334-8f56-114b18e1a4bd)

After this optimization, the paramater `fileName`'s length must be less than the PATH_MAX/MAX_PATH, and `open`/`CreateFileA` has already checked this for us, so it's not worth to check it again in the `createSubfolders`.