### PR TITLE
Display: fix an uninitialized FFDisplayOptions field

### DIFF
--- a/src/modules/display/display.c
+++ b/src/modules/display/display.c
@@ -436,6 +436,7 @@ void ffInitDisplayOptions(FFDisplayOptions* options)
     ffOptionInitModuleArg(&options->moduleArgs, "󰍹");
     options->compactType = FF_DISPLAY_COMPACT_TYPE_NONE;
     options->preciseRefreshRate = false;
+    options->order = FF_DISPLAY_ORDER_NONE;
 }
 
 void ffDestroyDisplayOptions(FFDisplayOptions* options)


### PR DESCRIPTION
The `order` field of `FFDisplayOptions` was not initialized before being used:
<img width="567" height="395" alt="image" src="https://github.com/user-attachments/assets/23e9e3ac-9d2d-404f-ae43-ae9b63ee47cc" />