### PR TITLE
CPU (Linux): fix CPU detection on some PPC platforms

### DIFF
--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -608,7 +608,7 @@ FF_MAYBE_UNUSED static const char* detectCPUOthers(const FFCPUOptions* options, 
 
     #if __ANDROID__
     detectAndroid(cpu);
-    #else
+    #elif !__powerpc__ && !__powerpc
     detectSocName(cpu);
     #endif
 


### PR DESCRIPTION
On some PowerPC devices (notably the Nintendo Wii and Nintendo Wii U), fastfetch detects the CPU incorrectly.  It goes down the code path of 'detectSocName()', and actually matches the model of the device itself... as the CPU model name.  This is obviously incorrect, and leads to reporting such as 'CPU: wii'.  Disable this code path alltogether on PPC to prevent this, and just let it pull from cpuinfo. This lets it have correct CPU reporting, such as on the Wii, giving 'CPU: 750CL @ 0.73GHz'.

I have confirmed that this does not cause any regressions in CPU detection on x86_64 (my PC), ARM (Raspberry Pi 4), and on other PPC devices (iBook G3).

There may be a more elegant way of doing this than disabling the codepath alltogether on PPC, but it didn't seem to have any useful reporing for PPC platforms in there anyways, so this is what I went with.
