### PR TITLE
Show brand of Xserver in WM section

### DIFF
--- a/src/detection/displayserver/displayserver.c
+++ b/src/detection/displayserver/displayserver.c
@@ -61,6 +61,7 @@ const FFDisplayServerResult* ffConnectDisplayServer()
         ffStrbufInit(&result.wmProtocolName);
         ffStrbufInit(&result.deProcessName);
         ffStrbufInit(&result.dePrettyName);
+        ffStrbufInit(&result.serverVendor);
         ffListInit(&result.displays, sizeof(FFDisplayResult));
         ffConnectDisplayServerImpl(&result);
     }

--- a/src/detection/displayserver/displayserver.h
+++ b/src/detection/displayserver/displayserver.h
@@ -91,6 +91,7 @@ typedef struct FFDisplayServerResult
     FFstrbuf wmProtocolName;
     FFstrbuf deProcessName;
     FFstrbuf dePrettyName;
+    FFstrbuf serverVendor;
     FFlist displays; //List of FFDisplayResult
 } FFDisplayServerResult;
 

--- a/src/detection/displayserver/linux/xcb.c
+++ b/src/detection/displayserver/linux/xcb.c
@@ -6,6 +6,7 @@
 #include "common/time.h"
 #include "util/edidHelper.h"
 #include "util/mallocHelper.h"
+#include "util/stringUtils.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -24,6 +25,9 @@ typedef struct XcbPropertyData
     FF_LIBRARY_SYMBOL(xcb_get_atom_name_name)
     FF_LIBRARY_SYMBOL(xcb_get_atom_name_name_length)
     FF_LIBRARY_SYMBOL(xcb_get_atom_name_reply)
+    FF_LIBRARY_SYMBOL(xcb_get_setup)
+    FF_LIBRARY_SYMBOL(xcb_setup_vendor)
+    FF_LIBRARY_SYMBOL(xcb_setup_vendor_length)
 } XcbPropertyData;
 
 static bool xcbInitPropertyData(FF_MAYBE_UNUSED void* libraryHandle, XcbPropertyData* propertyData)
@@ -38,6 +42,9 @@ static bool xcbInitPropertyData(FF_MAYBE_UNUSED void* libraryHandle, XcbProperty
     FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, xcb_get_atom_name_name, false)
     FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, xcb_get_atom_name_name_length, false)
     FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, xcb_get_atom_name_reply, false)
+    FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, xcb_get_setup, false)
+    FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, xcb_setup_vendor, false)
+    FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, xcb_setup_vendor_length, false)
 
     return true;
 }
@@ -84,6 +91,25 @@ static void xcbDetectWMfromEWMH(XcbPropertyData* data, xcb_connection_t* connect
         return;
 
     ffStrbufSetS(&result->wmProcessName, wmName);
+}
+
+static void xcbFetchServerVendor(XcbPropertyData* data, xcb_connection_t* connection, FFDisplayServerResult* result)
+{
+    const xcb_setup_t* setup = data->ffxcb_get_setup(connection);
+
+    int length = data->ffxcb_setup_vendor_length(setup);
+    if(length <= 0)
+        return;
+
+    //Why are xcb property strings not null terminated???
+    void* replyValue = malloc((size_t)length + 1);
+    memcpy(replyValue, data->ffxcb_setup_vendor(setup), (size_t) length);
+    ((char*) replyValue)[length] = '\0';
+
+    if (ffStrSet(replyValue))
+        ffStrbufSetS(&result->serverVendor, replyValue);
+
+    free(replyValue);
 }
 
 typedef struct XcbRandrData
@@ -381,8 +407,10 @@ const char* ffdsConnectXcbRandr(FFDisplayServerResult* result)
     xcb_screen_iterator_t iterator = ffxcb_setup_roots_iterator(ffxcb_get_setup(data.connection));
 
 
-    if(iterator.rem > 0 && propertyDataInitialized)
+    if(iterator.rem > 0 && propertyDataInitialized) {
         xcbDetectWMfromEWMH(&data.propData, data.connection, iterator.data->root, result);
+        xcbFetchServerVendor(&data.propData, data.connection, result);
+    }
 
 
     while(iterator.rem > 0)

--- a/src/detection/displayserver/linux/xlib.c
+++ b/src/detection/displayserver/linux/xlib.c
@@ -14,6 +14,7 @@ typedef struct X11PropertyData
 {
     FF_LIBRARY_SYMBOL(XInternAtom)
     FF_LIBRARY_SYMBOL(XGetWindowProperty)
+    FF_LIBRARY_SYMBOL(XServerVendor)
     FF_LIBRARY_SYMBOL(XFree)
 } X11PropertyData;
 
@@ -21,6 +22,7 @@ static bool x11InitPropertyData(FF_MAYBE_UNUSED void* libraryHandle, X11Property
 {
     FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, XInternAtom, false)
     FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, XGetWindowProperty, false)
+    FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, XServerVendor, false)
     FF_LIBRARY_LOAD_SYMBOL_PTR(libraryHandle, propertyData, XFree, false)
 
     return true;
@@ -60,6 +62,16 @@ static void x11DetectWMFromEWMH(X11PropertyData* data, Display* display, FFDispl
 
     data->ffXFree(wmName);
     data->ffXFree(wmWindow);
+}
+
+static void x11FetchServerVendor(X11PropertyData* data, Display* display, FFDisplayServerResult* result)
+{
+    if(result->serverVendor.length > 0 || ffStrbufCompS(&result->wmProtocolName, FF_WM_PROTOCOL_WAYLAND) == 0)
+        return;
+
+    const char* serverVendor = data->ffXServerVendor(display);
+    if(ffStrSet(serverVendor))
+        ffStrbufSetS(&result->serverVendor, serverVendor);
 }
 
 typedef struct XrandrData
@@ -305,8 +317,10 @@ const char* ffdsConnectXrandr(FFDisplayServerResult* result)
     if(data.display == NULL)
         return "XOpenDisplay() failed";
 
-    if(propertyDataInitialized && ScreenCount(data.display) > 0)
+    if(propertyDataInitialized && ScreenCount(data.display) > 0) {
         x11DetectWMFromEWMH(&propertyData, data.display, result);
+        x11FetchServerVendor(&propertyData, data.display, result);
+    }
 
     data.result = result;
 

--- a/src/modules/wm/wm.c
+++ b/src/modules/wm/wm.c
@@ -42,6 +42,13 @@ void ffPrintWM(FFWMOptions* options)
             putchar(')');
         }
 
+        if(result->serverVendor.length > 0)
+        {
+            fputs(" [", stdout);
+            ffStrbufWriteTo(&result->serverVendor, stdout);
+            putchar(']');
+        }
+
         if(pluginName.length > 0)
         {
             fputs(" (with ", stdout);


### PR DESCRIPTION
Putting it in square brackets next to the WM seemed like the most logical choice after looking at how icon and font information is displayed. If you want any changes made, just tell me and I'll take care of it.

<img width="232" height="62" alt="image" src="https://github.com/user-attachments/assets/e0017e01-3897-4952-b520-e1409c565dd4" />
