### PR TITLE
CPU(Linux): Fix build on GNU.

### DIFF
--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -14,6 +14,10 @@
 
 #define FF_CPUINFO_PATH "/proc/cpuinfo"
 
+#ifndef O_PATH
+#define O_PATH 0
+#endif
+
 static double readTempFile(int dfd, const char* filename, FFstrbuf* buffer)
 {
     if (filename ? !ffReadFileBufferRelative(dfd, filename, buffer) : !ffReadFDBuffer(dfd, buffer))


### PR DESCRIPTION
There is no O_PATH.

The cpu temperature does not work anyway as there is no /sys and I dont know if this info is reported somewhere.

The /proc/cpuinfo part could be factored out into a sepearte file but I am not sure if this is a good idea.