### PR TITLE
use `hyprctl version` instead of `Hyprctl --version` when detecting Hyprland version

### DIFF
--- a/src/detection/wm/wm_linux.c
+++ b/src/detection/wm/wm_linux.c
@@ -26,15 +26,15 @@ static bool extractHyprlandVersion(const char* line, FF_MAYBE_UNUSED uint32_t le
 static const char* getHyprland(FFstrbuf* result)
 {
     FF_STRBUF_AUTO_DESTROY path = ffStrbufCreate();
-    const char* error = ffFindExecutableInPath("Hyprland", &path);
-    if (error) return "Failed to find Hyprland executable path";
+    const char* error = ffFindExecutableInPath("hyprctl", &path);
+    if (error) return "Failed to find hyprctl executable path";
 
     if (ffBinaryExtractStrings(path.chars, extractHyprlandVersion, result, (uint32_t) strlen("v0.0.0")) == NULL)
         return NULL;
 
     if (ffProcessAppendStdOut(result, (char* const[]){
         path.chars,
-        "--version",
+        "version",
         NULL
     }) == NULL)
     { // Hyprland 0.46.2 built from branch v0.46.2-b at... long and multi line
@@ -43,7 +43,7 @@ static const char* getHyprland(FFstrbuf* result)
         return NULL;
     }
 
-    return "Failed to run command `Hyprland --version`";
+    return "Failed to run command `hyprctl version`";
 }
 
 static bool extractSwayVersion(const char* line, FF_MAYBE_UNUSED uint32_t len, void *userdata)


### PR DESCRIPTION
resolves #1610 

breaking changes:
 - fastfetch in a distrobox container will now report the host hyprland version instead of the container hyprland version.

before:
```console
$ time fastfetch -l none
 :  Hyprland 0.45.2 (Wayland)

________________________________________________________
Executed in   98.18 millis    fish           external
   usr time   47.13 millis  816.00 micros   46.31 millis
   sys time   48.31 millis  112.00 micros   48.20 millis
```
after:
```console
$ time ./build/fastfetch -l none
 :  Hyprland 0.45.2 (Wayland)

________________________________________________________
Executed in   23.55 millis    fish           external
   usr time    5.74 millis  786.00 micros    4.96 millis
   sys time   16.30 millis   58.00 micros   16.25 millis
```