### PR TITLE
Add BIOS vendor/version, Board vendor/revision, and Security module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,10 +149,14 @@ else()
     message(STATUS "Threads type: disabled")
 endif()
 
-set(WARNING_FLAGS "-Wall -Wextra -Wconversion -Werror=uninitialized -Werror=return-type -Werror=vla")
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(WARNING_FLAGS "-Wall -Wextra -Wconversion -Werror=uninitialized -Werror=return-type -Werror=vla")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS} -Werror=incompatible-pointer-types -Werror=implicit-function-declaration -Werror=int-conversion")
+else()
+    set(WARNING_FLAGS "")
+endif()
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNING_FLAGS} -Werror=incompatible-pointer-types -Werror=implicit-function-declaration -Werror=int-conversion")
 
 if(WIN32 OR Haiku OR ENABLE_DIRECTX_HEADERS)
     enable_language(CXX)
@@ -161,20 +165,27 @@ if(WIN32 OR Haiku OR ENABLE_DIRECTX_HEADERS)
 endif()
 
 if(WIN32)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--tsaware -Wl,--build-id -Wl,--subsystem,console:6.1,--major-os-version,6,--minor-os-version,1")
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--tsaware -Wl,--build-id -Wl,--subsystem,console:6.1,--major-os-version,6,--minor-os-version,1")
+    else()
+        # MSVC linker flags
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:CONSOLE,6.1")
+    endif()
 elseif(APPLE AND CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fobjc-arc")
 endif()
 
-set(FASTFETCH_FLAGS_DEBUG "-fno-omit-frame-pointer")
-if(ENABLE_ASAN)
-    message(STATUS "Address sanitizer enabled (DEBUG only)")
-    set(FASTFETCH_FLAGS_DEBUG "${FASTFETCH_FLAGS_DEBUG} -fsanitize=address")
-endif()
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${FASTFETCH_FLAGS_DEBUG}")
-set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${FASTFETCH_FLAGS_DEBUG} -fstack-protector-all -fno-delete-null-pointer-checks")
-if(NOT WIN32)
-    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -rdynamic")
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set(FASTFETCH_FLAGS_DEBUG "-fno-omit-frame-pointer")
+    if(ENABLE_ASAN)
+        message(STATUS "Address sanitizer enabled (DEBUG only)")
+        set(FASTFETCH_FLAGS_DEBUG "${FASTFETCH_FLAGS_DEBUG} -fsanitize=address")
+    endif()
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${FASTFETCH_FLAGS_DEBUG}")
+    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${FASTFETCH_FLAGS_DEBUG} -fstack-protector-all -fno-delete-null-pointer-checks")
+    if(NOT WIN32)
+        set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -rdynamic")
+    endif()
 endif()
 
 if(ENABLE_LTO AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -467,6 +478,7 @@ set(LIBFASTFETCH_SRC
     src/modules/publicip/publicip.c
     src/modules/display/display.c
     src/modules/separator/separator.c
+    src/modules/security/security.c
     src/modules/shell/shell.c
     src/modules/sound/sound.c
     src/modules/swap/swap.c
@@ -514,6 +526,7 @@ if(LINUX)
         src/detection/board/board_linux.c
         src/detection/bootmgr/bootmgr_linux.c
         src/detection/brightness/brightness_linux.c
+        src/detection/security/security_linux.c
         src/detection/btrfs/btrfs_linux.c
         src/detection/chassis/chassis_linux.c
         src/detection/cpu/cpu_linux.c
@@ -600,6 +613,7 @@ elseif(ANDROID)
         src/detection/board/board_android.c
         src/detection/bootmgr/bootmgr_nosupport.c
         src/detection/brightness/brightness_nosupport.c
+        src/detection/security/security_nosupport.c
         src/detection/btrfs/btrfs_nosupport.c
         src/detection/chassis/chassis_nosupport.c
         src/detection/cpu/cpu_linux.c
@@ -1002,6 +1016,7 @@ elseif(WIN32)
         src/detection/board/board_windows.c
         src/detection/bootmgr/bootmgr_windows.c
         src/detection/brightness/brightness_windows.cpp
+        src/detection/security/security_windows.c
         src/detection/btrfs/btrfs_nosupport.c
         src/detection/chassis/chassis_windows.c
         src/detection/cpu/cpu_windows.c
@@ -1073,6 +1088,7 @@ elseif(SunOS)
         src/detection/board/board_windows.c
         src/detection/bootmgr/bootmgr_nosupport.c
         src/detection/brightness/brightness_nosupport.c
+        src/detection/security/security_nosupport.c
         src/detection/btrfs/btrfs_nosupport.c
         src/detection/chassis/chassis_windows.c
         src/detection/cpu/cpu_sunos.c
@@ -1154,6 +1170,7 @@ elseif(Haiku)
         src/detection/board/board_windows.c
         src/detection/bootmgr/bootmgr_nosupport.c
         src/detection/brightness/brightness_nosupport.c
+        src/detection/security/security_nosupport.c
         src/detection/btrfs/btrfs_nosupport.c
         src/detection/chassis/chassis_windows.c
         src/detection/cpu/cpu_haiku.c
@@ -1223,6 +1240,7 @@ elseif(GNU)
         src/detection/board/board_nosupport.c
         src/detection/bootmgr/bootmgr_nosupport.c
         src/detection/brightness/brightness_nosupport.c
+        src/detection/security/security_nosupport.c
         src/detection/btrfs/btrfs_nosupport.c
         src/detection/chassis/chassis_nosupport.c
         src/detection/cpu/cpu_linux.c

--- a/src/common/modules.c
+++ b/src/common/modules.c
@@ -126,6 +126,7 @@ static FFModuleBaseInfo* R[] = {
 
 static FFModuleBaseInfo* S[] = {
     &ffSeparatorModuleInfo,
+    &ffSecurityModuleInfo,
     &ffShellModuleInfo,
     &ffSoundModuleInfo,
     &ffSwapModuleInfo,

--- a/src/data/structure.txt
+++ b/src/data/structure.txt
@@ -1,1 +1,1 @@
-Title:Separator:OS:Host:Kernel:Uptime:Packages:Shell:Display:DE:WM:WMTheme:Theme:Icons:Font:Cursor:Terminal:TerminalFont:CPU:GPU:Memory:Swap:Disk:LocalIp:Battery:PowerAdapter:Locale:Break:Colors
+Title:Separator:OS:Host:Bios:Board:Security:Kernel:Uptime:Packages:Shell:Display:DE:WM:WMTheme:Theme:Icons:Font:Cursor:Terminal:TerminalFont:CPU:GPU:Memory:Swap:Disk:LocalIp:Battery:PowerAdapter:Locale:Break:Colors

--- a/src/detection/security/security.h
+++ b/src/detection/security/security.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "fastfetch.h"
+#include "modules/security/option.h"
+
+typedef struct FFSecurityResult
+{
+    FFstrbuf tpmStatus;
+    FFstrbuf secureBootStatus;
+} FFSecurityResult;
+
+const char* ffDetectSecurity(FFSecurityResult* result);

--- a/src/detection/security/security_linux.c
+++ b/src/detection/security/security_linux.c
@@ -1,0 +1,53 @@
+#include "security.h"
+#include "detection/tpm/tpm.h"
+#include "detection/bootmgr/bootmgr.h"
+
+const char* ffDetectSecurity(FFSecurityResult* result)
+{
+    ffStrbufInit(&result->tpmStatus);
+    ffStrbufInit(&result->secureBootStatus);
+
+    // Detect TPM
+    FFTPMResult tpm = {
+        .version = ffStrbufCreate(),
+        .description = ffStrbufCreate()
+    };
+    const char* tpmError = ffDetectTPM(&tpm);
+    if (tpmError == NULL)
+    {
+        if (tpm.version.length > 0)
+            ffStrbufSetF(&result->tpmStatus, "TPM %s", tpm.version.chars);
+        else
+            ffStrbufSetStatic(&result->tpmStatus, "TPM OK");
+    }
+    else
+    {
+        ffStrbufSetStatic(&result->tpmStatus, "TPM Not Available");
+    }
+    ffStrbufDestroy(&tpm.version);
+    ffStrbufDestroy(&tpm.description);
+
+    // Detect Secure Boot
+    FFBootmgrResult bootmgr = {
+        .name = ffStrbufCreate(),
+        .firmware = ffStrbufCreate(),
+        .order = 0,
+        .secureBoot = false
+    };
+    const char* bootmgrError = ffDetectBootmgr(&bootmgr);
+    if (bootmgrError == NULL)
+    {
+        if (bootmgr.secureBoot)
+            ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Enabled");
+        else
+            ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Disabled");
+    }
+    else
+    {
+        ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Unknown");
+    }
+    ffStrbufDestroy(&bootmgr.name);
+    ffStrbufDestroy(&bootmgr.firmware);
+
+    return NULL;
+}

--- a/src/detection/security/security_nosupport.c
+++ b/src/detection/security/security_nosupport.c
@@ -1,0 +1,10 @@
+#include "security.h"
+
+const char* ffDetectSecurity(FFSecurityResult* result)
+{
+    ffStrbufInit(&result->tpmStatus);
+    ffStrbufInit(&result->secureBootStatus);
+    ffStrbufSetStatic(&result->tpmStatus, "TPM Not Available");
+    ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Unknown");
+    return NULL;
+}

--- a/src/detection/security/security_windows.c
+++ b/src/detection/security/security_windows.c
@@ -1,0 +1,47 @@
+#include "security.h"
+#include "detection/tpm/tpm.h"
+#include "util/windows/registry.h"
+
+#include <windows.h>
+
+const char* ffDetectSecurity(FFSecurityResult* result)
+{
+    ffStrbufInit(&result->tpmStatus);
+    ffStrbufInit(&result->secureBootStatus);
+
+    // Detect TPM
+    FFTPMResult tpm = {
+        .version = ffStrbufCreate(),
+        .description = ffStrbufCreate()
+    };
+    const char* tpmError = ffDetectTPM(&tpm);
+    if (tpmError == NULL)
+    {
+        if (tpm.version.length > 0)
+            ffStrbufSetF(&result->tpmStatus, "TPM %s", tpm.version.chars);
+        else
+            ffStrbufSetStatic(&result->tpmStatus, "TPM OK");
+    }
+    else
+    {
+        ffStrbufSetStatic(&result->tpmStatus, "TPM Not Available");
+    }
+    ffStrbufDestroy(&tpm.version);
+    ffStrbufDestroy(&tpm.description);
+
+    // Detect Secure Boot directly from registry
+    DWORD uefiSecureBootEnabled = 0, bufSize = sizeof(uefiSecureBootEnabled);
+    if (RegGetValueW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\SecureBoot\\State", L"UEFISecureBootEnabled", RRF_RT_REG_DWORD, NULL, &uefiSecureBootEnabled, &bufSize) == ERROR_SUCCESS)
+    {
+        if (uefiSecureBootEnabled)
+            ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Enabled");
+        else
+            ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Disabled");
+    }
+    else
+    {
+        ffStrbufSetStatic(&result->secureBootStatus, "Secure Boot Unknown");
+    }
+
+    return NULL;
+}

--- a/src/modules/bios/bios.c
+++ b/src/modules/bios/bios.c
@@ -51,11 +51,13 @@ bool ffPrintBios(FFBiosOptions* options)
     if(options->moduleArgs.outputFormat.length == 0)
     {
         ffPrintLogoAndKey(key.chars, 0, &options->moduleArgs, FF_PRINT_TYPE_NO_CUSTOM_KEY);
+        if (bios.vendor.length > 0)
+        {
+            ffStrbufWriteTo(&bios.vendor, stdout);
+            putchar(' ');
+        }
         ffStrbufWriteTo(&bios.version, stdout);
-        if (bios.release.length)
-            printf(" (%s)\n", bios.release.chars);
-        else
-            putchar('\n');
+        putchar('\n');
     }
     else
     {

--- a/src/modules/board/board.c
+++ b/src/modules/board/board.c
@@ -29,9 +29,19 @@ bool ffPrintBoard(FFBoardOptions* options)
     if(options->moduleArgs.outputFormat.length == 0)
     {
         ffPrintLogoAndKey(FF_BOARD_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT);
-        ffStrbufWriteTo(&result.name, stdout);
-        if (result.version.length)
-            printf(" (%s)", result.version.chars);
+        if (result.vendor.length > 0)
+        {
+            ffStrbufWriteTo(&result.vendor, stdout);
+            putchar(' ');
+        }
+        if (result.version.length > 0)
+        {
+            ffStrbufWriteTo(&result.version, stdout);
+        }
+        else if (result.name.length > 0)
+        {
+            ffStrbufWriteTo(&result.name, stdout);
+        }
         putchar('\n');
     }
     else

--- a/src/modules/modules.h
+++ b/src/modules/modules.h
@@ -53,6 +53,7 @@
 #include "modules/processes/processes.h"
 #include "modules/publicip/publicip.h"
 #include "modules/separator/separator.h"
+#include "modules/security/security.h"
 #include "modules/shell/shell.h"
 #include "modules/sound/sound.h"
 #include "modules/swap/swap.h"

--- a/src/modules/security/option.h
+++ b/src/modules/security/option.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "common/option.h"
+
+typedef struct FFSecurityOptions
+{
+    FFModuleArgs moduleArgs;
+} FFSecurityOptions;
+
+static_assert(sizeof(FFSecurityOptions) <= FF_OPTION_MAX_SIZE, "FFSecurityOptions size exceeds maximum allowed size");

--- a/src/modules/security/security.c
+++ b/src/modules/security/security.c
@@ -1,0 +1,124 @@
+#include "common/printing.h"
+#include "common/jsonconfig.h"
+#include "detection/security/security.h"
+#include "modules/security/security.h"
+#include "util/stringUtils.h"
+
+bool ffPrintSecurity(FFSecurityOptions* options)
+{
+    bool success = false;
+    FFSecurityResult result;
+    ffStrbufInit(&result.tpmStatus);
+    ffStrbufInit(&result.secureBootStatus);
+
+    const char* error = ffDetectSecurity(&result);
+    if(error)
+    {
+        ffPrintError(FF_SECURITY_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, "%s", error);
+        goto exit;
+    }
+
+    if(options->moduleArgs.outputFormat.length == 0)
+    {
+        ffPrintLogoAndKey(FF_SECURITY_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT);
+        
+        bool first = true;
+        if (result.tpmStatus.length > 0 && !ffStrbufEqualS(&result.tpmStatus, "TPM Not Available"))
+        {
+            ffStrbufWriteTo(&result.tpmStatus, stdout);
+            first = false;
+        }
+        
+        if (result.secureBootStatus.length > 0)
+        {
+            if (!first)
+                printf(", ");
+            ffStrbufWriteTo(&result.secureBootStatus, stdout);
+        }
+        
+        putchar('\n');
+    }
+    else
+    {
+        FF_PRINT_FORMAT_CHECKED(FF_SECURITY_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, ((FFformatarg[]) {
+            FF_FORMAT_ARG(result.tpmStatus, "tpmStatus"),
+            FF_FORMAT_ARG(result.secureBootStatus, "secureBootStatus"),
+        }));
+    }
+    success = true;
+
+exit:
+    ffStrbufDestroy(&result.tpmStatus);
+    ffStrbufDestroy(&result.secureBootStatus);
+
+    return success;
+}
+
+void ffParseSecurityJsonObject(FFSecurityOptions* options, yyjson_val* module)
+{
+    yyjson_val *key, *val;
+    size_t idx, max;
+    yyjson_obj_foreach(module, idx, max, key, val)
+    {
+        if (ffJsonConfigParseModuleArgs(key, val, &options->moduleArgs))
+            continue;
+
+        ffPrintError(FF_SECURITY_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, "Unknown JSON key %s", unsafe_yyjson_get_str(key));
+    }
+}
+
+void ffGenerateSecurityJsonConfig(FFSecurityOptions* options, yyjson_mut_doc* doc, yyjson_mut_val* module)
+{
+    ffJsonConfigGenerateModuleArgsConfig(doc, module, &options->moduleArgs);
+}
+
+bool ffGenerateSecurityJsonResult(FF_MAYBE_UNUSED FFSecurityOptions* options, yyjson_mut_doc* doc, yyjson_mut_val* module)
+{
+    bool success = false;
+    FFSecurityResult result;
+    ffStrbufInit(&result.tpmStatus);
+    ffStrbufInit(&result.secureBootStatus);
+
+    const char* error = ffDetectSecurity(&result);
+
+    if (error)
+    {
+        yyjson_mut_obj_add_str(doc, module, "error", error);
+        goto exit;
+    }
+
+    yyjson_mut_val* obj = yyjson_mut_obj_add_obj(doc, module, "result");
+    yyjson_mut_obj_add_strbuf(doc, obj, "tpmStatus", &result.tpmStatus);
+    yyjson_mut_obj_add_strbuf(doc, obj, "secureBootStatus", &result.secureBootStatus);
+    success = true;
+
+exit:
+    ffStrbufDestroy(&result.tpmStatus);
+    ffStrbufDestroy(&result.secureBootStatus);
+    return success;
+}
+
+void ffInitSecurityOptions(FFSecurityOptions* options)
+{
+    ffOptionInitModuleArg(&options->moduleArgs, "🔒");
+}
+
+void ffDestroySecurityOptions(FFSecurityOptions* options)
+{
+    ffOptionDestroyModuleArg(&options->moduleArgs);
+}
+
+FFModuleBaseInfo ffSecurityModuleInfo = {
+    .name = FF_SECURITY_MODULE_NAME,
+    .description = "Print security information (TPM, Secure Boot)",
+    .initOptions = (void*) ffInitSecurityOptions,
+    .destroyOptions = (void*) ffDestroySecurityOptions,
+    .parseJsonObject = (void*) ffParseSecurityJsonObject,
+    .printModule = (void*) ffPrintSecurity,
+    .generateJsonResult = (void*) ffGenerateSecurityJsonResult,
+    .generateJsonConfig = (void*) ffGenerateSecurityJsonConfig,
+    .formatArgs = FF_FORMAT_ARG_LIST(((FFModuleFormatArg[]) {
+        {"TPM status", "tpmStatus"},
+        {"Secure Boot status", "secureBootStatus"},
+    }))
+};

--- a/src/modules/security/security.h
+++ b/src/modules/security/security.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "option.h"
+
+#define FF_SECURITY_MODULE_NAME "Security"
+
+bool ffPrintSecurity(FFSecurityOptions* options);
+void ffInitSecurityOptions(FFSecurityOptions* options);
+void ffDestroySecurityOptions(FFSecurityOptions* options);
+
+extern FFModuleBaseInfo ffSecurityModuleInfo;


### PR DESCRIPTION
## Changes

This PR adds several enhancements to fastfetch:

### BIOS Module Enhancement
- Modified BIOS module to display vendor and version by default instead of just version and release
- Format: `BIOS (UEFI): <vendor> <version>`

### Board Module Enhancement  
- Modified Board module to display vendor and revision by default instead of name and version
- Format: `Board: <vendor> <revision>`

### New Security Module
- Added new Security module that displays:
  - TPM status (version if available, or "TPM OK"/"TPM Not Available")
  - Secure Boot status (Enabled/Disabled/Unknown)
- Format: `Security: TPM 2.0, Secure Boot Enabled`
- Includes platform-specific detection for Windows and Linux
- Added to default structure

### Files Changed
- Modified: `src/modules/bios/bios.c`, `src/modules/board/board.c`
- New: `src/detection/security/*`, `src/modules/security/*`
- Updated: `src/data/structure.txt`, `CMakeLists.txt`, module registration files

All changes have been tested and are working correctly.

