### PR TITLE
GPU: fix hiding unknown GPUs

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -2053,6 +2053,7 @@
                                         "enum": [
                                             "integrated",
                                             "discrete",
+                                            "unknown",
                                             "none"
                                         ],
                                         "default": "none"

--- a/src/data/help.json
+++ b/src/data/help.json
@@ -1139,12 +1139,13 @@
         },
         {
             "long": "gpu-hide-type",
-            "desc": "Specify which types of GPUs should not be displayed",
+            "desc": "Specify which types of GPUs should not be displayed (default: all GPUs are shown, regardless of recognition)",
             "arg": {
                 "type": "enum",
                 "enum": {
                     "integrated": "Hide integrated GPUs",
                     "discrete": "Hide discrete GPUs",
+                    "unknown": "Hide unknown (unrecognized) GPUs",
                     "none": "Do not hide any GPUs"
                 },
                 "default": "none"

--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -173,6 +173,9 @@ void ffPrintGPU(FFGPUOptions* options)
 
     FF_LIST_FOR_EACH(FFGPUResult, gpu, gpus)
     {
+        if(gpu->type == FF_GPU_TYPE_UNKNOWN && options->hideType == FF_GPU_TYPE_UNKNOWN)
+            continue;
+
         if(gpu->type == FF_GPU_TYPE_INTEGRATED && options->hideType == FF_GPU_TYPE_INTEGRATED)
             continue;
 
@@ -230,7 +233,8 @@ bool ffParseGPUCommandOptions(FFGPUOptions* options, const char* key, const char
     if (ffStrEqualsIgnCase(subKey, "hide-type"))
     {
         options->hideType = (FFGPUType) ffOptionParseEnum(key, value, (FFKeyValuePair[]) {
-            { "none", FF_GPU_TYPE_UNKNOWN },
+            { "none", FF_GPU_TYPE_NONE },
+            { "unknown", FF_GPU_TYPE_UNKNOWN },
             { "integrated", FF_GPU_TYPE_INTEGRATED },
             { "discrete", FF_GPU_TYPE_DISCRETE },
             {},
@@ -288,7 +292,8 @@ void ffParseGPUJsonObject(FFGPUOptions* options, yyjson_val* module)
         {
             int value;
             const char* error = ffJsonConfigParseEnum(val, &value, (FFKeyValuePair[]) {
-                { "none", FF_GPU_TYPE_UNKNOWN },
+                { "none", FF_GPU_TYPE_NONE },
+                { "unknown", FF_GPU_TYPE_UNKNOWN },
                 { "integrated", FF_GPU_TYPE_INTEGRATED },
                 { "discrete", FF_GPU_TYPE_DISCRETE },
                 {},
@@ -345,8 +350,11 @@ void ffGenerateGPUJsonConfig(FFGPUOptions* options, yyjson_mut_doc* doc, yyjson_
     {
         switch (options->hideType)
         {
-            case FF_GPU_TYPE_UNKNOWN:
+            case FF_GPU_TYPE_NONE:
                 yyjson_mut_obj_add_str(doc, module, "hideType", "none");
+                break;
+            case FF_GPU_TYPE_UNKNOWN:
+                yyjson_mut_obj_add_str(doc, module, "hideType", "unknown");
                 break;
             case FF_GPU_TYPE_INTEGRATED:
                 yyjson_mut_obj_add_str(doc, module, "hideType", "integrated");

--- a/src/modules/gpu/option.h
+++ b/src/modules/gpu/option.h
@@ -7,7 +7,8 @@
 
 typedef enum __attribute__((__packed__)) FFGPUType
 {
-    FF_GPU_TYPE_UNKNOWN,
+    FF_GPU_TYPE_NONE,      // Indicates no specific GPU type. Useful as a hide filter only.
+    FF_GPU_TYPE_UNKNOWN,   // Indicates an unknown or unrecognized GPU type.
     FF_GPU_TYPE_INTEGRATED,
     FF_GPU_TYPE_DISCRETE,
 } FFGPUType;


### PR DESCRIPTION
The hide-type option now actually hides any unknown GPUs by default (hide-type == "unknown"). The old behavior (not hiding any GPUs) can be restored with "none".

Probably something of an edge-case, fastfetch would not hide a secondary GPU that is "recognized" as type == unknown (integrated in reality, but the kernel module is blacklisted because it messes things up otherwise).