### PR TITLE
CI: add Winget Releaser workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,3 +938,12 @@ jobs:
           commit: ${{ github.sha }}
           bodyFile: fastfetch-release-notes.md
           allowUpdates: true
+
+      - name: publish to winget
+        if: needs.linux-amd64.outputs.ffversion != steps.get_version_release.outputs.release
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Fastfetch-cli.Fastfetch
+          release-tag: ${{ needs.linux-amd64.outputs.ffversion }}
+          installers-regex: '-windows-\w+\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Reopening from #975 since the windows-aarch64 issue has been resolved now:

> * Continuation of [Packaging for scoop (Windows), Chocolatey (Windows), pkg (FreeBSD) #320 (comment)](https://github.com/fastfetch-cli/fastfetch/issues/320#issuecomment-1404822340)
> 
> [This action](https://github.com/vedantmgoyal2009/winget-releaser?rgh-link-date=2024-05-29T06%3A47%3A57Z) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs?rgh-link-date=2024-05-29T06%3A47%3A57Z)) and submits them.
> 
> Fastfetch has been added to Winget ([microsoft/winget-pkgs#154718](https://github.com/microsoft/winget-pkgs/pull/154718)), and this workflow will be used to update it.
> 
> **Before merging this:**
> 
> 1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.
> 
> ![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)
> 
> 2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs?rgh-link-date=2024-05-29T06%3A47%3A57Z) under @fastfetch-cli. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs?rgh-link-date=2024-05-29T06%3A47%3A57Z) repository on every release.
> 3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.
> 
> If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).

