### PR TITLE
Display (Linux): fix the error check for ffReadFileData

### DIFF
--- a/src/detection/displayserver/linux/drm.c
+++ b/src/detection/displayserver/linux/drm.c
@@ -30,7 +30,7 @@ static const char* drmParseSysfs(FFDisplayServerResult* result)
 
         char buf;
         ffStrbufAppendS(&drmDir, "/enabled");
-        if (!ffReadFileData(drmDir.chars, sizeof(buf), &buf) || buf != 'e') {
+        if (ffReadFileData(drmDir.chars, sizeof(buf), &buf) <= 0 || buf != 'e') {
           /* read failed or enabled != "enabled" */
           ffStrbufSubstrBefore(&drmDir, drmDirWithDnameLength);
           ffStrbufAppendS(&drmDir, "/status");


### PR DESCRIPTION
<img width="740" alt="Snipaste_2025-03-18_19-27-40" src="https://github.com/user-attachments/assets/fa623896-01b3-456b-8f50-c150a874a82c" />

`ffReadFileData` returns -1 when error happens, so `!ffReadFileData(drmDir.chars, sizeof(buf), &buf) || buf != 'e'` becomes `false || buf != 'e'` and the `buf` was not initlialised.