### PR TITLE
Replace Manual Alphanumeric Check

### DIFF
--- a/src/util/stringUtils.h
+++ b/src/util/stringUtils.h
@@ -72,12 +72,12 @@ static inline bool ffStrContainsC(const char* str, char compareTo)
 
 static inline bool ffCharIsEnglishAlphabet(char c)
 {
-    return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
+    return isalpha(c);
 }
 
 static inline bool ffCharIsDigit(char c)
 {
-    return '0' <= c && c <= '9';
+    return isalnum(c);
 }
 
 // Copies at most (dstBufSiz - 1) bytes from src to dst; dst is always null-terminated


### PR DESCRIPTION
Instead check if character is alphabet letter or number manually, we can utilize functions from C standard library.