### PR TITLE
Bluetooth (Linux): silence an unused variable warning

### DIFF
--- a/src/detection/bluetooth/bluetooth_linux.c
+++ b/src/detection/bluetooth/bluetooth_linux.c
@@ -232,7 +232,7 @@ static uint32_t connectedDevices(void)
 
 #endif
 
-const char* ffDetectBluetooth(FFBluetoothOptions* options, FF_MAYBE_UNUSED FFlist* devices /* FFBluetoothResult */)
+const char* ffDetectBluetooth(FF_MAYBE_UNUSED FFBluetoothOptions* options, FF_MAYBE_UNUSED FFlist* devices /* FFBluetoothResult */)
 {
     #ifdef FF_HAVE_DBUS
         int32_t connectedCount = -1;


### PR DESCRIPTION
<img width="852" alt="Snipaste_2025-04-28_21-30-02" src="https://github.com/user-attachments/assets/13a98a6d-e9c2-41d1-8b02-d5f694e71682" />
