### PR TITLE
FreeBSD: display Linux Binary Compatibility

### DIFF
--- a/src/detection/host/host_linux.c
+++ b/src/detection/host/host_linux.c
@@ -70,6 +70,27 @@ const char* ffDetectHost(FFHostResult* host)
     //KVM/Qemu virtual machine
     if(ffStrbufStartsWithS(&host->name, "Standard PC"))
         ffStrbufPrependS(&host->name, "KVM/QEMU ");
+    
+    // First check for FreeBSD regardless of host->family/name
+    FFstrbuf uname;
+    ffStrbufInit(&uname);
+    ffProcessAppendStdOut(&uname, (char* const[]) {
+        "uname",
+        "-a",
+        NULL,
+    });
+
+    if (ffStrbufContainsS(&uname, "FreeBSD")) {
+        ffStrbufAppendF(&host->name, " - %s", "FreeBSD Compatibility Layer");
+        ffStrbufAppendS(&host->family, "FreeBSD");
+
+        if (instance.config.general.detectVersion) {
+            ffStrbufAppend(&host->version, &uname);
+        }
+
+        ffStrbufDestroy(&uname);
+        return NULL;
+    }
 
     if(host->family.length == 0 && host->name.length == 0)
     {


### PR DESCRIPTION
FreeBSD: display Linux Binary Compatibility

![K(S3OGG3TX(1BD2MYR7DLDS](https://github.com/user-attachments/assets/cd52a32b-a9e4-4b9d-8099-a0e7e7ffed5f)


see also <https://docs.freebsd.org/en/books/handbook/linuxemu/>