### PR TITLE
Global: add missing O_CLOEXEC to open()

### DIFF
--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -290,7 +290,7 @@ bool ffSuppressIO(bool suppress)
 
 void listFilesRecursively(uint32_t baseLength, FFstrbuf* folder, uint8_t indentation, const char* folderName, bool pretty)
 {
-    FF_AUTO_CLOSE_FD int dfd = open(folder->chars, O_RDONLY);
+    FF_AUTO_CLOSE_FD int dfd = open(folder->chars, O_RDONLY | O_CLOEXEC);
     if (dfd < 0)
         return;
 

--- a/src/detection/battery/battery_nbsd.c
+++ b/src/detection/battery/battery_nbsd.c
@@ -16,8 +16,8 @@
 
 const char* ffDetectBattery(FF_MAYBE_UNUSED FFBatteryOptions* options, FFlist* results)
 {
-    FF_AUTO_CLOSE_FD int fd = open(_PATH_SYSMON, O_RDONLY);
-    if (fd < 0) return "open(_PATH_SYSMON, O_RDONLY) failed";
+    FF_AUTO_CLOSE_FD int fd = open(_PATH_SYSMON, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return "open(_PATH_SYSMON, O_RDONLY | O_CLOEXEC) failed";
 
     prop_dictionary_t root = NULL;
     if (prop_dictionary_recv_ioctl(fd, ENVSYS_GETDICTIONARY, &root) < 0)

--- a/src/detection/battery/battery_obsd.c
+++ b/src/detection/battery/battery_obsd.c
@@ -8,9 +8,9 @@
 
 const char* ffDetectBattery(FF_MAYBE_UNUSED FFBatteryOptions* options, FFlist* result)
 {
-    FF_AUTO_CLOSE_FD int devfd = open("/dev/apm", O_RDONLY);
+    FF_AUTO_CLOSE_FD int devfd = open("/dev/apm", O_RDONLY | O_CLOEXEC);
 
-    if (devfd < 0) return "open(dev/apm, O_RDONLY) failed";
+    if (devfd < 0) return "open(dev/apm, O_RDONLY | O_CLOEXEC) failed";
 
     struct apm_power_info info = {};
 

--- a/src/detection/bootmgr/bootmgr_bsd.c
+++ b/src/detection/bootmgr/bootmgr_bsd.c
@@ -20,7 +20,7 @@
 
 const char* ffDetectBootmgr(FFBootmgrResult* result)
 {
-    FF_AUTO_CLOSE_FD int efifd = open("/dev/efi", O_RDWR);
+    FF_AUTO_CLOSE_FD int efifd = open("/dev/efi", O_RDWR | O_CLOEXEC);
     if (efifd < 0) return "open(/dev/efi) failed";
 
     uint8_t buffer[2048];

--- a/src/detection/brightness/brightness_obsd.c
+++ b/src/detection/brightness/brightness_obsd.c
@@ -12,7 +12,7 @@ const char* ffDetectBrightness(FF_MAYBE_UNUSED FFBrightnessOptions* options, FFl
     for (char i = '0'; i <= '9'; ++i) {
         path[strlen("/dev/ttyC")] = i;
 
-        FF_AUTO_CLOSE_FD int devfd = open(path, O_RDONLY);
+        FF_AUTO_CLOSE_FD int devfd = open(path, O_RDONLY | O_CLOEXEC);
 
         if (devfd < 0) {
             if (errno == EACCES && i == '0')

--- a/src/detection/camera/camera_linux.c
+++ b/src/detection/camera/camera_linux.c
@@ -20,7 +20,7 @@ const char* ffDetectCamera(FFlist* result)
     for (uint32_t i = 0; i <= 9; ++i)
     {
         path[ARRAY_SIZE(path) - 2] = (char) (i + '0');
-        FF_AUTO_CLOSE_FD int fd = open(path, O_RDONLY);
+        FF_AUTO_CLOSE_FD int fd = open(path, O_RDONLY | O_CLOEXEC);
         if (fd < 0)
         {
             if (errno == ENOENT)

--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -474,7 +474,7 @@ FF_MAYBE_UNUSED static const char* detectCPUX86(const FFCPUOptions* options, FFC
 
 static const char* detectPhysicalCores(FFCPUResult* cpu)
 {
-    int dfd = open("/sys/devices/system/cpu/", O_RDONLY | O_DIRECTORY);
+    int dfd = open("/sys/devices/system/cpu/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
     if (dfd < 0) return "open(\"/sys/devices/system/cpu/\") failed";
 
     FF_AUTO_CLOSE_DIR DIR* dir = fdopendir(dfd);

--- a/src/detection/cpu/cpu_nbsd.c
+++ b/src/detection/cpu/cpu_nbsd.c
@@ -18,8 +18,8 @@ static void freePropDict(prop_dictionary_t* pdict)
 
 static const char* detectCpuTemp(double* current)
 {
-    FF_AUTO_CLOSE_FD int fd = open(_PATH_SYSMON, O_RDONLY);
-    if (fd < 0) return "open(_PATH_SYSMON, O_RDONLY) failed";
+    FF_AUTO_CLOSE_FD int fd = open(_PATH_SYSMON, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return "open(_PATH_SYSMON, O_RDONLY | O_CLOEXEC) failed";
 
     __attribute__((__cleanup__(freePropDict))) prop_dictionary_t root = NULL;
     if (prop_dictionary_recv_ioctl(fd, ENVSYS_GETDICTIONARY, &root) < 0)

--- a/src/detection/gpu/gpu_bsd.c
+++ b/src/detection/gpu/gpu_bsd.c
@@ -96,7 +96,7 @@ static const char* detectByDrm(const FFGPUOptions* options, FFlist* gpus)
             break;
         }
 
-        FF_AUTO_CLOSE_FD int fd = open(path, O_RDONLY);
+        FF_AUTO_CLOSE_FD int fd = open(path, O_RDONLY | O_CLOEXEC);
         if (fd < 0) continue;
 
         char driverName[64];
@@ -147,9 +147,9 @@ static const char* detectByDrm(const FFGPUOptions* options, FFlist* gpus)
 
 static const char* detectByPci(const FFGPUOptions* options, FFlist* gpus)
 {
-    FF_AUTO_CLOSE_FD int fd = open("/dev/pci", O_RDONLY, 0);
+    FF_AUTO_CLOSE_FD int fd = open("/dev/pci", O_RDONLY | O_CLOEXEC, 0);
     if (fd < 0)
-        return "open(\"/dev/pci\", O_RDONLY, 0) failed";
+        return "open(\"/dev/pci\", O_RDONLY | O_CLOEXEC, 0) failed";
 
     struct pci_conf confs[128];
     struct pci_match_conf match = {

--- a/src/detection/gpu/gpu_drm.c
+++ b/src/detection/gpu/gpu_drm.c
@@ -16,7 +16,7 @@
 
 const char* ffDrmDetectRadeon(const FFGPUOptions* options, FFGPUResult* gpu, const char* renderPath)
 {
-    FF_AUTO_CLOSE_FD int fd = open(renderPath, O_RDONLY);
+    FF_AUTO_CLOSE_FD int fd = open(renderPath, O_RDONLY | O_CLOEXEC);
     if (fd < 0) return "Failed to open DRM render device";
 
     uint32_t value;
@@ -85,7 +85,7 @@ const char* ffDrmDetectAmdgpu(const FFGPUOptions* options, FFGPUResult* gpu, con
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE(libdrm, amdgpu_query_heap_info)
     FF_LIBRARY_LOAD_SYMBOL_MESSAGE(libdrm, amdgpu_device_deinitialize)
 
-    FF_AUTO_CLOSE_FD int fd = open(renderPath, O_RDONLY);
+    FF_AUTO_CLOSE_FD int fd = open(renderPath, O_RDONLY | O_CLOEXEC);
     if (fd < 0) return "Failed to open DRM render device";
 
     amdgpu_device_handle handle;

--- a/src/detection/gpu/gpu_haiku.c
+++ b/src/detection/gpu/gpu_haiku.c
@@ -5,7 +5,7 @@
 
 const char* ffDetectGPUImpl(FF_MAYBE_UNUSED const FFGPUOptions* options, FFlist* gpus)
 {
-    FF_AUTO_CLOSE_FD int pokefd = open(POKE_DEVICE_FULLNAME, O_RDWR);
+    FF_AUTO_CLOSE_FD int pokefd = open(POKE_DEVICE_FULLNAME, O_RDWR | O_CLOEXEC);
     if (pokefd < 0) return "open(POKE_DEVICE_FULLNAME) failed";
 
     pci_info dev;

--- a/src/detection/gpu/gpu_linux.c
+++ b/src/detection/gpu/gpu_linux.c
@@ -249,7 +249,7 @@ static const char* drmDetectIntelSpecific(FFGPUResult* gpu, const char* drmKey, 
     #if FF_HAVE_DRM
     ffStrbufSetS(buffer, "/dev/dri/");
     ffStrbufAppendS(buffer, drmKey);
-    FF_AUTO_CLOSE_FD int fd = open(buffer->chars, O_RDONLY);
+    FF_AUTO_CLOSE_FD int fd = open(buffer->chars, O_RDONLY | O_CLOEXEC);
     if (fd < 0) return "Failed to open drm device";
 
     if (ffStrbufEqualS(&gpu->driver, "xe"))
@@ -412,7 +412,7 @@ FF_MAYBE_UNUSED static const char* drmDetectAsahiSpecific(FFGPUResult* gpu, cons
     #if FF_HAVE_DRM_ASAHI
     ffStrbufSetS(buffer, "/dev/dri/");
     ffStrbufAppendS(buffer, drmKey);
-    FF_AUTO_CLOSE_FD int fd = open(buffer->chars, O_RDONLY);
+    FF_AUTO_CLOSE_FD int fd = open(buffer->chars, O_RDONLY | O_CLOEXEC);
     if (fd >= 0)
         return ffDrmDetectAsahi(gpu, fd);
     #endif

--- a/src/detection/physicaldisk/physicaldisk_haiku.c
+++ b/src/detection/physicaldisk/physicaldisk_haiku.c
@@ -10,7 +10,7 @@
 
 static const char* detectDisk(FFstrbuf* path, const char* diskType, FFlist* result)
 {
-    FF_AUTO_CLOSE_FD int rawfd = open(path->chars, O_RDONLY);
+    FF_AUTO_CLOSE_FD int rawfd = open(path->chars, O_RDONLY | O_CLOEXEC);
     if (rawfd < 0) return "detectDisk: open(rawfd) failed";
 
     device_geometry geometry;

--- a/src/detection/sound/sound_bsd.c
+++ b/src/detection/sound/sound_bsd.c
@@ -32,7 +32,7 @@ const char* ffDetectSound(FFlist* devices)
     for (int idev = 0; idev <= info.nummixers; ++idev)
     {
         path[strlen("/dev/mixer")] = (char) ('0' + idev);
-        FF_AUTO_CLOSE_FD int fd = open(path, O_RDWR);
+        FF_AUTO_CLOSE_FD int fd = open(path, O_RDWR | O_CLOEXEC);
         if (fd < 0) break;
 
         if (idev == 0)

--- a/src/detection/sound/sound_nbsd.c
+++ b/src/detection/sound/sound_nbsd.c
@@ -25,7 +25,7 @@ const char* ffDetectSound(FFlist* devices)
     for (int idev = 0; idev < 9; ++idev)
     {
         path[strlen("/dev/audio")] = (char) ('0' + idev);
-        FF_AUTO_CLOSE_FD int fd = open(path, O_RDWR);
+        FF_AUTO_CLOSE_FD int fd = open(path, O_RDWR | O_CLOEXEC);
         if (fd < 0) break;
 
         audio_device_t ad;

--- a/src/util/binary_linux.c
+++ b/src/util/binary_linux.c
@@ -63,7 +63,7 @@ const char* ffBinaryExtractStrings(const char* elfFile, bool (*cb)(const char* s
         return "load libelf failed";
 
     // Open the ELF file
-    FF_AUTO_CLOSE_FD int fd = open(elfFile, O_RDONLY, 0);
+    FF_AUTO_CLOSE_FD int fd = open(elfFile, O_RDONLY | O_CLOEXEC, 0);
     if (fd < 0) return "open() failed";
 
     Elf* elf = elfData.ffelf_begin(fd, ELF_C_READ, NULL);

--- a/src/util/smbiosHelper.c
+++ b/src/util/smbiosHelper.c
@@ -183,7 +183,7 @@ const FFSmbiosHeaderTable* ffGetSmbiosHeaderTable()
             }
             FF_DEBUG("Parsed SMBIOS entry address: 0x%lx", (unsigned long)entryAddress);
 
-            FF_AUTO_CLOSE_FD int fd = open("/dev/mem", O_RDONLY);
+            FF_AUTO_CLOSE_FD int fd = open("/dev/mem", O_RDONLY | O_CLOEXEC);
             if (fd < 0) {
                 FF_DEBUG("Failed to open /dev/mem: %s", strerror(errno));
                 return NULL;
@@ -219,7 +219,7 @@ const FFSmbiosHeaderTable* ffGetSmbiosHeaderTable()
                 #endif
             );
 
-            FF_AUTO_CLOSE_FD int fd = open("/dev/smbios", O_RDONLY);
+            FF_AUTO_CLOSE_FD int fd = open("/dev/smbios", O_RDONLY | O_CLOEXEC);
             if (fd < 0) {
                 FF_DEBUG("Failed to open /dev/smbios: %s", strerror(errno));
                 return NULL;
@@ -328,7 +328,7 @@ const FFSmbiosHeaderTable* ffGetSmbiosHeaderTable()
                 #else
                 "/dev/mem" // kern.securelevel must be -1
                 #endif
-            , O_RDONLY);
+            , O_RDONLY | O_CLOEXEC);
             if (fd < 0) {
                 FF_DEBUG("Failed to open memory device: %s", strerror(errno));
                 return NULL;


### PR DESCRIPTION
All *nix systems support this flag, use it as possible as it can. Other programs such as Python and Golang have already defaultly set it.

Look at the Golang's runtime For an example:
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/55c819ef-72e2-4c37-a046-f8af8707dbbc" />
