### PR TITLE
Refactor Armbian version detection and add support for ubuntu-based armbian detection

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -49,10 +49,7 @@ static bool parseOsRelease(const char* fileName, FFOSResult* result)
 // Get Armbian version properties and set idLike based on the Armbian image basis
 FF_MAYBE_UNUSED static void getArmbianVersion(FFOSResult* result)
 {
-    if(ffStrbufIgnCaseEqualS(&result->id, "ubuntu"))
-        ffStrbufSetS(&result->idLike, "ubuntu");
-    else if(ffStrbufIgnCaseEqualS(&result->id, "debian"))
-        ffStrbufSetS(&result->idLike, "debian");
+    ffStrbufSet(&result->idLike, &result->id);
     ffStrbufSetS(&result->id, "armbian");
     ffStrbufClear(&result->versionID);
     uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -46,34 +46,46 @@ static bool parseOsRelease(const char* fileName, FFOSResult* result)
     });
 }
 
+// Get Armbian version properties and set idLike based on the Armbian image basis
+FF_MAYBE_UNUSED static void getArmbianVersion(FFOSResult* result)
+{
+    if(ffStrbufIgnCaseEqualS(&result->id, "ubuntu"))
+        ffStrbufSetS(&result->idLike, "ubuntu");
+    else if(ffStrbufIgnCaseEqualS(&result->id, "debian"))
+        ffStrbufSetS(&result->idLike, "debian");
+    ffStrbufSetS(&result->id, "armbian");
+    ffStrbufClear(&result->versionID);
+    uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
+    uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
+    ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
+}
+
+// Common logic for detecting Armbian image version
+FF_MAYBE_UNUSED static bool detectArmbianVersion(FFOSResult* result)
+{
+    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Official Armbian release images
+    {
+        ffStrbufSetS(&result->name, "Armbian");
+        getArmbianVersion(result);
+        return true;
+    }
+    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
+    {
+        ffStrbufSetS(&result->name, "Armbian (custom build)");
+        getArmbianVersion(result);
+        return true;
+    }
+    return false;
+}
+
 FF_MAYBE_UNUSED static void getUbuntuFlavour(FFOSResult* result)
 {
     const char* xdgConfigDirs = getenv("XDG_CONFIG_DIRS");
     if(!ffStrSet(xdgConfigDirs))
         return;
 
-    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Armbian 24.11 noble
-    {
-        ffStrbufSetS(&result->name, "Armbian");
-        ffStrbufSetS(&result->id, "armbian");
-        ffStrbufSetS(&result->idLike, "ubuntu");
-        ffStrbufClear(&result->versionID);
-        uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
-        uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
-        ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
+    if (detectArmbianVersion(result))
         return;
-    }
-    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
-    {
-        ffStrbufSetS(&result->name, "Armbian (custom build)");
-        ffStrbufSetS(&result->id, "armbian");
-        ffStrbufSetS(&result->idLike, "ubuntu");
-        ffStrbufClear(&result->versionID);
-        uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
-        uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
-        ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
-        return;
-    }
     else if(ffStrbufStartsWithS(&result->prettyName, "Linux Lite "))
     {
         ffStrbufSetS(&result->name, "Linux Lite");
@@ -186,28 +198,8 @@ FF_MAYBE_UNUSED static void getDebianVersion(FFOSResult* result)
 
 FF_MAYBE_UNUSED static bool detectDebianDerived(FFOSResult* result)
 {
-    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Armbian 24.2.1 bookworm
-    {
-        ffStrbufSetS(&result->name, "Armbian");
-        ffStrbufSetS(&result->id, "armbian");
-        ffStrbufSetS(&result->idLike, "debian");
-        ffStrbufClear(&result->versionID);
-        uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
-        uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
-        ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
+    if (detectArmbianVersion(result))
         return true;
-    }
-    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
-    {
-        ffStrbufSetS(&result->name, "Armbian (custom build)");
-        ffStrbufSetS(&result->id, "armbian");
-        ffStrbufSetS(&result->idLike, "debian");
-        ffStrbufClear(&result->versionID);
-        uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
-        uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
-        ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
-        return true;
-    }
     else if (ffStrbufStartsWithS(&result->name, "Loc-OS"))
     {
         ffStrbufSetS(&result->id, "locos");

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -52,7 +52,29 @@ FF_MAYBE_UNUSED static void getUbuntuFlavour(FFOSResult* result)
     if(!ffStrSet(xdgConfigDirs))
         return;
 
-    if(ffStrbufStartsWithS(&result->prettyName, "Linux Lite "))
+    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Armbian 24.11 noble
+    {
+        ffStrbufSetS(&result->name, "Armbian");
+        ffStrbufSetS(&result->id, "armbian");
+        ffStrbufSetS(&result->idLike, "ubuntu");
+        ffStrbufClear(&result->versionID);
+        uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
+        uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
+        ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
+        return;
+    }
+    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
+    {
+        ffStrbufSetS(&result->name, "Armbian (custom build)");
+        ffStrbufSetS(&result->id, "armbian");
+        ffStrbufSetS(&result->idLike, "ubuntu");
+        ffStrbufClear(&result->versionID);
+        uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
+        uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
+        ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
+        return;
+    }
+    else if(ffStrbufStartsWithS(&result->prettyName, "Linux Lite "))
     {
         ffStrbufSetS(&result->name, "Linux Lite");
         ffStrbufSetS(&result->id, "linuxlite");

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -46,33 +46,22 @@ static bool parseOsRelease(const char* fileName, FFOSResult* result)
     });
 }
 
-// Get Armbian version properties and set idLike based on the Armbian image basis
-FF_MAYBE_UNUSED static void getArmbianVersion(FFOSResult* result)
+// Common logic for detecting Armbian image version
+FF_MAYBE_UNUSED static bool detectArmbianVersion(FFOSResult* result)
 {
+    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Official Armbian release images
+        ffStrbufSetS(&result->name, "Armbian");
+    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
+        ffStrbufSetS(&result->name, "Armbian (custom build)");
+    else
+        return false;
     ffStrbufSet(&result->idLike, &result->id);
     ffStrbufSetS(&result->id, "armbian");
     ffStrbufClear(&result->versionID);
     uint32_t versionStart = ffStrbufFirstIndexC(&result->prettyName, ' ') + 1;
     uint32_t versionEnd = ffStrbufNextIndexC(&result->prettyName, versionStart, ' ');
     ffStrbufSetNS(&result->versionID, versionEnd - versionStart, result->prettyName.chars + versionStart);
-}
-
-// Common logic for detecting Armbian image version
-FF_MAYBE_UNUSED static bool detectArmbianVersion(FFOSResult* result)
-{
-    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Official Armbian release images
-    {
-        ffStrbufSetS(&result->name, "Armbian");
-        getArmbianVersion(result);
-        return true;
-    }
-    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
-    {
-        ffStrbufSetS(&result->name, "Armbian (custom build)");
-        getArmbianVersion(result);
-        return true;
-    }
-    return false;
+    return true;
 }
 
 FF_MAYBE_UNUSED static void getUbuntuFlavour(FFOSResult* result)


### PR DESCRIPTION
Ubuntu can be used to build Armbian, it is one of the official bases for Armbian. This allows the detection of Armbian in case it is based on Ubuntu.