### PR TITLE
WM: Add support for detecting window manager versions, add Hyprland version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,7 +534,7 @@ if(LINUX)
         src/detection/users/users_linux.c
         src/detection/wallpaper/wallpaper_linux.c
         src/detection/wifi/wifi_linux.c
-        src/detection/wm/wm_nosupport.c
+        src/detection/wm/wm_linux.c
         src/detection/de/de_linux.c
         src/detection/wmtheme/wmtheme_linux.c
         src/detection/camera/camera_linux.c

--- a/src/detection/wm/wm.h
+++ b/src/detection/wm/wm.h
@@ -3,3 +3,4 @@
 #include "fastfetch.h"
 
 const char* ffDetectWMPlugin(FFstrbuf* pluginName);
+const char* ffDetectWMVersion(const FFstrbuf* wmName, FFstrbuf* result, FFWMOptions* options);

--- a/src/detection/wm/wm_apple.c
+++ b/src/detection/wm/wm_apple.c
@@ -38,3 +38,8 @@ const char* ffDetectWMPlugin(FFstrbuf* pluginName)
 
     return NULL;
 }
+
+const char* ffDetectWMVersion(FF_MAYBE_UNUSED const FFstrbuf* wmName, FF_MAYBE_UNUSED FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options)
+{
+    return "Not supported on this platform";
+}

--- a/src/detection/wm/wm_linux.c
+++ b/src/detection/wm/wm_linux.c
@@ -1,0 +1,30 @@
+#include "wm.h"
+
+#include "common/processing.h"
+#include "detection/displayserver/displayserver.h"
+
+const char* ffDetectWMPlugin(FF_MAYBE_UNUSED FFstrbuf* pluginName)
+{
+    return "Not supported on this platform";
+}
+
+static void getHyprland(FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options)
+{
+    if (ffProcessAppendStdOut(result, (char* const[]){
+        "Hyprland",
+        "--version",
+        NULL
+    }) == NULL){ // Hyprland 0.46.2 built from branch v0.46.2-b at... long and multi line
+        ffStrbufSubstrAfterFirstC(result, ' ');
+        ffStrbufSubstrBeforeFirstC(result, ' ');
+    }
+}
+
+const char* ffDetectWMVersion(const FFstrbuf* wmName, FFstrbuf* result, FFWMOptions* options)
+{
+    if (ffStrbufEqualS(wmName, FF_WM_PRETTY_HYPRLAND))
+        getHyprland(result, options);
+    else
+        return "Unsupported WM";
+    return NULL;
+}

--- a/src/detection/wm/wm_nosupport.c
+++ b/src/detection/wm/wm_nosupport.c
@@ -4,3 +4,8 @@ const char* ffDetectWMPlugin(FF_MAYBE_UNUSED FFstrbuf* pluginName)
 {
     return "Not supported on this platform";
 }
+
+const char* ffDetectWMVersion(FF_MAYBE_UNUSED const FFstrbuf* wmName, FF_MAYBE_UNUSED FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options)
+{
+    return "Not supported on this platform";
+}

--- a/src/detection/wm/wm_windows.cpp
+++ b/src/detection/wm/wm_windows.cpp
@@ -64,3 +64,8 @@ const char* ffDetectWMPlugin(FFstrbuf* pluginName)
     }
     return NULL;
 }
+
+const char* ffDetectWMVersion(FF_MAYBE_UNUSED const FFstrbuf* wmName, FF_MAYBE_UNUSED FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options)
+{
+    return "Not supported on this platform";
+}

--- a/src/modules/wm/wm.c
+++ b/src/modules/wm/wm.c
@@ -19,11 +19,20 @@ void ffPrintWM(FFWMOptions* options)
     if(options->detectPlugin)
         ffDetectWMPlugin(&pluginName);
 
+    FF_STRBUF_AUTO_DESTROY version = ffStrbufCreate();
+    ffDetectWMVersion(&result->wmPrettyName, &version, options);
+
     if(options->moduleArgs.outputFormat.length == 0)
     {
         ffPrintLogoAndKey(FF_WM_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT);
 
         ffStrbufWriteTo(&result->wmPrettyName, stdout);
+
+        if(version.length > 0)
+        {
+            putchar(' ');
+            ffStrbufWriteTo(&version, stdout);
+        }
 
         if(result->wmProtocolName.length > 0)
         {


### PR DESCRIPTION
This PR adds the ability to detect/view window manager versions and introduces Hyprland as the first and currently only implementation (because thats why I use)