### PR TITLE
JsonSchema: correct references for keyboard, mouse items

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -2964,8 +2964,11 @@
                                     "keyWidth": {
                                         "$ref": "#/$defs/keyWidth"
                                     },
+                                    "outputColor": {
+                                        "$ref": "#/$defs/outputColor"
+                                    },
                                     "format": {
-                                        "$ref": "#/$defs/memoryFormat"
+                                        "$ref": "#/$defs/keyboardFormat"
                                     },
                                     "condition": {
                                         "$ref": "#/$defs/conditions"
@@ -3296,8 +3299,11 @@
                                     "keyWidth": {
                                         "$ref": "#/$defs/keyWidth"
                                     },
+                                    "outputColor": {
+                                        "$ref": "#/$defs/outputColor"
+                                    },
                                     "format": {
-                                        "$ref": "#/$defs/memoryFormat"
+                                        "$ref": "#/$defs/mouseFormat"
                                     },
                                     "condition": {
                                         "$ref": "#/$defs/conditions"


### PR DESCRIPTION
- corrected format references from memoryFormat to keyboardFormat and mouseFormat respectively
- added outputColor to both since it appears to be supported for keyboard and mouse items too