### PR TITLE
FFstrbuf: wrap yyjson.h include in conditional

### DIFF
--- a/src/util/FFstrbuf.h
+++ b/src/util/FFstrbuf.h
@@ -9,7 +9,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include "3rdparty/yyjson/yyjson.h"
+
+#ifdef FF_USE_SYSTEM_YYJSON
+    #include <yyjson.h>
+#else
+    #include "3rdparty/yyjson/yyjson.h"
+#endif
 
 #ifdef _WIN32
     // #include <shlwapi.h>


### PR DESCRIPTION
ATM, with `-DENABLE_SYSTEM_YYJSON=ON` it results in following build error:

```
starting phase `configure'
source directory: "/tmp/guix-build-fastfetch-2.50.1.drv-0/source" (relative from build: "../source")
build directory: "/tmp/guix-build-fastfetch-2.50.1.drv-0/build"
running 'cmake' with arguments ("../source" "-C /tmp/guix-build-fastfetch-2.50.1.drv-0/guix-file.QIaBXM" "-GUnix Makefiles" "-DENABLE_SYSTEM_YYJSON=ON" "-DBUILD_FLASHFETCH=OFF" "-DBUILD_TESTS=ON" "-DINSTALL_LICENSE=OFF" "-DBINARY_LINK_TYPE=dynamic" "-DENABLE_DIRECTX_HEADERS=OFF" "-DCUSTOM_PCI_IDS_PATH=/gnu/store/91vw5x8n88jfyc2f8lmhl7spsbgmk5z5-hwdata-0.392/share/hwdata/pci.ids" "-DCUSTOM_AMDGPU_IDS_PATH=/gnu/store/imqddvckw5vz7s9is35z1z6ciwyv85c5-libdrm-2.4.124/share/libdrm/amdgpu.ids")
loading initial cache file /tmp/guix-build-fastfetch-2.50.1.drv-0/guix-file.QIaBXM
-- The C compiler identification is GNU 14.3.0
-- Detecting C compiler ABI info
...
/tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/common/printing.c
/gnu/store/jb4szkjkmlqdc92nnhxvm9ypq6hvk9vw-gcc-14.3.0/bin/gcc -DFF_CUSTOM_AMDGPU_IDS_PATH=/gnu/store/imqddvckw5vz7s9is35z1z6ciwyv85c5-libdrm-2.4.124/share/libdrm/amdgpu.ids -DFF_CUSTOM_PCI_IDS_PATH=/gnu/store/91vw5x8n88jfyc2f8lmhl7spsbgmk5z5-hwdata-0.392/share/hwdata/pci.ids -DFF_DISABLE_DLOPEN=1 -DFF_HAVE_DBUS=1 -DFF_HAVE_DRM=1 -DFF_HAVE_DRM_AMDGPU=1 -DFF_HAVE_EGL=1 -DFF_HAVE_GIO=1 -DFF_HAVE_GLOB=1 -DFF_HAVE_IMAGEMAGICK6=1 -DFF_HAVE_LINUX_VIDEODEV2=1 -DFF_HAVE_LINUX_WIRELESS=1 -DFF_HAVE_PIPE2 -DFF_HAVE_STATX -DFF_HAVE_THREADS=1 -DFF_HAVE_TIMEDJOIN_NP=1 -DFF_HAVE_UTMPX=1 -DFF_HAVE_WAYLAND=1 -DFF_HAVE_WCWIDTH -DFF_HAVE_WORDEXP=1 -DFF_HAVE_XCB_RANDR=1 -DFF_HAVE_ZLIB=1 -DFF_PACKAGES_DISABLE_LIST=FF_PACKAGES_FLAG_WINGET_BIT -DFF_USE_SYSTEM_YYJSON -DMAGICKCORE_HDRI_ENABLE=0 -DMAGICKCORE_QUANTUM_DEPTH=16 -D_ATFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_TIME_BITS=64 -D_XOPEN_SOURCE -D__STDC_WANT_LIB_EXT1__ -I/gnu/store/imqddvckw5vz7s9is35z1z6ciwyv85c5-libdrm-2.4.124/include/libdrm -I/gnu/store/03wgdb4480fffhczj7kdxzvhpx3rfbr1-glib-2.83.3/include/glib-2.0 -I/gnu/store/03wgdb4480fffhczj7kdxzvhpx3rfbr1-glib-2.83.3/lib/glib-2.0/include -I/gnu/store/mp1biwg967ivg8bff65qskyc88d1ypwc-util-linux-2.40.4-lib/include/libmount -I/gnu/store/mp1biwg967ivg8bff65qskyc88d1ypwc-util-linux-2.40.4-lib/include/blkid -I/gnu/store/4g398598mvlfh5kmg96l9v2g3l77czvs-dbus-1.15.8/include/dbus-1.0 -I/gnu/store/4g398598mvlfh5kmg96l9v2g3l77czvs-dbus-1.15.8/lib/dbus-1.0/include -I/gnu/store/3psqmny29dqmyrj34n5c7fybxisdcq6v-imagemagick-6.9.13-5/include/ImageMagick-6 -I/tmp/guix-build-fastfetch-2.50.1.drv-0/build -I/tmp/guix-build-fastfetch-2.50.1.drv-0/source/src -Wall -Wextra -Wconversion -Werror=uninitialized -Werror=return-type -Werror=vla -Werror=incompatible-pointer-types -Werror=implicit-function-declaration -Werror=int-conversion -O2 -g -DNDEBUG -std=gnu11 -flto=auto -fno-fat-lto-objects -fdiagnostics-color=always -MD -MT CMakeFiles/libfastfetch.dir/src/common/properties.c.o -MF CMakeFiles/libfastfetch.dir/src/common/properties.c.o.d -o CMakeFiles/libfastfetch.dir/src/common/properties.c.o -c /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/common/properties.c
In file included from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/common/option.h:3,
                 from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/modules/battery/option.h:3,
                 from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/modules/battery/battery.h:3,
                 from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/modules/modules.h:3,
                 from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/common/modules.c:1:
/tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/util/FFstrbuf.h:12:10: fatal error: 3rdparty/yyjson/yyjson.h: No such file or directory
   12 | #include "3rdparty/yyjson/yyjson.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/libfastfetch.dir/build.make:194: CMakeFiles/libfastfetch.dir/src/common/modules.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/fastfetch.h:18,
                 from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/common/netif/netif.h:3,
                 from /tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/common/netif/netif.c:1:
/tmp/guix-build-fastfetch-2.50.1.drv-0/source/src/util/FFstrbuf.h:12:10: fatal error: 3rdparty/yyjson/yyjson.h: No such file or directory
   12 | #include "3rdparty/yyjson/yyjson.h"
 ```

This PR fixes it.