### PR TITLE
Correct macOS Used Memory.

### DIFF
--- a/src/detection/memory/memory_apple.c
+++ b/src/detection/memory/memory_apple.c
@@ -16,15 +16,12 @@ const char* ffDetectMemory(FFMemoryResult* ram)
     if(host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t) (&vmstat), &count) != KERN_SUCCESS)
         return "Failed to read host_statistics64";
 
-    // https://github.com/exelban/stats/blob/master/Modules/RAM/readers.swift#L56
+    // https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433-L435
     ram->bytesUsed = ((uint64_t)
-        + vmstat.active_count
-        + vmstat.inactive_count
-        + vmstat.speculative_count
-        + vmstat.wire_count
+        + vmstat.wire_count 
+        + vmstat.inactive_count 
+        + vmstat.active_count 
         + vmstat.compressor_page_count
-        - vmstat.purgeable_count
-        - vmstat.external_page_count
     ) * instance.state.platform.sysinfo.pageSize;
 
     return NULL;


### PR DESCRIPTION
macOS memory usage statistics are wrong.

For correct values, consider doing what Apple does in their official top(1) utility: https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433-L435

After testing this pull request locally you will notice the values reported by top(1) for used memory will match what this pull request reports for that.

I personally believe what activity monitor reports for ram usage is less correct than top(1). As far as I know, top(1) is a part of the single unix specification, so it is more standardized in how it calculates these types of things, and in a way that will be cross-platform, (as top(1) is available out of the box on numerous unix-likes, and activity monitor is not).

The code currently in the main branch does not match top(1), nor activity monitor either, so this is a step in the right direction either way, regardless of whichever one you prefer to use to get these values.