### PR TITLE
fix: compatibility for kIOMainPortDefault on older macOS SDKs

### DIFF
--- a/src/detection/bootmgr/bootmgr_apple.c
+++ b/src/detection/bootmgr/bootmgr_apple.c
@@ -4,6 +4,10 @@
 
 #include <IOKit/IOKitLib.h>
 
+#ifndef kIOMainPortDefault
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 static const char* detectSecureBoot(bool* result)
 {
     #if __aarch64__

--- a/src/detection/physicalmemory/physicalmemory_apple.m
+++ b/src/detection/physicalmemory/physicalmemory_apple.m
@@ -6,6 +6,10 @@
 
 #import <Foundation/Foundation.h>
 
+#ifndef kIOMainPortDefault
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 static void appendDevice(
     FFlist* result,
     NSString* type,


### PR DESCRIPTION
Apple renamed kIOMasterPortDefault to kIOMainPortDefault starting with macOS 12. This patch adds a preprocessor check to maintain compatibility with older development environments. Both kIOMasterPortDefault or kIOMainPortDefault are synonyms for 0.

Refs:
[kIOMainPortDefault](https://developer.apple.com/documentation/iokit/kiomainportdefault?language=objc
)
[kIOMasterPortDefault](https://developer.apple.com/documentation/iokit/kiomasterportdefault?language=objc
)
## Summary

<!-- Briefly describe what this PR does. -->

## Related issue (required for new logos for new distros)

<!--
If this PR adds a new logo, it MUST be linked to an existing "Logo Request" issue and has the requests fulfilled.

Use one of the following formats so GitHub links it properly:
- Closes #1234
- Fixes #1234
- Resolves #1234

PRs that add logos without an associated Logo Request issue will not be accepted.
-->

Closes #

## Changes

- 

## Checklist

- [X] I have tested my changes locally.
