### PR TITLE
Fix(packages): Add detection path for Linglong on Debian, issue #1898

### DIFF
--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -446,7 +446,12 @@ static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts,
     {
       packageCounts->guixSystem += getGuixPackages(baseDir, "/run/current-system/profile");
     }
-    if (!(options->disabled & FF_PACKAGES_FLAG_LINGLONG_BIT)) packageCounts->linglong += getNumElements(baseDir, "/var/lib/linglong/repo/refs/heads/main", true);
+    if (!(options->disabled & FF_PACKAGES_FLAG_LINGLONG_BIT))
+    {
+        packageCounts->linglong += getNumElements(baseDir, "/var/lib/linglong/repo/refs/heads/main", true);
+        if (packageCounts->linglong == 0)
+            packageCounts->linglong += getNumElements(baseDir, "/var/lib/linglong/repo/refs/remotes/stable/main", true);
+    }
     if (!(options->disabled & FF_PACKAGES_FLAG_PACSTALL_BIT)) packageCounts->pacstall += getNumElements(baseDir, "/var/lib/pacstall/metadata", false);
     if (!(options->disabled & FF_PACKAGES_FLAG_PISI_BIT)) packageCounts->pisi += getNumElements(baseDir, "/var/lib/pisi/package", true);
     if (!(options->disabled & FF_PACKAGES_FLAG_PKGSRC_BIT)) packageCounts->pkgsrc += getNumElements(baseDir, "/usr/pkg/pkgdb", DT_DIR);


### PR DESCRIPTION
This PR resolves an issue where Linglong packages were not detected on Debian 13 systems when installed from the official repository provided by the Deepin team.

Fixes  #1898 

## Problem

The original detection logic only checked for Linglong packages in the `/var/lib/linglong/repo/refs/heads/main` directory. However, on Debian 13 with Linglong installed from Deepin's repo, the packages are located in `/var/lib/linglong/repo/refs/remotes/stable/main`.

## Solution

This change adds a fallback check. It first attempts to count packages in the original `heads/main` path. If the count is zero, it then checks the `remotes/stable/main` path. This ensures compatibility with both installation methods.

## Verification

```
[100%] Built target fastfetch
        _,met$$$$$gg.
     ,g$$$$$$$$$$$$$$$P.
   ,g$$P""       """Y$$.".
  ,$$P'              `$$$.
',$$P       ,ggs.     `$$b:
`d$$'     ,$P"'   .    $$$
 $$P      d$'     ,    $$P
 $$:      $$.   -    ,d$$'
 $$;      Y$b._   _,d$P'       glqyu@GLQY-Debian
 Y$$.    `.`"Y$$$$P"'          -----------------
 `$$b      "-.__               OS: Debian GNU/Linux 13 (trixie) x86_64
  `Y$$b                        Host: ASUS TUF Gaming A15 FA506QM_FA506QM (1.0)
   `Y$$.                       Kernel: Linux 6.12.38+deb13-amd64
     `$$b.                     Uptime: 2 hours, 12 mins
       `Y$$b.                  Packages: 3369 (dpkg), 11 (flatpak), 2 (linglong)
         `"Y$b._               Shell: bash 5.2.37
             `""""             Display (NE156QHM-NY1): 2560x1440 @ 60 Hz in 16" [Built-in]
                               DE: KDE Plasma 6.3.6
                               WM: KWin (Wayland)
                               WM Theme: Breeze
                               Theme: Breeze (Dark) [Qt], Breeze-Dark [GTK2], Breeze [GTK3]
                               Icons: breeze-dark [Qt], breeze-dark [GTK2/3/4]
                               Font: Noto Sans (10pt) [Qt], Noto Sans (10pt) [GTK2/3/4]
                               Cursor: breeze (24px)
                               Terminal: code 1.103.1
                               CPU: AMD Ryzen 7 5800H (16) @ 4.46 GHz
                               GPU 1: NVIDIA GeForce RTX 3060 Mobile / Max-Q [Discrete]
                               GPU 2: AMD Radeon Vega Series / Radeon Vega Mobile Series []
                               Memory: 8.38 GiB / 58.77 GiB (14%)
                               Swap: 0 B / 1024.00 MiB (0%)
                               Disk (/): 108.27 GiB / 223.00 GiB (49%) - ext4
                               Disk (/media/glqyu/Data): 1.76 TiB / 1.85 TiB (95%) - ntfs3

                               Battery (A32-K55): 100% [AC Connected]
                               Locale: zh_CN.UTF-8
```

The fix is confirmed to work on my system.