### PR TITLE
CMake(Linux): make "-fno-omit-frame-pointer" configurable in release …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ option(SET_TWEAK "Add tweak to project version" ON) # This is set to off by gith
 option(IS_MUSL "Build with musl libc" OFF) # Used by Github Actions
 option(INSTALL_LICENSE "Install license into /usr/share/licenses" ON)
 option(ENABLE_EMBEDDED_PCIIDS "Embed pci.ids into fastfetch, requires `python`" OFF)
+option(ENABLE_FRAME_POINTERS "Build fastfetch with frame pointers" OFF) # For Fedora/Ubuntu/Arch Linux packagers
 
 set(BINARY_LINK_TYPE_OPTIONS dlopen dynamic static)
 set(BINARY_LINK_TYPE dlopen CACHE STRING "How to link fastfetch")
@@ -137,6 +138,10 @@ set(WARNING_FLAGS "-Wall -Wextra -Wconversion -Werror=uninitialized -Werror=retu
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS} -Werror=incompatible-pointer-types -Werror=implicit-function-declaration -Werror=int-conversion")
+
+if(LINUX AND ENABLE_FRAME_POINTERS AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
+endif()
 
 if(WIN32 OR ENABLE_DIRECTX_HEADERS)
     enable_language(CXX)


### PR DESCRIPTION
…mode.

Starting last year, Fedora and Ubuntu began to require softwares in the repository to turn on the "-fno-omit-frame-pointer" and "-mno-omit-leaf-frame-pointer" compiler options by default. This year Arch Linux also began to make similar requirements.

Fedora: <https://fedoraproject.org/wiki/Changes/fno-omit-frame-pointer>
Ubuntu: <https://www.phoronix.com/news/Ubuntu-Frame-Pointers-Default>
Arch Linux: <https://rfc.archlinux.page/0026-fno-omit-frame-pointer/>

So add an option and set its default value to OFF, packagers can set to ON if they need it. This might make those packagers' lives easier.

Currently the frame pointer is only valuable under Linux so it is only enabled when the build target is Linux.

This option is also not enabled in Debug mode, for two reasons:
1. Debug mode already sets "-fno-omit-frame-pointer", that's enough.
2. Frame pointers are not only for debugging but for tools like perf and eBPF to do profiling.

Test:

Turn on the option:
![on](https://github.com/user-attachments/assets/19f0350a-e8fe-400d-bfc6-0127029d2193)

Default/Turn off:
![off](https://github.com/user-attachments/assets/a2fece7e-a5d7-4fd2-8769-c64d0ae16338)

![image](https://github.com/user-attachments/assets/b41efe2c-c8bd-48f6-bbb5-5fb46b1dbe66)
