### PR TITLE
Logo: add option to use system yyjson

### DIFF
--- a/src/modules/logo/logo.c
+++ b/src/modules/logo/logo.c
@@ -1,4 +1,8 @@
-#include "3rdparty/yyjson/yyjson.h"
+#ifdef FF_USE_SYSTEM_YYJSON
+    #include <yyjson.h>
+#else
+    #include "3rdparty/yyjson/yyjson.h"
+#endif
 #include "common/printing.h"
 #include "logo/logo.h"
 #include "fastfetch.h"


### PR DESCRIPTION
## Summary

For Debian distros, this is needed since libyyjson package is used instead.

## Changes

- Add possibility to use system yyjson with src/modules/logo/logo.c

## Checklist

- [x] I have tested my changes locally (with sbuild).
