### PR TITLE
Chore (Windows): standardize more windows header casing.

### DIFF
--- a/src/detection/wm/wm_windows.cpp
+++ b/src/detection/wm/wm_windows.cpp
@@ -12,7 +12,7 @@ extern "C"
 #include <windows.h>
 #include <tlhelp32.h>
 #include <shlobj.h>
-#include <Propkey.h>
+#include <propkey.h>
 
 template <typename Fn>
 struct on_scope_exit {


### PR DESCRIPTION
Followup to 25353261d0a7be7bbccc6bb78146af7a2c9f15dc

Fastfetch now builds with an ucrt mingw  from linux without errors. Have not tested it on actual windows yet.

With wine  it seems to work with the default config when excluding the localip module (this looks like a limitation of wine)