### PR TITLE
Chore (Windows): Standardize windows header casing.

### DIFF
--- a/src/detection/packages/packages_windows.c
+++ b/src/detection/packages/packages_windows.c
@@ -6,7 +6,7 @@
 #include "util/mallocHelper.h"
 #include "common/io/io.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include "util/windows/nt.h"
 #include <ntstatus.h>
 


### PR DESCRIPTION
Followup to 0b6ca158eae90acb9af984feae5a56e529ffca15.