### PR TITLE
change arch_old logo colours to be more accurate to the actual original logo.

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -384,11 +384,11 @@ static const FFlogo A[] = {
         .type = FF_LOGO_LINE_TYPE_ALTER_BIT,
         .lines = FASTFETCH_DATATEXT_LOGO_ARCH_OLD,
         .colors = {
-            FF_COLOR_FG_CYAN,
+            FF_COLOR_FG_BLUE,
             FF_COLOR_FG_WHITE,
         },
         .colorTitle = FF_COLOR_FG_DEFAULT,
-        .colorKeys = FF_COLOR_FG_CYAN,
+        .colorKeys = FF_COLOR_FG_BLUE,
     },
     // Archlabs
     {


### PR DESCRIPTION
The old arch linux logo can be found [here](https://archlinux.org/art/)

Its designs collectively use a darker shade of blue, compared to the current more cyan colour on fastfetch. 