### PR TITLE
Logo (Builtin): fix colors of deepin and UOS

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -5147,10 +5147,10 @@ static const FFlogo U[] = {
         .names = {"UOS"},
         .lines = FASTFETCH_DATATEXT_LOGO_UOS,
         .colors = {
-            FF_COLOR_FG_RED,
+            FF_COLOR_FG_BLUE,
         },
         .colorKeys = FF_COLOR_FG_DEFAULT,
-        .colorTitle = FF_COLOR_FG_YELLOW,
+        .colorTitle = FF_COLOR_FG_BLUE,
     },
     // UrukOS
     {


### PR DESCRIPTION
The colors of both are in the blue range.

<img width="744" height="374" alt="deepin" src="https://github.com/user-attachments/assets/c8f29311-f790-4999-aab9-7000cd24dbc4" />

<img width="878" height="391" alt="UOS" src="https://github.com/user-attachments/assets/ae680111-d813-40ea-9b4d-4d6228e6309e" />

---

Small modification: when the word "deepin" appears alone or only combined with "linux", it is in lowercase.