### PR TITLE
refactor(json): use default config file if the user config is empty

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -409,8 +409,7 @@ static bool parseJsoncFile(const char* path)
         parseError ||
         (parseError = ffOptionsParseLogoJsonConfig(&instance.config.logo, root)) ||
         (parseError = ffOptionsParseGeneralJsonConfig(&instance.config.general, root)) ||
-        (parseError = ffOptionsParseDisplayJsonConfig(&instance.config.display, root)) ||
-        false
+        (parseError = ffOptionsParseDisplayJsonConfig(&instance.config.display, root))
     ) {
         fprintf(stderr, "JsonConfig Error: %s\n", parseError);
         exit(477);


### PR DESCRIPTION
if the user config is empty we get a failed to parse json error, instead of erroring out we should just show the default config since there is technically nothing wrong with the users config file if its empty :)

minor variable naming change as well for readability

potentially fixes a case where we could read twice instead of once

removes a redundant || false condition (habbit probs)