### PR TITLE
Logo (Builtin): fix Chimera Linux distro name to match ID

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -956,7 +956,7 @@ static const FFlogo C[] = {
     },
     // Chimera Linux
     {
-        .names = {"Chimera Linux"},
+        .names = {"chimera"},
         .lines = FASTFETCH_DATATEXT_LOGO_CHIMERA_LINUX,
         .colors = {
             FF_COLOR_FG_RED,

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -954,9 +954,9 @@ static const FFlogo C[] = {
         .colorKeys = FF_COLOR_FG_GREEN,
         .colorTitle = FF_COLOR_FG_WHITE,
     },
-    // Chimera Linux
+    // Chimera
     {
-        .names = {"chimera"},
+        .names = {"Chimera"},
         .lines = FASTFETCH_DATATEXT_LOGO_CHIMERA_LINUX,
         .colors = {
             FF_COLOR_FG_RED,


### PR DESCRIPTION
It was broken (just the default tux) on [2.36.0](https://github.com/fastfetch-cli/fastfetch/releases/tag/2.36.0) and I bisected it down to https://github.com/fastfetch-cli/fastfetch/commit/f2755a844bac2c2f62e82c36e5da6ae51527e9dd. [`/etc/os-release`](https://github.com/chimera-linux/cports/blob/master/main/base-files/files/lib/os-release) for (future) reference:
```ini
NAME="Chimera"
ID="chimera"
PRETTY_NAME="Chimera Linux"
HOME_URL="https://chimera-linux.org"
DOCUMENTATION_URL="https://chimera-linux.org/docs"
LOGO="chimera-logo"
ANSI_COLOR="0;38;2;214;79;93"
```