### PR TITLE
Smbios: fix transitive include for `loff_t`

### DIFF
--- a/src/util/smbiosHelper.c
+++ b/src/util/smbiosHelper.c
@@ -55,6 +55,7 @@ const FFSmbiosHeader* ffSmbiosNextEntry(const FFSmbiosHeader* header)
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__sun) || defined(__HAIKU__) || defined(__OpenBSD__)
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/mman.h>
 #include <stddef.h>
 


### PR DESCRIPTION
This PR fixes an issue with `loff_t` not being found on Linux using the `mlibc` environment.
This happens because `smbiosHelper.c` relies on `loff_t` being included by `sys/stat.h` or `sys/mman.h`, but its manpage says this is provided by `sys/types.h`