### PR TITLE
TerminalFont (Linux): support termite terminal

### DIFF
--- a/src/detection/terminalfont/terminalfont_linux.c
+++ b/src/detection/terminalfont/terminalfont_linux.c
@@ -475,4 +475,6 @@ void ffDetectTerminalFontPlatform(const FFTerminalResult* terminal, FFTerminalFo
     else if(ffStrbufStartsWithIgnCaseS(&terminal->processName, "Terminal"))
         detectHaikuTerminal(terminalFont);
     #endif
+    else if(ffStrbufStartsWithIgnCaseS(&terminal->processName, "termite"))
+        detectFromConfigFile("termite/config", "font =", terminalFont);
 }


### PR DESCRIPTION
Hi, I noticed it was missing font detection for the terminal `termite` (which I use) so I added it.

The config is simple ini-like config file.

Currently developed termite fork: https://github.com/aperezdc/termite.