### PR TITLE
Fix comment for AerynOS in builtin.c

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -39,7 +39,7 @@ static const FFlogo A[] = {
             FF_COLOR_FG_256 "36",
         },
     },
-    // Aeon
+    // AerynOS
     {
         .names = {"AerynOS"},
         .lines = FASTFETCH_DATATEXT_LOGO_AERYNOS,


### PR DESCRIPTION
Changes the comment for AerynOS which said Aeon 