### PR TITLE
Combine all armbian variants

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -41,10 +41,13 @@ static bool parseOsRelease(const char* fileName, FFOSResult* result)
 // Common logic for detecting Armbian image version
 FF_MAYBE_UNUSED static bool detectArmbianVersion(FFOSResult* result)
 {
-    if (ffStrbufStartsWithS(&result->prettyName, "Armbian ")) // Official Armbian release images
+    // Possible values `PRETTY_NAME` starts with on Armbian:
+    // - `Armbian` for official releases
+    // - `Armbian_community` for community releases
+    // - `Armbian_Security` for images with kali repo added
+    // - `Armbian-unofficial` for an unofficial image built from source, e.g. during development and testing
+    if (ffStrbufStartsWithS(&result->prettyName, "Armbian"))
         ffStrbufSetS(&result->name, "Armbian");
-    else if (ffStrbufStartsWithS(&result->prettyName, "Armbian-unofficial ")) // Unofficial Armbian image built from source
-        ffStrbufSetS(&result->name, "Armbian (custom build)");
     else
         return false;
     ffStrbufSet(&result->idLike, &result->id);


### PR DESCRIPTION
Change armbian detection to detect by checking `PRETTY_NAME` if it starts with `"Armbian"`, without a space on the end. This detects additional 2 values that can be there: community releases and security (kali) images.
The detection was reported to be broken for community support images, and should work for other possible Armbian image variants in the future. Wrote a list of strings that the pretty name can start with right now, in a code comment.