### PR TITLE
add kiss packages count

### DIFF
--- a/src/detection/packages/packages.h
+++ b/src/detection/packages/packages.h
@@ -21,6 +21,7 @@ typedef struct FFPackagesResult
     uint32_t guixUser;
     uint32_t hpkgSystem;
     uint32_t hpkgUser;
+    uint32_t kiss;
     uint32_t linglong;
     uint32_t lpkg;
     uint32_t lpkgbuild;

--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -420,6 +420,7 @@ static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts,
     if (!(options->disabled & FF_PACKAGES_FLAG_EMERGE_BIT)) packageCounts->emerge += countFilesRecursive(baseDir, "/var/db/pkg", "SIZE");
     if (!(options->disabled & FF_PACKAGES_FLAG_EOPKG_BIT)) packageCounts->eopkg += getNumElements(baseDir, "/var/lib/eopkg/package", true);
     if (!(options->disabled & FF_PACKAGES_FLAG_FLATPAK_BIT)) packageCounts->flatpakSystem += getFlatpakPackages(baseDir, "/var/lib");
+    if (!(options->disabled & FF_PACKAGES_FLAG_KISS_BIT)) packageCounts->kiss += getNumElements(baseDir, "/var/db/kiss/installed", true);
     if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT))
     {
         packageCounts->nixDefault += ffPackagesGetNix(baseDir, "/nix/var/nix/profiles/default");

--- a/src/modules/packages/option.h
+++ b/src/modules/packages/option.h
@@ -36,6 +36,7 @@ typedef enum __attribute__((__packed__)) FFPackagesFlags
     FF_PACKAGES_FLAG_HPKG_BIT = 1ULL << 28,
     FF_PACKAGES_FLAG_PISI_BIT = 1ULL << 29,
     FF_PACKAGES_FLAG_SOAR_BIT = 1ULL << 30,
+    FF_PACKAGES_FLAG_KISS_BIT = 1ULL << 31,
     FF_PACKAGES_FLAG_FORCE_UNSIGNED = UINT64_MAX,
 } FFPackagesFlags;
 static_assert(sizeof(FFPackagesFlags) == sizeof(uint64_t), "");

--- a/src/modules/packages/packages.c
+++ b/src/modules/packages/packages.c
@@ -76,6 +76,7 @@ bool ffPrintPackages(FFPackagesOptions* options)
         FF_PRINT_PACKAGE(apk)
         FF_PRINT_PACKAGE(pkg)
         FF_PRINT_PACKAGE(pkgsrc)
+        FF_PRINT_PACKAGE(kiss)
         if (options->combined)
         {
             FF_PRINT_PACKAGE_ALL(hpkg)
@@ -194,6 +195,7 @@ bool ffPrintPackages(FFPackagesOptions* options)
             FF_FORMAT_ARG(counts.hpkgUser, "hpkg-user"),
             FF_FORMAT_ARG(counts.pisi, "pisi"),
             FF_FORMAT_ARG(counts.soar, "soar"),
+            FF_FORMAT_ARG(counts.kiss, "kiss"),
             FF_FORMAT_ARG(nixAll, "nix-all"),
             FF_FORMAT_ARG(flatpakAll, "flatpak-all"),
             FF_FORMAT_ARG(brewAll, "brew-all"),
@@ -267,6 +269,9 @@ void ffParsePackagesJsonObject(FFPackagesOptions* options, yyjson_val* module)
                             break;
                         case 'H': if (false);
                             FF_TEST_PACKAGE_NAME(HPKG)
+                            break;
+                        case 'K': if (false);
+                            FF_TEST_PACKAGE_NAME(KISS)
                             break;
                         case 'L': if (false);
                             FF_TEST_PACKAGE_NAME(LPKG)
@@ -346,6 +351,7 @@ void ffGeneratePackagesJsonConfig(FFPackagesOptions* options, yyjson_mut_doc* do
     FF_TEST_PACKAGE_NAME(FLATPAK)
     FF_TEST_PACKAGE_NAME(GUIX)
     FF_TEST_PACKAGE_NAME(HPKG)
+    FF_TEST_PACKAGE_NAME(KISS)
     FF_TEST_PACKAGE_NAME(LINGLONG)
     FF_TEST_PACKAGE_NAME(LPKG)
     FF_TEST_PACKAGE_NAME(LPKGBUILD)
@@ -425,6 +431,7 @@ bool ffGeneratePackagesJsonResult(FF_MAYBE_UNUSED FFPackagesOptions* options, yy
     FF_APPEND_PACKAGE_COUNT(scoopGlobal)
     FF_APPEND_PACKAGE_COUNT(snap)
     FF_APPEND_PACKAGE_COUNT(soar)
+    FF_APPEND_PACKAGE_COUNT(kiss)
     FF_APPEND_PACKAGE_COUNT(sorcery)
     FF_APPEND_PACKAGE_COUNT(winget)
     FF_APPEND_PACKAGE_COUNT(xbps)
@@ -498,6 +505,7 @@ FFModuleBaseInfo ffPackagesModuleInfo = {
         {"Number of hpkg-user packages", "hpkg-user"},
         {"Number of pisi packages", "pisi"},
         {"Number of soar packages", "soar"},
+        {"Number of kiss packages", "kiss"},
         {"Total number of all nix packages", "nix-all"},
         {"Total number of all flatpak app packages", "flatpak-all"},
         {"Total number of all brew packages", "brew-all"},


### PR DESCRIPTION
Sorry to bother you, but this PR adds the kiss packages count support.
I knew the mainline of kiss linux and kiss package manager is dead. but it is still maintaining by unofficial community: https://kisscommunity.org/ , so I don't think it should be abandoned.
I promise I have tested this on my machine, its works fine.
I can't programming well, so I'm not sure if it can be used, I'm so sorry.
<img width="868" height="562" alt="output" src="https://github.com/user-attachments/assets/3f0dac51-c3a8-44fe-be2c-3aec4a4cce2e" />
