### PR TITLE
FFstrbuf: fix small FFstrbuf allocations in ffStrbufEnsureFree

### DIFF
--- a/src/util/FFstrbuf.c
+++ b/src/util/FFstrbuf.c
@@ -33,7 +33,7 @@ void ffStrbufEnsureFree(FFstrbuf* strbuf, uint32_t free)
         return;
 
     uint32_t allocate = strbuf->allocated;
-    if(allocate < 2)
+    if(allocate < FASTFETCH_STRBUF_DEFAULT_ALLOC)
         allocate = FASTFETCH_STRBUF_DEFAULT_ALLOC;
 
     while((strbuf->length + free + 1) > allocate) // + 1 for the null byte


### PR DESCRIPTION
Consider some corner cases: 
- allocate was 28, need a new cap of 31 bytes. The old code grows the cap to 56 bytes. 24 bytes were wasted. (see below, you could waste more than 24 bytes)
- allocate was 8, need a new cap of 18 bytes. allocate was 8 -> 16 -> 32, no waste but multiplicated twice.
- allocate was 5, need a 11 bytes new cap. allocate was 5 -> 10 -> 20. You may think the new code will waste 12 bytes. However on the most of modern systems small memory areas are managed by blocks, blocks' sizes usually are powers of 2 or multiples of 16. Unfortunately, 20 is neither a power of 2 nor a multiple of 16, so it will be allocated into a 32-bytes block. Eventually there's no waste.

if 0 and 1 can be extended to 32 why 2, 3, 4, 5 cannot? It didn't hold water. Use `FASTFETCH_STRBUF_DEFAULT_ALLOC` as the smallest allocation size is more reasonable and more useful. Change `if(allocate < 2)` to `if(allocate == 0)` is resaonable but not useful.

In addition, the corner case actually exists in `fastfetch -c all`:

![old](https://github.com/user-attachments/assets/5f31f4ec-11cd-49ab-89c4-9ad3fb42d8e1)

After fixing:

![new](https://github.com/user-attachments/assets/74455b6b-d803-481d-9555-eb394ef4cdaa)

In other cases, memory usage did not change.
