### PR TITLE
Fix strict-aliasing warning in gpu_wsl.cpp

### DIFF
--- a/src/detection/gpu/gpu_wsl.cpp
+++ b/src/detection/gpu/gpu_wsl.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include <dxguids/dxguids.h>
 #include <utility>
 #include <cinttypes>
+#include <cstring>
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 
@@ -83,7 +84,9 @@ const char* ffGPUDetectByDirectX(FF_MAYBE_UNUSED const FFGPUOptions* options, FF
         if (SUCCEEDED(adapter->GetProperty(DXCoreAdapterProperty::InstanceLuid, sizeof(luid), &luid)))
         {
             static_assert(sizeof(luid) == sizeof(uint64_t), "LUID size mismatch");
-            gpu->deviceId = ffGPUGeneral2Id(*(uint64_t*)&luid);
+            uint64_t luidInt;
+            memcpy(&luidInt, &luid, sizeof(luid));
+            gpu->deviceId = ffGPUGeneral2Id(luidInt);
         }
 
         ffStrbufInit(&gpu->driver);


### PR DESCRIPTION
Replace unsafe pointer type punning with memcpy when converting LUID to uint64_t. This resolves a `-Wstrict-aliasing` warning where `*(uint64_t*)&luid` was dereferencing a type-punned pointer.

- Added `<cstring>` include for `memcpy`.
- Replaced reinterpret cast with `memcpy` for safe type conversion.