### PR TITLE
Logo (Builtin): add ObsidianOS

### DIFF
--- a/src/logo/ascii/obsidianos.txt
+++ b/src/logo/ascii/obsidianos.txt
@@ -1,0 +1,19 @@
+                  $1-`$2
+                 .$1o+`$2
+                `o$1oo/$2
+               `+o$1ooo:$2
+              `+oo$1oooo:$2
+              -+oo$1oooo+:$2
+            `/:-:+$1+oooo+:$2
+           `/++++/$1+++++++:$2
+          `/++++++$1++++++++:$2
+         `/+++oooo$1ooooooooo/`$2
+        ./ooosssso$1++osssssso+`$2
+       .oossssso-`$1```/ossssss+`$2
+      -osssssso.  $1    :ssssssso.$2
+     :osssssss/   $1     osssso+++.$2
+    /ossssssss/   $1     +ssssooo/-$2
+  `/ossssso+/:-   $1     -:/+osssso+-$2
+ `+sso+:-`        $1         `.-/+oso:$2
+`++:.             $1              `-/+/$2
+.`                $1                 `/$2

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -3392,6 +3392,15 @@ static const FFlogo O[] = {
             FF_COLOR_FG_WHITE,
         },
     },
+    // ObsidianOS
+    {
+        .names = {"ObsidianOS"},
+        .lines = FASTFETCH_DATATEXT_LOGO_OBSIDIANOS,
+        .colors = {
+            FF_COLOR_FG_MAGENTA,
+            FF_COLOR_FG_CYAN,
+        },
+    },
     // OmniOS
     {
         .names = {"OmniOS"},


### PR DESCRIPTION
Add support for ObsidianOS logo.

More info about ObsidianOS:
An Arch-based distro with A/B Partition Layout. [Website](https://obsidian-os.github.io), [GitHub Organization](https://github.com/Obsidian-OS), [Docs](https://obsidian-os.github.io/docs)

Screenshot (on VM):
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/0a00fd15-34e2-4549-985b-2b11f6b059d4" />

`/etc/os-release`:
```
NAME="ObsidianOS"
PRETTY_NAME="Obsidian GNU/Linux"
ID=obsidian
BUILD_ID=rolling
ANSI_COLOR=38;2;138;43;226
HOME_URL="https://github.com/obsidian-os"
DOCUMENTATION_URL="https://obsidian-os.github.io/docs"
SUPPORT_URL="https://github.com/orgs/Obsidian-OS/discussions"
BUG_REPORT_URL="https://github.com/obsidian-os/issue-tracker/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=obsidianos
```

**Build tested only on Arch, should work on all of em tho**

Hope to see it get merged :)