### PR TITLE
Update logo for Xenia Linux

### DIFF
--- a/src/logo/ascii/xenia.txt
+++ b/src/logo/ascii/xenia.txt
@@ -1,21 +1,15 @@
-$2      ,c.                       .c;
-$2    .$1KMMMk$2....             ....$1kMMMK$2.
-$2   .$1WMMMMMX$2.....         .....$1KMMMMMW.
-$1   XMMMMMMM0$2.....        ....$1OMMMMMMMN
-$1  dMMMMMMMMM;$2.... ..... ....,$1MMMMMMMMMd
-$1  WMMMMMMMMMl;$3okKKKKKKKKKOo$1;cMMMMMMMMMM
-$1 'MMMMMMMNX$2K0$3KKKKKKKKKKKKKKK$20K$1XNMMMMMMM;
-$1 oMMMMMMM$2Oxo$3KKKKKKKKKKKKKKKKK$2oxO$1MMMMMMMd
-$1 dMMMMMMM$2dxxx$3KKKKKKKKKKKKKKK$2xxxd$1NMMMMMMk
-$1 :MMMMX0$2xxxxxx$30KKKKKKKK0KK0$2xxxxxx0$1XMMMMc
-$1  MMMO$2xxxxxxxxdx$3kdd$20x0$3ddk$2xdxxxxxxxx$1OMMM
-$1 ;$2xxkxddxxxxdodxxxxdxdxxxxdodxxxxddxkxx$1;
-$1dxd$2KMMMWXo$1'.....'$2cdxxxdc$1'.....'$2lXWMMMX$1dxd
-$1cxd$2XMMMN$1,..........$2dxd$1'.........'$2XMMMN$1dxl
-$1 .xx$2WMMl$1...''....'.;k:.'....''...$2lMMW$1xx.
-$1..:kXMMx..'....''..kMk..''....'..xMMXkc..
-$1 dMMMMMMd.....'...xMMMx...''....dMMMMMMx
-$1    kMMMMWOoc:coOkolllokOoc:coOWMMMMO
-$1         .MMMMMMMMl$2...$1lNMMMMMMM.
-$1            KMMMMMMX$2l$1KMMMMMMX
-$1               .MMMMMMMMM.
+$1                                      **
+                                 * ** */
+ $2@$1/////           / *** ***   **** ***/
+    //////////////**** ** * ** *** **/
+  ,, ,,//////////* ****** ** ** **  /
+   , , ,,, /////******* *********  /
+      , ,,,,,  ** **  ***********
+            ., ,,,**** ******* *** ///
+             ,, *********** ** ////
+               ,,,,, ******* //// //
+                    ,,,,,,. ///// //
+                      ,,,  , ///////
+                         ,,,, /////
+                            ,, / /
+                                /

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -5261,9 +5261,8 @@ static const FFlogo X[] = {
         .names = {"Xenia"},
         .lines = FASTFETCH_DATATEXT_LOGO_XENIA,
         .colors = {
-            FF_COLOR_FG_YELLOW,
-            FF_COLOR_FG_GREEN,
             FF_COLOR_FG_RED,
+            FF_COLOR_FG_WHITE
         }
     },
     // XCP-ng


### PR DESCRIPTION
The current logo under the logo option `xenia` is not the most current logo, and does not align with the current Xenia Linux branding.

This pull request makes changes to the ASCII art as well as colouring of the Xenia logo.

The new output looks like the image below:
![image](https://github.com/user-attachments/assets/42e45f19-b95f-459f-bf2a-ac19004f9b39)
