### PR TITLE
Fix: named tags in format strings not resolving correctly

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -475,7 +475,7 @@
             "type": "string"
         },
         "usersFormat": {
-            "description": "Output format of the module `Users`. See Wiki for formatting syntax\n    1. {name}: User name\n    2. {host-name}: Host name\n    3. {session}: Session name\n    4. {client-ip}: Client IP\n    5. {login-time}: Login Time in local timezone\n    6. {days}: Days after login\n    7. {hours}: Hours after login\n    8. {minutes}: Minutes after login\n    9. {seconds}: Seconds after login\n    10. {milliseconds}: Milliseconds after login\n    11. {years}: Years integer after login\n    12. {days-of-year}: Days of year after login\n    13. {years-fraction}: Years fraction after login",
+            "description": "Output format of the module `Users`. See Wiki for formatting syntax\n    1. {name}: User name\n    2. {host-name}: Host name\n    3. {session-name}: Session name\n    4. {client-ip}: Client IP\n    5. {login-time}: Login Time in local timezone\n    6. {days}: Days after login\n    7. {hours}: Hours after login\n    8. {minutes}: Minutes after login\n    9. {seconds}: Seconds after login\n    10. {milliseconds}: Milliseconds after login\n    11. {years}: Years integer after login\n    12. {days-of-year}: Days of year after login\n    13. {years-fraction}: Years fraction after login",
             "type": "string"
         },
         "versionFormat": {

--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -479,7 +479,7 @@
             "type": "string"
         },
         "versionFormat": {
-            "description": "Output format of the module `Version`. See Wiki for formatting syntax\n    1. {name}: Project name\n    2. {version}: Version\n    3. {version-tweak}: Version tweak\n    4. {build-type}: Build type (debug or release)\n    5. {sysname}: System name\n    6. {arch}: Architecture\n    7. {cmake-built-type}: CMake build type when compiling (Debug, Release, RelWithDebInfo, MinSizeRel)\n    8. {compile-time}: Date time when compiling\n    9. {compiler}: Compiler used when compiling\n    10. {libc}: Libc used when compiling",
+            "description": "Output format of the module `Version`. See Wiki for formatting syntax\n    1. {project-name}: Project name\n    2. {version}: Version\n    3. {version-tweak}: Version tweak\n    4. {build-type}: Build type (debug or release)\n    5. {sysname}: System name\n    6. {arch}: Architecture\n    7. {cmake-built-type}: CMake build type when compiling (Debug, Release, RelWithDebInfo, MinSizeRel)\n    8. {compile-time}: Date time when compiling\n    9. {compiler}: Compiler used when compiling\n    10. {libc}: Libc used when compiling",
             "type": "string"
         },
         "vulkanFormat": {

--- a/src/modules/users/users.c
+++ b/src/modules/users/users.c
@@ -219,7 +219,7 @@ static FFModuleBaseInfo ffModuleInfo = {
     .formatArgs = FF_FORMAT_ARG_LIST(((FFModuleFormatArg[]) {
         {"User name", "name"},
         {"Host name", "host-name"},
-        {"Session name", "session"},
+        {"Session name", "session-name"},
         {"Client IP", "client-ip"},
         {"Login Time in local timezone", "login-time"},
         {"Days after login", "days"},

--- a/src/modules/version/version.c
+++ b/src/modules/version/version.c
@@ -120,7 +120,7 @@ static FFModuleBaseInfo ffModuleInfo = {
     .generateJsonResult = (void*) ffGenerateVersionJsonResult,
     .generateJsonConfig = (void*) ffGenerateVersionJsonConfig,
     .formatArgs = FF_FORMAT_ARG_LIST(((FFModuleFormatArg[]) {
-        {"Project name", "name"},
+        {"Project name", "project-name"},
         {"Version", "version"},
         {"Version tweak", "version-tweak"},
         {"Build type (debug or release)", "build-type"},


### PR DESCRIPTION
After completing the tests, all modules—except for `btrfs`, `gamepad`, `media`, `player`, `poweradapter`, and `zpool`—were found to parse correctly. Issues were identified only in the `version` and `users` modules, both of which have been fixed and now produce the expected output.