### PR TITLE
Add missing new lines after printing, like neofetch

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -788,4 +788,7 @@ int main(int argc, char** argv)
         writeConfigFile(&data, &instance.state.genConfigPath);
 
     ffStrbufDestroy(&data.structure);
+
+    // Finish off by adding leading new lines like neofetch
+    printf("\n\n");
 }

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -384,11 +384,11 @@ static const FFlogo A[] = {
         .type = FF_LOGO_LINE_TYPE_ALTER_BIT,
         .lines = FASTFETCH_DATATEXT_LOGO_ARCH_OLD,
         .colors = {
-            FF_COLOR_FG_CYAN,
+            FF_COLOR_FG_BLUE,
             FF_COLOR_FG_WHITE,
         },
         .colorTitle = FF_COLOR_FG_DEFAULT,
-        .colorKeys = FF_COLOR_FG_CYAN,
+        .colorKeys = FF_COLOR_FG_BLUE,
     },
     // Archlabs
     {


### PR DESCRIPTION
Adds the missing new lines after printing the colour scheme showcase:

Before:
![before2](https://github.com/user-attachments/assets/32866ad9-7c80-41e9-8b8e-5f65d9129444)

After:
![after2](https://github.com/user-attachments/assets/3c25d1b8-22cc-463d-8781-244c8634dd9a)


Maybe this needs to edited, as I am not sure if the new lines are in an appropriate location (just a printf call in the main function, inside fastfetch.c)