### PR TITLE
DisplayServer (Linux): fix xcb_connect error handling

### DIFF
--- a/src/detection/displayserver/linux/xcb.c
+++ b/src/detection/displayserver/linux/xcb.c
@@ -335,6 +335,7 @@ const char* ffdsConnectXcbRandr(FFDisplayServerResult* result)
 {
     FF_LIBRARY_LOAD(xcbRandr, "dlopen libxcb-randr failed", "libxcb-randr" FF_LIBRARY_EXTENSION, 1)
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE(xcbRandr, xcb_connect)
+    FF_LIBRARY_LOAD_SYMBOL_MESSAGE(xcbRandr, xcb_connection_has_error)
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE(xcbRandr, xcb_get_setup)
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE(xcbRandr, xcb_setup_roots_iterator)
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE(xcbRandr, xcb_screen_next)
@@ -368,8 +369,11 @@ const char* ffdsConnectXcbRandr(FFDisplayServerResult* result)
 
 
     data.connection = ffxcb_connect(NULL, NULL);
-    if(data.connection == NULL)
+    if(ffxcb_connection_has_error(data.connection) > 0)
+    {
+        ffxcb_disconnect(data.connection);
         return "xcb_connect() failed";
+    }
 
 
     data.result = result;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b4c112c4-2fc3-49b1-a0e6-324e59bace78)
![image](https://github.com/user-attachments/assets/fb948a82-2412-44a9-ab57-817ed220a354)

[doc](https://xcb.freedesktop.org/manual/group__XCB__Core__API.html)

We should use  `xcb_connection_has_error` to check whether errors have happened.