### PR TITLE
WM (Linux): fix wl-restart parsing

### DIFF
--- a/src/detection/displayserver/linux/wayland/wayland.c
+++ b/src/detection/displayserver/linux/wayland/wayland.c
@@ -39,7 +39,7 @@ static bool waylandDetectWM(int fd, FFDisplayServerResult* result)
         filename = result->wmProcessName.chars;
 
     if (ffStrEquals(filename, "wl-restart"))
-        ffStrbufSubstrAfterFirstC(&result->wmProcessName, '\0');
+        ffStrbufSubstrAfterLastC(&result->wmProcessName, '\0');
 
     ffStrbufSubstrBeforeFirstC(&result->wmProcessName, '\0'); //Trim the arguments
     ffStrbufSubstrAfterLastC(&result->wmProcessName, '/'); //Trim the path


### PR DESCRIPTION
Make the WM name in `wl-restart -n 5 Hyprland` parse as "Hyprland" instead of "-n".