### PR TITLE
Scripts: `gen-man.py` honors SOURCE_DATE_EPOCH.

### DIFF
--- a/scripts/gen-man.py
+++ b/scripts/gen-man.py
@@ -10,8 +10,9 @@ For the format of the JSON file, see https://github.com/fastfetch-cli/fastfetch/
 
 from json import load
 from datetime import date
+from time import time
 from re import search
-from os import path
+from os import environ, path
 
 
 ###### Text Decorations Tags ######
@@ -34,7 +35,9 @@ manSection = 1
 # title (center header)
 titlePage = "Fastfetch man page"
 # date (center footer)
-todayDate = date.today().strftime("%b %d %Y") # format : "Month (abbreviation) Day Year"
+# format : "Month (abbreviation) Day Year"
+todayDate = date.fromtimestamp(
+    int(environ.get("SOURCE_DATE_EPOCH", time()))).strftime("%b %d %Y")
 # file to fastfetch version (left footer)
 pathToVersionFile = path.join(pathToCurrentDir, "../CMakeLists.txt")
 


### PR DESCRIPTION
This makes `gen-man.py` use SOURCE_DATE_EPOCH as the timestamp to allow for deterministic timestamps https://reproducible-builds.org/docs/source-date-epoch/ . The timestamp of the other manpage already does the same because cmakes `string`  takes care of that.