### PR TITLE
TerminalShell: use ffBinaryExtractStrings result as possible

### DIFF
--- a/src/detection/terminalshell/terminalshell.c
+++ b/src/detection/terminalshell/terminalshell.c
@@ -69,6 +69,7 @@ static bool getShellVersionBash(FFstrbuf* exe, FFstrbuf* exePath, FFstrbuf* vers
     if (*path == '\0')
         path = exe->chars;
     ffBinaryExtractStrings(path, extractBashVersion, version, (uint32_t) strlen("@(#)Bash version 0.0.0(0) release GNU"));
+    if (version->length > 0) return true;
 
     if(!getExeVersionRaw(exe, version))
         return false;


### PR DESCRIPTION
The code calls `ffBinaryExtractStrings` but does not use its result.

Reduce an unnecessary call for clone+exec on Linux.