### PR TITLE
IO: fix an off-by-one bug

### DIFF
--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -29,7 +29,7 @@ static void createSubfolders(const char* fileName)
     while((token = strchr(fileName, '/')) != NULL)
     {
         uint32_t length = (uint32_t)(token - fileName + 1);
-        pathTail = ffStrCopyN(pathTail, fileName, length);
+        pathTail = ffStrCopyN(pathTail, fileName, length + 1);
         mkdir(path, S_IRWXU | S_IRGRP | S_IROTH);
         fileName = token + 1;
     }

--- a/src/common/io/io_windows.c
+++ b/src/common/io/io_windows.c
@@ -14,7 +14,7 @@ static void createSubfolders(const char* fileName)
     while((token = strchr(fileName, '/')) != NULL)
     {
         uint32_t length = (uint32_t)(token - fileName + 1);
-        pathTail = ffStrCopyN(pathTail, fileName, length);
+        pathTail = ffStrCopyN(pathTail, fileName, length + 1);
         CreateDirectoryA(path, NULL);
         fileName = token + 1;
     }

--- a/src/util/stringUtils.h
+++ b/src/util/stringUtils.h
@@ -80,6 +80,7 @@ static inline bool ffCharIsDigit(char c)
     return '0' <= c && c <= '9';
 }
 
+// ffStrCopyN copies at most (nDst - 1) bytes from src to dst
 static inline char* ffStrCopyN(char* __restrict__ dst, const char* __restrict__ src, size_t nDst)
 {
     assert(dst != NULL);


### PR DESCRIPTION
It's my bad, I didn't notice that `ffStrCopyN` will do `strnlen(src, nDst - 1)`. I won't change `ffStrCopyN` because it has been used at many places and "-1" may be correct, so I only changed my code.

Fix that and add a comment to `ffStrCopyN`.