### PR TITLE
tests: add FFstrbuf smallest allocation test & minor fix

### DIFF
--- a/tests/list.c
+++ b/tests/list.c
@@ -116,7 +116,7 @@ int main(void)
 
     {
         FF_LIST_AUTO_DESTROY test = ffListCreate(1);
-        VERIFY(test.elementSize = 1);
+        VERIFY(test.elementSize == 1);
         VERIFY(test.capacity == 0);
         VERIFY(test.length == 0);
     }

--- a/tests/strbuf.c
+++ b/tests/strbuf.c
@@ -442,6 +442,19 @@ int main(void)
     VERIFY(ffStrbufEqualS(&strbuf, "AA12BB3456CCDD"));
     ffStrbufDestroy(&strbuf);
 
+    // smallest allocation test
+    {
+        FF_STRBUF_AUTO_DESTROY strbuf1 = ffStrbufCreateA(10);
+        VERIFY(strbuf1.allocated == 10);
+        ffStrbufEnsureFree(&strbuf1, 16);
+        VERIFY(strbuf1.allocated == 32);
+
+        FF_STRBUF_AUTO_DESTROY strbuf2 = ffStrbufCreate();
+        VERIFY(strbuf2.allocated == 0);
+        ffStrbufEnsureFree(&strbuf2, 16);
+        VERIFY(strbuf2.allocated == 32);
+    }
+
     //Success
     puts("\e[32mAll tests passed!" FASTFETCH_TEXT_MODIFIER_RESET);
 }


### PR DESCRIPTION
Fix a misuse of assignment operators.

All tests are green:
![image](https://github.com/user-attachments/assets/c8e8daeb-b43b-4afe-b2ba-e49d7110b419)
