### PR TITLE
Fix lliurex detection

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -88,6 +88,20 @@ FF_MAYBE_UNUSED static void getUbuntuFlavour(FFOSResult* result)
         ffStrbufSetStatic(&result->id, "vanilla");
         ffStrbufSetStatic(&result->idLike, "ubuntu");
     }
+    if (ffPathExists("/etc/lliurex-cdd-version", FF_PATHTYPE_FILE))
+	{
+        ffStrbufSetStatic(&result->name, "LliureX");
+        ffStrbufSetStatic(&result->id, "lliurex");
+        ffStrbufClear(&result->version);
+        if (ffProcessAppendStdOut(&result->version, (char* const[]) {
+            "/usr/bin/lliurex-version",
+            NULL,
+        }) == NULL) // 8.2.2
+            ffStrbufTrimRightSpace(&result->versionID);
+        ffStrbufSetF(&result->prettyName, "LliureX %s", result->version.chars);
+        ffStrbufSetStatic(&result->idLike, "ubuntu");
+        return;
+	}
 
     if(ffStrContains(xdgConfigDirs, "kde") || ffStrContains(xdgConfigDirs, "plasma") || ffStrContains(xdgConfigDirs, "kubuntu"))
     {
@@ -166,15 +180,6 @@ FF_MAYBE_UNUSED static void getUbuntuFlavour(FFOSResult* result)
         ffStrbufSetStatic(&result->name, "Ubuntu Touch");
         ffStrbufSetF(&result->prettyName, "Ubuntu Touch %s", result->version.chars);
         ffStrbufSetStatic(&result->id, "ubuntu-touch");
-        ffStrbufSetStatic(&result->idLike, "ubuntu");
-        return;
-    }
-
-    if(ffStrContains(xdgConfigDirs, "lliurex"))
-    {
-        ffStrbufSetStatic(&result->name, "LliureX");
-        ffStrbufSetF(&result->prettyName, "LliureX %s", result->version.chars);
-        ffStrbufSetStatic(&result->id, "lliurex");
         ffStrbufSetStatic(&result->idLike, "ubuntu");
         return;
     }

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -88,6 +88,7 @@ FF_MAYBE_UNUSED static void getUbuntuFlavour(FFOSResult* result)
         ffStrbufSetStatic(&result->id, "vanilla");
         ffStrbufSetStatic(&result->idLike, "ubuntu");
     }
+
     if (ffPathExists("/etc/lliurex-cdd-version", FF_PATHTYPE_FILE))
 	{
         ffStrbufSetStatic(&result->name, "LliureX");


### PR DESCRIPTION
Hi. Some time ago I did a PR for adding support for the Lliurex distribution. After the PR was accepted with changes I didn't test them (sorry for that) because i was facing some troubles and forgot about this but as lliurex is a mix of Ubuntu LTS and Neon the detection based on XDG_CONFIG_DIRS was failing because conflicted with kubutnu as both use plasma as desktop.
This patch fixes this problem checking for the presence of a lliurex-specific file (/etc/lliurex-cdd-version) and getting the version from another specific command of llurex.
I've included the detection code just before the tests for XDG_CONFIG_DIRS because xdg_config_dirs in lliurex also contains "plasma" so any detection mechanism for lliurex must run before the check for kubuntu; also the old detection code has been removed.
Thanks!
