### PR TITLE
Don't flush terminal input when querying checking window size

### DIFF
--- a/src/common/io/io_unix.c
+++ b/src/common/io/io_unix.c
@@ -177,7 +177,11 @@ static int ftty = -1;
 static struct termios oldTerm;
 void restoreTerm(void)
 {
-    tcsetattr(ftty, TCSAFLUSH, &oldTerm);
+    tcsetattr(ftty, TCSANOW, &oldTerm);
+}
+
+static size_t min(size_t left, size_t right) {
+    return left < right ? left : right;
 }
 
 const char* ffGetTerminalResponse(const char* request, int nParams, const char* format, ...)
@@ -193,8 +197,8 @@ const char* ffGetTerminalResponse(const char* request, int nParams, const char* 
 
         struct termios newTerm = oldTerm;
         newTerm.c_lflag &= (tcflag_t) ~(ICANON | ECHO);
-        if(tcsetattr(ftty, TCSAFLUSH, &newTerm) == -1)
-            return "tcsetattr(STDIN_FILENO, TCSAFLUSH, &newTerm)";
+        if(tcsetattr(ftty, TCSANOW, &newTerm) == -1)
+            return "tcsetattr(STDIN_FILENO, TCSANOW, &newTerm)";
         atexit(restoreTerm);
     }
 
@@ -224,7 +228,8 @@ const char* ffGetTerminalResponse(const char* request, int nParams, const char* 
 
     while (true)
     {
-        ssize_t nRead = read(ftty, buffer + bytesRead, sizeof(buffer) - bytesRead - 1);
+        ssize_t nRead = read(ftty, buffer + bytesRead,
+                             min(1, sizeof(buffer) - bytesRead - 1));
 
         if (nRead <= 0)
         {


### PR DESCRIPTION
As reported in https://github.com/MidnightCommander/mc/issues/4789,
after Midnight Commander starts a shell, it writes some characters
to the shells stdin, to initialize it.

Since mc doesn't know when shell initialization
(e.g. .bashrc), it doesn't wait for that.
Hence mc's commands race with bashrc.

This surfaces reliably when running fastfetch from .bashrc with a *.png
logo.  Writing the logo involves a call to ffDetectTerminalSize(),
which queries /dev/tty.

It first flushes (TCSAFLUSH) the input since a0705197 (IO: disallow
input echo, 2024-07-31), which removes the input queued by mc.

Then it reads from the TTY 1024 bytes at a time.
This is also bad because it might swallow key presses
made by the user.

So maybe
1. Don't flush.
2. Reduce the likelihood of swallowing users's key presses by reading
   only one byte at a time.

Note that with or without TCSAFLUSH,
our query responses might be interspersed with keyboard input.
Though I guess TCSAFLUSH makes this less likely.