### PR TITLE
fixing fastfetch wrong colors for xray_os logo

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -5000,9 +5000,10 @@ static const FFlogo X[] = {
         .names = {"Xray_OS"},
         .lines = FASTFETCH_DATATEXT_LOGO_XRAY_OS,
         .colors = {
-            FF_COLOR_FG_256 "16",
+            FF_COLOR_FG_256 "15",
             FF_COLOR_FG_256 "14",
             FF_COLOR_FG_256 "16",
+            FF_COLOR_FG_256 "24",
         }
     },
     // LAST


### PR DESCRIPTION
for some reason the colors the xray_os ASCII logo were misconfigured, I just fixed that