### PR TITLE
Packages(Linux): Auto detect the DBPath directory for pacman on archlinux

### DIFF
--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -1,562 +1,601 @@
-#include "packages.h"
+#include "common/FFstrbuf.h"
 #include "common/io.h"
 #include "common/parsing.h"
 #include "common/properties.h"
 #include "common/settings.h"
 #include "common/stringUtils.h"
 #include "detection/os/os.h"
+#include "packages.h"
 
-static uint32_t getNumElements(FFstrbuf* baseDir, const char* dirname, bool isdir)
-{
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, dirname);
-    uint32_t num_elements = ffPackagesGetNumElements(baseDir->chars, isdir);
+static uint32_t getNumElements(FFstrbuf *baseDir, const char *dirname,
+                               bool isdir) {
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, dirname);
+  uint32_t num_elements = ffPackagesGetNumElements(baseDir->chars, isdir);
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+  return num_elements;
+}
+
+static uint32_t getNumStringsImpl(const char *filename, const char *needle) {
+  FF_STRBUF_AUTO_DESTROY content = ffStrbufCreate();
+  if (!ffReadFileBuffer(filename, &content))
+    return 0;
+
+  uint32_t count = 0;
+  char *iter = content.chars;
+  size_t needleLength = strlen(needle);
+  while ((iter = memmem(iter, content.length - (size_t)(iter - content.chars),
+                        needle, needleLength)) != NULL) {
+    ++count;
+    iter += needleLength;
+  }
+
+  return count;
+}
+
+static uint32_t getNumStrings(FFstrbuf *baseDir, const char *filename,
+                              const char *needle, const char *packageId) {
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, filename);
+
+  FF_STRBUF_AUTO_DESTROY cacheDir = ffStrbufCreate();
+  FF_STRBUF_AUTO_DESTROY cacheContent = ffStrbufCreate();
+
+  uint32_t num_elements;
+  if (ffPackagesReadCache(&cacheDir, &cacheContent, baseDir->chars, packageId,
+                          &num_elements)) {
     ffStrbufSubstrBefore(baseDir, baseDirLength);
     return num_elements;
+  }
+
+  num_elements = getNumStringsImpl(baseDir->chars, needle);
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+
+  ffPackagesWriteCache(&cacheDir, &cacheContent, num_elements);
+
+  return num_elements;
 }
 
-static uint32_t getNumStringsImpl(const char* filename, const char* needle)
-{
-    FF_STRBUF_AUTO_DESTROY content = ffStrbufCreate();
-    if (!ffReadFileBuffer(filename, &content))
-        return 0;
+static uint32_t getSQLite3Int(FFstrbuf *baseDir, const char *dbPath,
+                              const char *query, const char *packageId) {
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, dbPath);
 
-    uint32_t count = 0;
-    char *iter = content.chars;
-    size_t needleLength = strlen(needle);
-    while ((iter = memmem(iter, content.length - (size_t)(iter - content.chars), needle, needleLength)) != NULL)
-    {
-        ++count;
-        iter += needleLength;
-    }
+  FF_STRBUF_AUTO_DESTROY cacheDir = ffStrbufCreate();
+  FF_STRBUF_AUTO_DESTROY cacheContent = ffStrbufCreate();
 
-    return count;
-}
-
-static uint32_t getNumStrings(FFstrbuf* baseDir, const char* filename, const char* needle, const char* packageId)
-{
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, filename);
-
-    FF_STRBUF_AUTO_DESTROY cacheDir = ffStrbufCreate();
-    FF_STRBUF_AUTO_DESTROY cacheContent = ffStrbufCreate();
-
-    uint32_t num_elements;
-    if (ffPackagesReadCache(&cacheDir, &cacheContent, baseDir->chars, packageId, &num_elements))
-    {
-        ffStrbufSubstrBefore(baseDir, baseDirLength);
-        return num_elements;
-    }
-
-    num_elements = getNumStringsImpl(baseDir->chars, needle);
+  uint32_t num_elements;
+  if (ffPackagesReadCache(&cacheDir, &cacheContent, baseDir->chars, packageId,
+                          &num_elements)) {
     ffStrbufSubstrBefore(baseDir, baseDirLength);
-
-    ffPackagesWriteCache(&cacheDir, &cacheContent, num_elements);
-
     return num_elements;
+  }
+
+  num_elements = (uint32_t)ffSettingsGetSQLite3Int(baseDir->chars, query);
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+
+  ffPackagesWriteCache(&cacheDir, &cacheContent, num_elements);
+
+  return num_elements;
 }
 
-static uint32_t getSQLite3Int(FFstrbuf* baseDir, const char* dbPath, const char* query, const char* packageId)
-{
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, dbPath);
+static uint32_t countFilesRecursiveImpl(FFstrbuf *baseDirPath,
+                                        const char *filename) {
+  uint32_t baseDirPathLength = baseDirPath->length;
 
-    FF_STRBUF_AUTO_DESTROY cacheDir = ffStrbufCreate();
-    FF_STRBUF_AUTO_DESTROY cacheContent = ffStrbufCreate();
+  ffStrbufAppendC(baseDirPath, '/');
+  ffStrbufAppendS(baseDirPath, filename);
+  bool exists = ffPathExists(baseDirPath->chars, FF_PATHTYPE_FILE);
+  ffStrbufSubstrBefore(baseDirPath, baseDirPathLength);
+  if (exists)
+    return 1;
 
-    uint32_t num_elements;
-    if (ffPackagesReadCache(&cacheDir, &cacheContent, baseDir->chars, packageId, &num_elements))
-    {
-        ffStrbufSubstrBefore(baseDir, baseDirLength);
-        return num_elements;
-    }
+  DIR *dirp = opendir(baseDirPath->chars);
+  if (dirp == NULL)
+    return 0;
 
-    num_elements = (uint32_t) ffSettingsGetSQLite3Int(baseDir->chars, query);
-    ffStrbufSubstrBefore(baseDir, baseDirLength);
+  ffStrbufAppendC(baseDirPath, '/');
+  baseDirPathLength = baseDirPath->length;
 
-    ffPackagesWriteCache(&cacheDir, &cacheContent, num_elements);
+  uint32_t sum = 0;
 
-    return num_elements;
-}
+  struct dirent *entry;
+  while ((entry = readdir(dirp)) != NULL) {
+    // According to the PMS, neither category nor package name can begin with
+    // '.', so no need to check for . or .. specifically
+    if (entry->d_type != DT_DIR || entry->d_name[0] == '.')
+      continue;
 
-static uint32_t countFilesRecursiveImpl(FFstrbuf* baseDirPath, const char* filename)
-{
-    uint32_t baseDirPathLength = baseDirPath->length;
-
-    ffStrbufAppendC(baseDirPath, '/');
-    ffStrbufAppendS(baseDirPath, filename);
-    bool exists = ffPathExists(baseDirPath->chars, FF_PATHTYPE_FILE);
+    ffStrbufAppendS(baseDirPath, entry->d_name);
+    sum += countFilesRecursiveImpl(baseDirPath, filename);
     ffStrbufSubstrBefore(baseDirPath, baseDirPathLength);
-    if(exists)
-        return 1;
+  }
 
-    DIR* dirp = opendir(baseDirPath->chars);
-    if(dirp == NULL)
-        return 0;
-
-    ffStrbufAppendC(baseDirPath, '/');
-    baseDirPathLength = baseDirPath->length;
-
-    uint32_t sum = 0;
-
-    struct dirent *entry;
-    while((entry = readdir(dirp)) != NULL) {
-        // According to the PMS, neither category nor package name can begin with '.', so no need to check for . or .. specifically
-        if(entry->d_type != DT_DIR || entry->d_name[0] == '.')
-            continue;
-
-        ffStrbufAppendS(baseDirPath, entry->d_name);
-        sum += countFilesRecursiveImpl(baseDirPath, filename);
-        ffStrbufSubstrBefore(baseDirPath, baseDirPathLength);
-    }
-
-    closedir(dirp);
-    return sum;
+  closedir(dirp);
+  return sum;
 }
 
-static uint32_t countFilesRecursive(FFstrbuf* baseDir, const char* dirname, const char* filename)
-{
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, dirname);
-    uint32_t sum = countFilesRecursiveImpl(baseDir, filename);
-    ffStrbufSubstrBefore(baseDir, baseDirLength);
-    return sum;
+static uint32_t countFilesRecursive(FFstrbuf *baseDir, const char *dirname,
+                                    const char *filename) {
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, dirname);
+  uint32_t sum = countFilesRecursiveImpl(baseDir, filename);
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+  return sum;
 }
 
-static uint32_t getXBPSImpl(FFstrbuf* baseDir)
-{
-    DIR* dir = opendir(baseDir->chars);
-    if(dir == NULL)
-        return 0;
+static uint32_t getXBPSImpl(FFstrbuf *baseDir) {
+  DIR *dir = opendir(baseDir->chars);
+  if (dir == NULL)
+    return 0;
 
-    uint32_t result = 0;
+  uint32_t result = 0;
 
-    struct dirent *entry;
-    while((entry = readdir(dir)) != NULL)
-    {
-        if(entry->d_type != DT_REG || !ffStrStartsWithIgnCase(entry->d_name, "pkgdb-"))
-            continue;
+  struct dirent *entry;
+  while ((entry = readdir(dir)) != NULL) {
+    if (entry->d_type != DT_REG ||
+        !ffStrStartsWithIgnCase(entry->d_name, "pkgdb-"))
+      continue;
 
-        ffStrbufAppendC(baseDir, '/');
-        ffStrbufAppendS(baseDir, entry->d_name);
-        result = getNumStringsImpl(baseDir->chars, "<string>installed</string>");
-        break;
-    }
+    ffStrbufAppendC(baseDir, '/');
+    ffStrbufAppendS(baseDir, entry->d_name);
+    result = getNumStringsImpl(baseDir->chars, "<string>installed</string>");
+    break;
+  }
 
-    closedir(dir);
-    return result;
+  closedir(dir);
+  return result;
 }
 
-static uint32_t getXBPS(FFstrbuf* baseDir, const char* dirname)
-{
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, dirname);
-    uint32_t result = getXBPSImpl(baseDir);
-    ffStrbufSubstrBefore(baseDir, baseDirLength);
-    return result;
+static uint32_t getXBPS(FFstrbuf *baseDir, const char *dirname) {
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, dirname);
+  uint32_t result = getXBPSImpl(baseDir);
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+  return result;
 }
 
-static uint32_t getSnap(FFstrbuf* baseDir)
-{
-    uint32_t result = getNumElements(baseDir, "/snap", true);
+static uint32_t getSnap(FFstrbuf *baseDir) {
+  uint32_t result = getNumElements(baseDir, "/snap", true);
 
-    if (result == 0)
-        result = getNumElements(baseDir, "/var/lib/snapd/snap", true);
+  if (result == 0)
+    result = getNumElements(baseDir, "/var/lib/snapd/snap", true);
 
-    //Accounting for the /snap/bin folder
-    return result > 0 ? result - 1 : 0;
+  // Accounting for the /snap/bin folder
+  return result > 0 ? result - 1 : 0;
 }
 
 #ifdef FF_HAVE_RPM
 #include "common/library.h"
-#include <rpm/rpmlib.h>
-#include <rpm/rpmts.h>
 #include <rpm/rpmdb.h>
+#include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
+#include <rpm/rpmts.h>
 
-static uint32_t getRpmFromLibrpm(void)
-{
-    FF_LIBRARY_LOAD(rpm, 0, "librpm" FF_LIBRARY_EXTENSION, 12)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmReadConfigFiles, 0)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmtsCreate, 0)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmtsInitIterator, 0)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmdbGetIteratorCount, 0)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmdbFreeIterator, 0)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmtsFree, 0)
-    FF_LIBRARY_LOAD_SYMBOL(rpm, rpmlogSetMask, 0)
+static uint32_t getRpmFromLibrpm(void) {
+  FF_LIBRARY_LOAD(rpm, 0, "librpm" FF_LIBRARY_EXTENSION, 12)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmReadConfigFiles, 0)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmtsCreate, 0)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmtsInitIterator, 0)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmdbGetIteratorCount, 0)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmdbFreeIterator, 0)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmtsFree, 0)
+  FF_LIBRARY_LOAD_SYMBOL(rpm, rpmlogSetMask, 0)
 
-    // Don't print any error messages
-    ffrpmlogSetMask(RPMLOG_MASK(RPMLOG_EMERG));
+  // Don't print any error messages
+  ffrpmlogSetMask(RPMLOG_MASK(RPMLOG_EMERG));
 
-    if(ffrpmReadConfigFiles(NULL, NULL) != 0)
-        return 0;
+  if (ffrpmReadConfigFiles(NULL, NULL) != 0)
+    return 0;
 
-    rpmts ts = ffrpmtsCreate();
-    if(ts == NULL)
-        return 0;
+  rpmts ts = ffrpmtsCreate();
+  if (ts == NULL)
+    return 0;
 
-    rpmdbMatchIterator mi = ffrpmtsInitIterator(ts, RPMDBI_LABEL, NULL, 0);
-    if(mi == NULL)
-    {
-        ffrpmtsFree(ts);
-        return 0;
-    }
-
-    int count = ffrpmdbGetIteratorCount(mi);
-
-    ffrpmdbFreeIterator(mi);
+  rpmdbMatchIterator mi = ffrpmtsInitIterator(ts, RPMDBI_LABEL, NULL, 0);
+  if (mi == NULL) {
     ffrpmtsFree(ts);
+    return 0;
+  }
 
-    return count > 0 ? (uint32_t) count : 0;
+  int count = ffrpmdbGetIteratorCount(mi);
+
+  ffrpmdbFreeIterator(mi);
+  ffrpmtsFree(ts);
+
+  return count > 0 ? (uint32_t)count : 0;
 }
 
-#endif //FF_HAVE_RPM
+#endif // FF_HAVE_RPM
 
-static uint32_t getAMPackages(FFstrbuf* baseDir)
-{
-    uint32_t baseLength = baseDir->length;
-    FF_AUTO_CLOSE_DIR DIR* dirp = opendir(baseDir->chars);
-    if (!dirp) return 0;
+static uint32_t getAMPackages(FFstrbuf *baseDir) {
+  uint32_t baseLength = baseDir->length;
+  FF_AUTO_CLOSE_DIR DIR *dirp = opendir(baseDir->chars);
+  if (!dirp)
+    return 0;
 
-    uint32_t result = 0;
-    struct dirent *entry;
-    while ((entry = readdir(dirp)) != NULL)
-    {
-        if (entry->d_name[0] == '.') continue;
-        if (entry->d_type == DT_DIR)
-        {
-            ffStrbufAppendF(baseDir, "/%s/remove", entry->d_name);
-            if (ffPathExists(baseDir->chars, FF_PATHTYPE_FILE))
-                ++result;
-            ffStrbufSubstrBefore(baseDir, baseLength);
-        }
+  uint32_t result = 0;
+  struct dirent *entry;
+  while ((entry = readdir(dirp)) != NULL) {
+    if (entry->d_name[0] == '.')
+      continue;
+    if (entry->d_type == DT_DIR) {
+      ffStrbufAppendF(baseDir, "/%s/remove", entry->d_name);
+      if (ffPathExists(baseDir->chars, FF_PATHTYPE_FILE))
+        ++result;
+      ffStrbufSubstrBefore(baseDir, baseLength);
     }
-    return result;
+  }
+  return result;
 }
 
-static uint32_t getAMSystem(FFstrbuf* baseDir)
-{
-    // #771
+static uint32_t getAMSystem(FFstrbuf *baseDir) {
+  // #771
+  uint32_t baseDirLength = baseDir->length;
+
+  ffStrbufAppendS(baseDir, "/opt");
+  uint32_t optDirLength = baseDir->length;
+
+  uint32_t result = 0;
+
+  ffStrbufAppendS(baseDir, "/am/APP-MANAGER");
+  if (ffPathExists(baseDir->chars, FF_PATHTYPE_FILE)) {
+    ++result; // `am` itself is counted as a package too
+    ffStrbufSubstrBefore(baseDir, optDirLength);
+    result = getAMPackages(baseDir);
+  }
+
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+  return result;
+}
+
+static uint32_t getAMUser(void) {
+  if (instance.state.platform.configDirs.length == 0)
+    return 0;
+
+  // check if $XDG_CONFIG_HOME/appman/appman-config exists
+  FFstrbuf *baseDir =
+      FF_LIST_FIRST(FFstrbuf, instance.state.platform.configDirs);
+  uint32_t baseLen = baseDir->length;
+  ffStrbufAppendS(baseDir, "appman/appman-config");
+  FF_STRBUF_AUTO_DESTROY packagesPath = ffStrbufCreate();
+  if (ffReadFileBuffer(baseDir->chars, &packagesPath))
+    ffStrbufTrimRightSpace(&packagesPath);
+  ffStrbufSubstrBefore(baseDir, baseLen);
+
+  return packagesPath.length > 0 ? getAMPackages(&packagesPath) : 0;
+}
+
+static int compareHash(const void *a, const void *b) {
+  return memcmp(a, b, 32);
+}
+
+static uint32_t getGuixPackagesImpl(char *filename) {
+  FF_STRBUF_AUTO_DESTROY content = ffStrbufCreate();
+  if (!ffAppendFileBuffer(filename, &content))
+    return 0;
+
+  // Count number of unique /gnu/store/ paths in PROFILE/manifest based on their
+  // hash value. Contains packages explicitly installed and their propagated
+  // inputs.
+  char *pend = content.chars;
+
+  for (const char *pattern = content.chars;
+       (pattern = strstr(pattern, "/gnu/store/")); pattern += 32) {
+    pattern += strlen("/gnu/store/");
+    memmove(pend, pattern, 32);
+    pend += 32;
+  }
+
+  if (pend == content.chars)
+    return 0;
+
+  qsort(content.chars, (size_t)(pend - content.chars) / 32, 32, compareHash);
+
+  uint32_t count = 1;
+  for (const char *p = content.chars + 32; p < pend; p += 32)
+    count += compareHash(p - 32, p) != 0;
+
+  return count;
+}
+
+static uint32_t getGuixPackages(FFstrbuf *baseDir, const char *dirname) {
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, dirname);
+  ffStrbufAppendS(baseDir, "/manifest");
+  uint32_t num_elements = getGuixPackagesImpl(baseDir->chars);
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+  return num_elements;
+}
+
+static inline uint32_t getFlatpakRuntimePackagesArch(FFstrbuf *baseDir) {
+  FF_AUTO_CLOSE_DIR DIR *dirp = opendir(baseDir->chars);
+  if (dirp == NULL)
+    return 0;
+
+  uint32_t num_elements = 0;
+
+  struct dirent *entry;
+  while ((entry = readdir(dirp)) != NULL) {
+    if (entry->d_type == DT_DIR && entry->d_name[0] != '.') {
+      num_elements += getNumElements(baseDir, entry->d_name, true);
+    }
+  }
+
+  return num_elements;
+}
+
+static inline uint32_t getFlatpakRuntimePackages(FFstrbuf *baseDir) {
+  ffStrbufAppendS(baseDir, "runtime/");
+  FF_AUTO_CLOSE_DIR DIR *dirp = opendir(baseDir->chars);
+  if (dirp == NULL)
+    return 0;
+
+  uint32_t runtimeDirLength = baseDir->length;
+  uint32_t num_elements = 0;
+
+  struct dirent *entry;
+  while ((entry = readdir(dirp)) != NULL) {
+    if (entry->d_type == DT_DIR && entry->d_name[0] != '.') {
+      // `flatpak list` ignores `.Locale` and `.Debug` packages, and maybe
+      // others
+      const char *dot = strrchr(entry->d_name, '.');
+      if (__builtin_expect(!dot, false))
+        continue;
+      dot++;
+
+      if (ffStrEquals(dot, "Locale") || ffStrEquals(dot, "Debug"))
+        continue;
+
+      ffStrbufAppendS(baseDir, entry->d_name);
+      ffStrbufAppendC(baseDir, '/');
+      num_elements += getFlatpakRuntimePackagesArch(baseDir);
+      ffStrbufSubstrBefore(baseDir, runtimeDirLength);
+    }
+  }
+
+  return num_elements;
+}
+
+static inline uint32_t getFlatpakAppPackages(FFstrbuf *baseDir) {
+  ffStrbufAppendS(baseDir, "app/");
+  FF_AUTO_CLOSE_DIR DIR *dirp = opendir(baseDir->chars);
+  if (dirp == NULL)
+    return 0;
+
+  uint32_t appDirLength = baseDir->length;
+  uint32_t num_elements = 0;
+
+  struct dirent *entry;
+  while ((entry = readdir(dirp)) != NULL) {
+    if (entry->d_type == DT_DIR && entry->d_name[0] != '.') {
+      ffStrbufAppendS(baseDir, entry->d_name);
+      ffStrbufAppendS(baseDir, "/current");
+      if (ffPathExists(baseDir->chars,
+                       FF_PATHTYPE_ANY)) // Exclude deleted apps, #1856
+        ++num_elements;
+      ffStrbufSubstrBefore(baseDir, appDirLength);
+    }
+  }
+  return num_elements;
+}
+
+static uint32_t getFlatpakPackages(FFstrbuf *baseDir, const char *dirname) {
+  uint32_t num_elements = 0;
+  uint32_t baseDirLength = baseDir->length;
+  ffStrbufAppendS(baseDir, dirname);
+  ffStrbufAppendS(baseDir, "/flatpak/");
+  uint32_t flatpakDirLength = baseDir->length;
+
+  num_elements += getFlatpakAppPackages(baseDir);
+  ffStrbufSubstrBefore(baseDir, flatpakDirLength);
+
+  num_elements += getFlatpakRuntimePackages(baseDir);
+
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
+
+  return num_elements;
+}
+
+static uint32_t getPacmanPackages(FFstrbuf *baseDir) {
+  FF_STRBUF_AUTO_DESTROY pacmanDir = ffStrbufCreate();
+
+  uint32_t baseDirLen = baseDir->length;
+  ffStrbufAppendS(&pacmanDir, "/etc/pacman.conf");
+  if (!ffParsePropFile(baseDir->chars, "DBPath =", &pacmanDir))
+    ffStrbufSetS(&pacmanDir, "/var/lib/pacman");
+  ffStrbufSubstrBefore(&pacmanDir, baseDirLen);
+  ffStrbufTrimRight(&pacmanDir, '/');
+  ffStrbufAppendS(&pacmanDir, "/local");
+  return getNumElements(baseDir, pacmanDir.chars, true);
+}
+
+static void getPackageCounts(FFstrbuf *baseDir, FFPackagesResult *packageCounts,
+                             FFPackagesOptions *options) {
+  if (!(options->disabled & FF_PACKAGES_FLAG_APK_BIT))
+    packageCounts->apk +=
+        getNumStrings(baseDir, "/lib/apk/db/installed", "C:Q", "apk");
+  if (!(options->disabled & FF_PACKAGES_FLAG_DPKG_BIT))
+    packageCounts->dpkg +=
+        getNumStrings(baseDir, "/var/lib/dpkg/status",
+                      "Status: install ok installed", "dpkg");
+  if (!(options->disabled & FF_PACKAGES_FLAG_LPKG_BIT))
+    packageCounts->lpkg += getNumStrings(
+        baseDir, "/opt/Loc-OS-LPKG/installed-lpkg/Listinstalled-lpkg.list",
+        "\n", "lpkg");
+  if (!(options->disabled & FF_PACKAGES_FLAG_EMERGE_BIT))
+    packageCounts->emerge +=
+        countFilesRecursive(baseDir, "/var/db/pkg", "SIZE");
+  if (!(options->disabled & FF_PACKAGES_FLAG_EOPKG_BIT))
+    packageCounts->eopkg +=
+        getNumElements(baseDir, "/var/lib/eopkg/package", true);
+  if (!(options->disabled & FF_PACKAGES_FLAG_FLATPAK_BIT))
+    packageCounts->flatpakSystem += getFlatpakPackages(baseDir, "/var/lib");
+  if (!(options->disabled & FF_PACKAGES_FLAG_KISS_BIT))
+    packageCounts->kiss +=
+        getNumElements(baseDir, "/var/db/kiss/installed", true);
+  if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT)) {
+    packageCounts->nixDefault +=
+        ffPackagesGetNix(baseDir, "/nix/var/nix/profiles/default");
+    packageCounts->nixSystem +=
+        ffPackagesGetNix(baseDir, "/run/current-system");
+  }
+  // TODO: change to getPacmanPackages():
+  if (!(options->disabled & FF_PACKAGES_FLAG_PACMAN_BIT))
+    packageCounts->pacman += getPacmanPackages(baseDir);
+  if (!(options->disabled & FF_PACKAGES_FLAG_LPKGBUILD_BIT))
+    packageCounts->lpkgbuild +=
+        getNumElements(baseDir, "/opt/Loc-OS-LPKG/lpkgbuild/remove", false);
+  if (!(options->disabled & FF_PACKAGES_FLAG_PKGTOOL_BIT))
+    packageCounts->pkgtool +=
+        getNumElements(baseDir, "/var/log/packages", false);
+  if (!(options->disabled & FF_PACKAGES_FLAG_RPM_BIT)) {
+    // `Sigmd5` is the only table that doesn't contain the virtual `gpg-pubkey`
+    // package
+    packageCounts->rpm += getSQLite3Int(baseDir, "/var/lib/rpm/rpmdb.sqlite",
+                                        "SELECT count(*) FROM Sigmd5", "rpm");
+  }
+  if (!(options->disabled & FF_PACKAGES_FLAG_SNAP_BIT))
+    packageCounts->snap += getSnap(baseDir);
+  if (!(options->disabled & FF_PACKAGES_FLAG_XBPS_BIT))
+    packageCounts->xbps += getXBPS(baseDir, "/var/db/xbps");
+  if (!(options->disabled & FF_PACKAGES_FLAG_BREW_BIT)) {
+    packageCounts->brewCask +=
+        getNumElements(baseDir, "/home/linuxbrew/.linuxbrew/Caskroom", true);
+    packageCounts->brew +=
+        getNumElements(baseDir, "/home/linuxbrew/.linuxbrew/Cellar", true);
+  }
+  if (!(options->disabled & FF_PACKAGES_FLAG_PALUDIS_BIT))
+    packageCounts->paludis += countFilesRecursive(
+        baseDir, "/var/db/paludis/repositories", "environment.bz2");
+  if (!(options->disabled & FF_PACKAGES_FLAG_OPKG_BIT))
+    packageCounts->opkg += getNumStrings(baseDir, "/usr/lib/opkg/status",
+                                         "Package:", "opkg"); // openwrt
+  if (!(options->disabled & FF_PACKAGES_FLAG_AM_BIT))
+    packageCounts->amSystem = getAMSystem(baseDir);
+  if (!(options->disabled & FF_PACKAGES_FLAG_SORCERY_BIT))
+    packageCounts->sorcery += getNumStrings(
+        baseDir, "/var/state/sorcery/packages", ":installed:", "sorcery");
+  if (!(options->disabled & FF_PACKAGES_FLAG_GUIX_BIT)) {
+    packageCounts->guixSystem +=
+        getGuixPackages(baseDir, "/run/current-system/profile");
+  }
+  if (!(options->disabled & FF_PACKAGES_FLAG_LINGLONG_BIT))
+    packageCounts->linglong +=
+        getNumElements(baseDir, "/var/lib/linglong/layers", true);
+  if (!(options->disabled & FF_PACKAGES_FLAG_PACSTALL_BIT))
+    packageCounts->pacstall +=
+        getNumElements(baseDir, "/var/lib/pacstall/metadata", false);
+  if (!(options->disabled & FF_PACKAGES_FLAG_PISI_BIT))
+    packageCounts->pisi +=
+        getNumElements(baseDir, "/var/lib/pisi/package", true);
+  if (!(options->disabled & FF_PACKAGES_FLAG_PKGSRC_BIT))
+    packageCounts->pkgsrc += getNumElements(baseDir, "/usr/pkg/pkgdb", DT_DIR);
+}
+
+static void getPackageCountsRegular(FFstrbuf *baseDir,
+                                    FFPackagesResult *packageCounts,
+                                    FFPackagesOptions *options) {
+  getPackageCounts(baseDir, packageCounts, options);
+
+  if (!(options->disabled & FF_PACKAGES_FLAG_PACMAN_BIT)) {
     uint32_t baseDirLength = baseDir->length;
-
-    ffStrbufAppendS(baseDir, "/opt");
-    uint32_t optDirLength = baseDir->length;
-
-    uint32_t result = 0;
-
-    ffStrbufAppendS(baseDir, "/am/APP-MANAGER");
-    if (ffPathExists(baseDir->chars, FF_PATHTYPE_FILE))
-    {
-        ++result; // `am` itself is counted as a package too
-        ffStrbufSubstrBefore(baseDir, optDirLength);
-        result = getAMPackages(baseDir);
-    }
-
+    ffStrbufAppendS(baseDir, FASTFETCH_TARGET_DIR_ETC "/pacman-mirrors.conf");
+    if (ffParsePropFile(baseDir->chars,
+                        "Branch =", &packageCounts->pacmanBranch) &&
+        packageCounts->pacmanBranch.length == 0)
+      ffStrbufAppendS(&packageCounts->pacmanBranch, "stable");
     ffStrbufSubstrBefore(baseDir, baseDirLength);
-    return result;
+  }
 }
 
-static uint32_t getAMUser(void)
-{
-    if (instance.state.platform.configDirs.length == 0) return 0;
+static void getPackageCountsBedrock(FFstrbuf *baseDir,
+                                    FFPackagesResult *packageCounts,
+                                    FFPackagesOptions *options) {
+  uint32_t baseDirLength = baseDir->length;
 
-    // check if $XDG_CONFIG_HOME/appman/appman-config exists
-    FFstrbuf* baseDir = FF_LIST_FIRST(FFstrbuf, instance.state.platform.configDirs);
-    uint32_t baseLen = baseDir->length;
-    ffStrbufAppendS(baseDir, "appman/appman-config");
-    FF_STRBUF_AUTO_DESTROY packagesPath = ffStrbufCreate();
-    if (ffReadFileBuffer(baseDir->chars, &packagesPath))
-        ffStrbufTrimRightSpace(&packagesPath);
-    ffStrbufSubstrBefore(baseDir, baseLen);
+  ffStrbufAppendS(baseDir, "/bedrock/strata");
 
-    return packagesPath.length > 0 ? getAMPackages(&packagesPath) : 0;
-}
-
-static int compareHash(const void* a, const void* b)
-{
-    return memcmp(a, b, 32);
-}
-
-static uint32_t getGuixPackagesImpl(char* filename)
-{
-    FF_STRBUF_AUTO_DESTROY content = ffStrbufCreate();
-    if (!ffAppendFileBuffer(filename, &content))
-        return 0;
-
-    // Count number of unique /gnu/store/ paths in PROFILE/manifest based on their hash value.
-    // Contains packages explicitly installed and their propagated inputs.
-    char* pend = content.chars;
-
-    for (const char* pattern = content.chars; (pattern = strstr(pattern, "/gnu/store/")); pattern += 32)
-    {
-        pattern += strlen("/gnu/store/");
-        memmove(pend, pattern, 32);
-        pend += 32;
-    }
-
-    if (pend == content.chars)
-        return 0;
-
-    qsort(content.chars, (size_t) (pend - content.chars) / 32, 32, compareHash);
-
-    uint32_t count = 1;
-    for (const char* p = content.chars + 32; p < pend; p += 32)
-        count += compareHash(p - 32, p) != 0;
-
-    return count;
-}
-
-static uint32_t getGuixPackages(FFstrbuf* baseDir, const char* dirname)
-{
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, dirname);
-    ffStrbufAppendS(baseDir, "/manifest");
-    uint32_t num_elements = getGuixPackagesImpl(baseDir->chars);
+  FF_AUTO_CLOSE_DIR DIR *dir = opendir(baseDir->chars);
+  if (dir == NULL) {
     ffStrbufSubstrBefore(baseDir, baseDirLength);
-    return num_elements;
-}
+    return;
+  }
 
-static inline uint32_t getFlatpakRuntimePackagesArch(FFstrbuf* baseDir)
-{
-    FF_AUTO_CLOSE_DIR DIR* dirp = opendir(baseDir->chars);
-    if (dirp == NULL)
-        return 0;
+  ffStrbufAppendC(baseDir, '/');
+  uint32_t baseDirLength2 = baseDir->length;
 
-    uint32_t num_elements = 0;
+  struct dirent *entry;
+  while ((entry = readdir(dir)) != NULL) {
+    if (entry->d_type != DT_DIR)
+      continue;
+    if (entry->d_name[0] == '.')
+      continue;
 
-    struct dirent *entry;
-    while ((entry = readdir(dirp)) != NULL)
-    {
-        if(entry->d_type == DT_DIR && entry->d_name[0] != '.')
-        {
-            num_elements += getNumElements(baseDir, entry->d_name, true);
-        }
-    }
-
-    return num_elements;
-}
-
-static inline uint32_t getFlatpakRuntimePackages(FFstrbuf* baseDir)
-{
-    ffStrbufAppendS(baseDir, "runtime/");
-    FF_AUTO_CLOSE_DIR DIR* dirp = opendir(baseDir->chars);
-    if (dirp == NULL)
-        return 0;
-
-    uint32_t runtimeDirLength = baseDir->length;
-    uint32_t num_elements = 0;
-
-    struct dirent *entry;
-    while ((entry = readdir(dirp)) != NULL)
-    {
-        if(entry->d_type == DT_DIR && entry->d_name[0] != '.')
-        {
-            // `flatpak list` ignores `.Locale` and `.Debug` packages, and maybe others
-            const char* dot = strrchr(entry->d_name, '.');
-            if (__builtin_expect(!dot, false)) continue;
-            dot++;
-
-            if (ffStrEquals(dot, "Locale") || ffStrEquals(dot, "Debug"))
-                continue;
-
-            ffStrbufAppendS(baseDir, entry->d_name);
-            ffStrbufAppendC(baseDir, '/');
-            num_elements += getFlatpakRuntimePackagesArch(baseDir);
-            ffStrbufSubstrBefore(baseDir, runtimeDirLength);
-        }
-    }
-
-    return num_elements;
-}
-
-static inline uint32_t getFlatpakAppPackages(FFstrbuf* baseDir)
-{
-    ffStrbufAppendS(baseDir, "app/");
-    FF_AUTO_CLOSE_DIR DIR* dirp = opendir(baseDir->chars);
-    if (dirp == NULL)
-        return 0;
-
-    uint32_t appDirLength = baseDir->length;
-    uint32_t num_elements = 0;
-
-    struct dirent *entry;
-    while ((entry = readdir(dirp)) != NULL)
-    {
-        if(entry->d_type == DT_DIR && entry->d_name[0] != '.')
-        {
-            ffStrbufAppendS(baseDir, entry->d_name);
-            ffStrbufAppendS(baseDir, "/current");
-            if (ffPathExists(baseDir->chars, FF_PATHTYPE_ANY)) // Exclude deleted apps, #1856
-                ++num_elements;
-            ffStrbufSubstrBefore(baseDir, appDirLength);
-        }
-    }
-    return num_elements;
-}
-
-static uint32_t getFlatpakPackages(FFstrbuf* baseDir, const char* dirname)
-{
-    uint32_t num_elements = 0;
-    uint32_t baseDirLength = baseDir->length;
-    ffStrbufAppendS(baseDir, dirname);
-    ffStrbufAppendS(baseDir, "/flatpak/");
-    uint32_t flatpakDirLength = baseDir->length;
-
-    num_elements += getFlatpakAppPackages(baseDir);
-    ffStrbufSubstrBefore(baseDir, flatpakDirLength);
-
-    num_elements += getFlatpakRuntimePackages(baseDir);
-
-    ffStrbufSubstrBefore(baseDir, baseDirLength);
-
-    return num_elements;
-}
-
-static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts, FFPackagesOptions* options)
-{
-    if (!(options->disabled & FF_PACKAGES_FLAG_APK_BIT)) packageCounts->apk += getNumStrings(baseDir, "/lib/apk/db/installed", "C:Q", "apk");
-    if (!(options->disabled & FF_PACKAGES_FLAG_DPKG_BIT)) packageCounts->dpkg += getNumStrings(baseDir, "/var/lib/dpkg/status", "Status: install ok installed", "dpkg");
-    if (!(options->disabled & FF_PACKAGES_FLAG_LPKG_BIT)) packageCounts->lpkg += getNumStrings(baseDir, "/opt/Loc-OS-LPKG/installed-lpkg/Listinstalled-lpkg.list", "\n", "lpkg");
-    if (!(options->disabled & FF_PACKAGES_FLAG_EMERGE_BIT)) packageCounts->emerge += countFilesRecursive(baseDir, "/var/db/pkg", "SIZE");
-    if (!(options->disabled & FF_PACKAGES_FLAG_EOPKG_BIT)) packageCounts->eopkg += getNumElements(baseDir, "/var/lib/eopkg/package", true);
-    if (!(options->disabled & FF_PACKAGES_FLAG_FLATPAK_BIT)) packageCounts->flatpakSystem += getFlatpakPackages(baseDir, "/var/lib");
-    if (!(options->disabled & FF_PACKAGES_FLAG_KISS_BIT)) packageCounts->kiss += getNumElements(baseDir, "/var/db/kiss/installed", true);
-    if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT))
-    {
-        packageCounts->nixDefault += ffPackagesGetNix(baseDir, "/nix/var/nix/profiles/default");
-        packageCounts->nixSystem += ffPackagesGetNix(baseDir, "/run/current-system");
-    }
-    if (!(options->disabled & FF_PACKAGES_FLAG_PACMAN_BIT)) packageCounts->pacman += getNumElements(baseDir, "/var/lib/pacman/local", true);
-    if (!(options->disabled & FF_PACKAGES_FLAG_LPKGBUILD_BIT)) packageCounts->lpkgbuild += getNumElements(baseDir, "/opt/Loc-OS-LPKG/lpkgbuild/remove", false);
-    if (!(options->disabled & FF_PACKAGES_FLAG_PKGTOOL_BIT)) packageCounts->pkgtool += getNumElements(baseDir, "/var/log/packages", false);
-    if (!(options->disabled & FF_PACKAGES_FLAG_RPM_BIT))
-    {
-        // `Sigmd5` is the only table that doesn't contain the virtual `gpg-pubkey` package
-        packageCounts->rpm += getSQLite3Int(baseDir, "/var/lib/rpm/rpmdb.sqlite", "SELECT count(*) FROM Sigmd5", "rpm");
-    }
-    if (!(options->disabled & FF_PACKAGES_FLAG_SNAP_BIT)) packageCounts->snap += getSnap(baseDir);
-    if (!(options->disabled & FF_PACKAGES_FLAG_XBPS_BIT)) packageCounts->xbps += getXBPS(baseDir, "/var/db/xbps");
-    if (!(options->disabled & FF_PACKAGES_FLAG_BREW_BIT))
-    {
-        packageCounts->brewCask += getNumElements(baseDir, "/home/linuxbrew/.linuxbrew/Caskroom", true);
-        packageCounts->brew += getNumElements(baseDir, "/home/linuxbrew/.linuxbrew/Cellar", true);
-    }
-    if (!(options->disabled & FF_PACKAGES_FLAG_PALUDIS_BIT)) packageCounts->paludis += countFilesRecursive(baseDir, "/var/db/paludis/repositories", "environment.bz2");
-    if (!(options->disabled & FF_PACKAGES_FLAG_OPKG_BIT)) packageCounts->opkg += getNumStrings(baseDir, "/usr/lib/opkg/status", "Package:", "opkg"); // openwrt
-    if (!(options->disabled & FF_PACKAGES_FLAG_AM_BIT)) packageCounts->amSystem = getAMSystem(baseDir);
-    if (!(options->disabled & FF_PACKAGES_FLAG_SORCERY_BIT)) packageCounts->sorcery += getNumStrings(baseDir, "/var/state/sorcery/packages", ":installed:", "sorcery");
-    if (!(options->disabled & FF_PACKAGES_FLAG_GUIX_BIT))
-    {
-      packageCounts->guixSystem += getGuixPackages(baseDir, "/run/current-system/profile");
-    }
-    if (!(options->disabled & FF_PACKAGES_FLAG_LINGLONG_BIT)) packageCounts->linglong += getNumElements(baseDir, "/var/lib/linglong/layers", true);
-    if (!(options->disabled & FF_PACKAGES_FLAG_PACSTALL_BIT)) packageCounts->pacstall += getNumElements(baseDir, "/var/lib/pacstall/metadata", false);
-    if (!(options->disabled & FF_PACKAGES_FLAG_PISI_BIT)) packageCounts->pisi += getNumElements(baseDir, "/var/lib/pisi/package", true);
-    if (!(options->disabled & FF_PACKAGES_FLAG_PKGSRC_BIT)) packageCounts->pkgsrc += getNumElements(baseDir, "/usr/pkg/pkgdb", DT_DIR);
-}
-
-static void getPackageCountsRegular(FFstrbuf* baseDir, FFPackagesResult* packageCounts, FFPackagesOptions* options)
-{
+    ffStrbufAppendS(baseDir, entry->d_name);
     getPackageCounts(baseDir, packageCounts, options);
+    ffStrbufSubstrBefore(baseDir, baseDirLength2);
+  }
 
-    if (!(options->disabled & FF_PACKAGES_FLAG_PACMAN_BIT))
-    {
-        uint32_t baseDirLength = baseDir->length;
-        ffStrbufAppendS(baseDir, FASTFETCH_TARGET_DIR_ETC "/pacman-mirrors.conf");
-        if(ffParsePropFile(baseDir->chars, "Branch =", &packageCounts->pacmanBranch) && packageCounts->pacmanBranch.length == 0)
-            ffStrbufAppendS(&packageCounts->pacmanBranch, "stable");
-        ffStrbufSubstrBefore(baseDir, baseDirLength);
-    }
+  ffStrbufSubstrBefore(baseDir, baseDirLength);
 }
 
-static void getPackageCountsBedrock(FFstrbuf* baseDir, FFPackagesResult* packageCounts, FFPackagesOptions* options)
-{
-    uint32_t baseDirLength = baseDir->length;
+void ffDetectPackagesImpl(FFPackagesResult *result,
+                          FFPackagesOptions *options) {
+  FF_STRBUF_AUTO_DESTROY baseDir = ffStrbufCreateA(512);
+  ffStrbufAppendS(&baseDir, FASTFETCH_TARGET_DIR_ROOT);
 
-    ffStrbufAppendS(baseDir, "/bedrock/strata");
+  if (ffStrbufIgnCaseEqualS(&ffDetectOS()->id, "bedrock"))
+    getPackageCountsBedrock(&baseDir, result, options);
+  else
+    getPackageCountsRegular(&baseDir, result, options);
 
-    FF_AUTO_CLOSE_DIR DIR* dir = opendir(baseDir->chars);
-    if(dir == NULL)
-    {
-        ffStrbufSubstrBefore(baseDir, baseDirLength);
-        return;
+// If SQL failed, we can still try with librpm.
+// This is needed on openSUSE, which seems to use a proprietary database file
+// This method doesn't work on bedrock, so we do it here.
+#ifdef FF_HAVE_RPM
+  if (!(options->disabled & FF_PACKAGES_FLAG_RPM_BIT) && result->rpm == 0)
+    result->rpm = getRpmFromLibrpm();
+#endif
+
+  ffStrbufSet(&baseDir, &instance.state.platform.homeDir);
+  if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT)) {
+    // Count packages from $HOME/.nix-profile
+    result->nixUser += ffPackagesGetNix(&baseDir, ".nix-profile");
+
+    // Check in $XDG_STATE_HOME/nix/profile
+    FF_STRBUF_AUTO_DESTROY stateHome = ffStrbufCreate();
+    const char *stateHomeEnv = getenv("XDG_STATE_HOME");
+    if (ffStrSet(stateHomeEnv)) {
+      ffStrbufSetS(&stateHome, stateHomeEnv);
+      ffStrbufEnsureEndsWithC(&stateHome, '/');
+    } else {
+      ffStrbufSet(&stateHome, &instance.state.platform.homeDir);
+      ffStrbufAppendS(&stateHome, ".local/state/");
     }
+    result->nixUser += ffPackagesGetNix(&stateHome, "nix/profile");
 
-    ffStrbufAppendC(baseDir, '/');
-    uint32_t baseDirLength2 = baseDir->length;
+    // Check in /etc/profiles/per-user/$USER
+    FF_STRBUF_AUTO_DESTROY userPkgsDir =
+        ffStrbufCreateStatic("/etc/profiles/per-user/");
+    result->nixUser +=
+        ffPackagesGetNix(&userPkgsDir, instance.state.platform.userName.chars);
+  }
 
-    struct dirent* entry;
-    while((entry = readdir(dir)) != NULL)
-    {
-        if(entry->d_type != DT_DIR)
-            continue;
-        if(entry->d_name[0] == '.')
-            continue;
+  if (!(options->disabled & FF_PACKAGES_FLAG_GUIX_BIT)) {
+    result->guixUser += getGuixPackages(&baseDir, ".guix-profile");
+    result->guixHome += getGuixPackages(&baseDir, ".guix-home/profile");
+  }
 
-        ffStrbufAppendS(baseDir, entry->d_name);
-        getPackageCounts(baseDir, packageCounts, options);
-        ffStrbufSubstrBefore(baseDir, baseDirLength2);
-    }
+  if (!(options->disabled & FF_PACKAGES_FLAG_FLATPAK_BIT))
+    result->flatpakUser = getFlatpakPackages(&baseDir, "/.local/share");
 
-    ffStrbufSubstrBefore(baseDir, baseDirLength);
-}
+  if (!(options->disabled & FF_PACKAGES_FLAG_AM_BIT))
+    result->amUser = getAMUser();
 
-void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options)
-{
-    FF_STRBUF_AUTO_DESTROY baseDir = ffStrbufCreateA(512);
-    ffStrbufAppendS(&baseDir, FASTFETCH_TARGET_DIR_ROOT);
-
-    if(ffStrbufIgnCaseEqualS(&ffDetectOS()->id, "bedrock"))
-        getPackageCountsBedrock(&baseDir, result, options);
-    else
-        getPackageCountsRegular(&baseDir, result, options);
-
-    // If SQL failed, we can still try with librpm.
-    // This is needed on openSUSE, which seems to use a proprietary database file
-    // This method doesn't work on bedrock, so we do it here.
-    #ifdef FF_HAVE_RPM
-        if(!(options->disabled & FF_PACKAGES_FLAG_RPM_BIT) && result->rpm == 0)
-            result->rpm = getRpmFromLibrpm();
-    #endif
-
-    ffStrbufSet(&baseDir, &instance.state.platform.homeDir);
-    if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT))
-    {
-        // Count packages from $HOME/.nix-profile
-        result->nixUser += ffPackagesGetNix(&baseDir, ".nix-profile");
-
-        // Check in $XDG_STATE_HOME/nix/profile
-        FF_STRBUF_AUTO_DESTROY stateHome = ffStrbufCreate();
-        const char* stateHomeEnv = getenv("XDG_STATE_HOME");
-        if (ffStrSet(stateHomeEnv))
-        {
-            ffStrbufSetS(&stateHome, stateHomeEnv);
-            ffStrbufEnsureEndsWithC(&stateHome, '/');
-        }
-        else
-        {
-            ffStrbufSet(&stateHome, &instance.state.platform.homeDir);
-            ffStrbufAppendS(&stateHome, ".local/state/");
-        }
-        result->nixUser += ffPackagesGetNix(&stateHome, "nix/profile");
-
-        // Check in /etc/profiles/per-user/$USER
-        FF_STRBUF_AUTO_DESTROY userPkgsDir = ffStrbufCreateStatic("/etc/profiles/per-user/");
-        result->nixUser += ffPackagesGetNix(&userPkgsDir, instance.state.platform.userName.chars);
-    }
-
-    if (!(options->disabled & FF_PACKAGES_FLAG_GUIX_BIT))
-    {
-       result->guixUser += getGuixPackages(&baseDir, ".guix-profile");
-       result->guixHome += getGuixPackages(&baseDir, ".guix-home/profile");
-    }
-
-    if (!(options->disabled & FF_PACKAGES_FLAG_FLATPAK_BIT))
-        result->flatpakUser = getFlatpakPackages(&baseDir, "/.local/share");
-
-    if (!(options->disabled & FF_PACKAGES_FLAG_AM_BIT))
-        result->amUser = getAMUser();
-
-    if (!(options->disabled & FF_PACKAGES_FLAG_SOAR_BIT))
-        result->soar += getSQLite3Int(&baseDir, ".local/share/soar/db/soar.db", "SELECT COUNT(DISTINCT pkg_id || pkg_name) FROM packages WHERE is_installed = true", "soar");
+  if (!(options->disabled & FF_PACKAGES_FLAG_SOAR_BIT))
+    result->soar += getSQLite3Int(&baseDir, ".local/share/soar/db/soar.db",
+                                  "SELECT COUNT(DISTINCT pkg_id || pkg_name) "
+                                  "FROM packages WHERE is_installed = true",
+                                  "soar");
 }

--- a/src/modules/packages/packages.c
+++ b/src/modules/packages/packages.c
@@ -1,158 +1,138 @@
-#include "common/printing.h"
-#include "common/jsonconfig.h"
-#include "common/stringUtils.h"
 #include "detection/packages/packages.h"
+#include "common/jsonconfig.h"
+#include "common/printing.h"
+#include "common/stringUtils.h"
 #include "modules/packages/packages.h"
 
-bool ffPrintPackages(FFPackagesOptions* options)
-{
-    FFPackagesResult counts = {};
-    ffStrbufInit(&counts.pacmanBranch);
+bool ffPrintPackages(FFPackagesOptions *options) {
+  FFPackagesResult counts = {};
+  ffStrbufInit(&counts.pacmanBranch);
 
-    const char* error = ffDetectPackages(&counts, options);
+  const char *error = ffDetectPackages(&counts, options);
 
-    if(error)
-    {
-        ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, "%s", error);
-        return false;
+  if (error) {
+    ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs,
+                 FF_PRINT_TYPE_DEFAULT, "%s", error);
+    return false;
+  }
+
+  uint32_t nixAll = counts.nixDefault + counts.nixSystem + counts.nixUser;
+  uint32_t flatpakAll = counts.flatpakSystem + counts.flatpakUser;
+  uint32_t brewAll = counts.brew + counts.brewCask;
+  uint32_t guixAll = counts.guixSystem + counts.guixUser + counts.guixHome;
+  uint32_t hpkgAll = counts.hpkgSystem + counts.hpkgUser;
+  uint32_t amAll = counts.amSystem + counts.amUser;
+  uint32_t scoopAll = counts.scoopUser + counts.scoopGlobal;
+
+  if (options->moduleArgs.outputFormat.length == 0) {
+    ffPrintLogoAndKey(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs,
+                      FF_PRINT_TYPE_DEFAULT);
+
+#define FF_PRINT_PACKAGE_NAME(var, name)                                       \
+  {                                                                            \
+    if (counts.var > 0) {                                                      \
+      printf("%u (%s)", counts.var, (name));                                   \
+      if ((all -= counts.var) > 0)                                             \
+        fputs(", ", stdout);                                                   \
+    }                                                                          \
+  }
+
+#define FF_PRINT_PACKAGE(name) FF_PRINT_PACKAGE_NAME(name, #name)
+
+#define FF_PRINT_PACKAGE_ALL(name)                                             \
+  {                                                                            \
+    if (name##All > 0) {                                                       \
+      printf("%u (%s)", name##All, #name);                                     \
+      if ((all -= name##All) > 0)                                              \
+        fputs(", ", stdout);                                                   \
+    }                                                                          \
+  }
+
+    uint32_t all = counts.all;
+    if (counts.pacman > 0) {
+      printf("%u (pacman)", counts.pacman);
+      if (counts.pacmanBranch.length > 0)
+        printf("[%s]", counts.pacmanBranch.chars);
+      if ((all -= counts.pacman) > 0)
+        printf(", ");
+    };
+    FF_PRINT_PACKAGE(dpkg)
+    FF_PRINT_PACKAGE(rpm)
+    FF_PRINT_PACKAGE(emerge)
+    FF_PRINT_PACKAGE(eopkg)
+    FF_PRINT_PACKAGE(xbps)
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(nix);
+    } else {
+      FF_PRINT_PACKAGE_NAME(nixSystem, "nix-system")
+      FF_PRINT_PACKAGE_NAME(nixUser, "nix-user")
+      FF_PRINT_PACKAGE_NAME(nixDefault, "nix-default")
     }
-
-    uint32_t nixAll = counts.nixDefault + counts.nixSystem + counts.nixUser;
-    uint32_t flatpakAll = counts.flatpakSystem + counts.flatpakUser;
-    uint32_t brewAll = counts.brew + counts.brewCask;
-    uint32_t guixAll = counts.guixSystem + counts.guixUser + counts.guixHome;
-    uint32_t hpkgAll = counts.hpkgSystem + counts.hpkgUser;
-    uint32_t amAll = counts.amSystem + counts.amUser;
-    uint32_t scoopAll = counts.scoopUser + counts.scoopGlobal;
-
-    if(options->moduleArgs.outputFormat.length == 0)
-    {
-        ffPrintLogoAndKey(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT);
-
-        #define FF_PRINT_PACKAGE_NAME(var, name) {\
-            if(counts.var > 0) \
-            { \
-                printf("%u (%s)", counts.var, (name)); \
-                if((all -= counts.var) > 0) \
-                    fputs(", ", stdout); \
-            } \
-        }
-
-        #define FF_PRINT_PACKAGE(name) FF_PRINT_PACKAGE_NAME(name, #name)
-
-        #define FF_PRINT_PACKAGE_ALL(name) {\
-            if(name ## All > 0) \
-            { \
-                printf("%u (%s)", name ## All, #name); \
-                if((all -= name ## All) > 0) \
-                    fputs(", ", stdout); \
-            } \
-        }
-
-        uint32_t all = counts.all;
-        if(counts.pacman > 0)
-        {
-            printf("%u (pacman)", counts.pacman);
-            if(counts.pacmanBranch.length > 0)
-                printf("[%s]", counts.pacmanBranch.chars);
-            if((all -= counts.pacman) > 0)
-                printf(", ");
-        };
-        FF_PRINT_PACKAGE(dpkg)
-        FF_PRINT_PACKAGE(rpm)
-        FF_PRINT_PACKAGE(emerge)
-        FF_PRINT_PACKAGE(eopkg)
-        FF_PRINT_PACKAGE(xbps)
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(nix);
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(nixSystem, "nix-system")
-            FF_PRINT_PACKAGE_NAME(nixUser, "nix-user")
-            FF_PRINT_PACKAGE_NAME(nixDefault, "nix-default")
-        }
-        FF_PRINT_PACKAGE(apk)
-        FF_PRINT_PACKAGE(pkg)
-        FF_PRINT_PACKAGE(pkgsrc)
-        FF_PRINT_PACKAGE(kiss)
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(hpkg)
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(hpkgSystem, counts.hpkgUser ? "hpkg-system" : "hpkg")
-            FF_PRINT_PACKAGE_NAME(hpkgUser, "hpkg-user")
-        }
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(flatpak);
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(flatpakSystem, counts.flatpakUser ? "flatpak-system" : "flatpak")
-            FF_PRINT_PACKAGE_NAME(flatpakUser, "flatpak-user")
-        }
-        FF_PRINT_PACKAGE(snap)
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(brew);
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(brew, "brew")
-            FF_PRINT_PACKAGE_NAME(brewCask, "brew-cask")
-        }
-        FF_PRINT_PACKAGE(macports)
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(scoop);
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(scoopUser, counts.scoopGlobal ? "scoop-user" : "scoop")
-            FF_PRINT_PACKAGE_NAME(scoopGlobal, "scoop-global")
-        }
-        FF_PRINT_PACKAGE(choco)
-        FF_PRINT_PACKAGE(pkgtool)
-        FF_PRINT_PACKAGE(paludis)
-        FF_PRINT_PACKAGE(winget)
-        FF_PRINT_PACKAGE(opkg)
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(am);
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(amSystem, "am")
-            FF_PRINT_PACKAGE_NAME(amUser, "appman")
-        }
-        FF_PRINT_PACKAGE(sorcery)
-        FF_PRINT_PACKAGE(lpkg)
-        FF_PRINT_PACKAGE(lpkgbuild)
-        if (options->combined)
-        {
-            FF_PRINT_PACKAGE_ALL(guix);
-        }
-        else
-        {
-            FF_PRINT_PACKAGE_NAME(guixSystem, "guix-system")
-            FF_PRINT_PACKAGE_NAME(guixUser, "guix-user")
-            FF_PRINT_PACKAGE_NAME(guixHome, "guix-home")
-        }
-        FF_PRINT_PACKAGE(linglong)
-        FF_PRINT_PACKAGE(pacstall)
-        FF_PRINT_PACKAGE(mport)
-        FF_PRINT_PACKAGE(pisi)
-        FF_PRINT_PACKAGE(soar)
-
-        putchar('\n');
+    FF_PRINT_PACKAGE(apk)
+    FF_PRINT_PACKAGE(pkg)
+    FF_PRINT_PACKAGE(pkgsrc)
+    FF_PRINT_PACKAGE(kiss)
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(hpkg)
+    } else {
+      FF_PRINT_PACKAGE_NAME(hpkgSystem,
+                            counts.hpkgUser ? "hpkg-system" : "hpkg")
+      FF_PRINT_PACKAGE_NAME(hpkgUser, "hpkg-user")
     }
-    else
-    {
-        FF_PRINT_FORMAT_CHECKED(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, ((FFformatarg[]){
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(flatpak);
+    } else {
+      FF_PRINT_PACKAGE_NAME(flatpakSystem,
+                            counts.flatpakUser ? "flatpak-system" : "flatpak")
+      FF_PRINT_PACKAGE_NAME(flatpakUser, "flatpak-user")
+    }
+    FF_PRINT_PACKAGE(snap)
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(brew);
+    } else {
+      FF_PRINT_PACKAGE_NAME(brew, "brew")
+      FF_PRINT_PACKAGE_NAME(brewCask, "brew-cask")
+    }
+    FF_PRINT_PACKAGE(macports)
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(scoop);
+    } else {
+      FF_PRINT_PACKAGE_NAME(scoopUser,
+                            counts.scoopGlobal ? "scoop-user" : "scoop")
+      FF_PRINT_PACKAGE_NAME(scoopGlobal, "scoop-global")
+    }
+    FF_PRINT_PACKAGE(choco)
+    FF_PRINT_PACKAGE(pkgtool)
+    FF_PRINT_PACKAGE(paludis)
+    FF_PRINT_PACKAGE(winget)
+    FF_PRINT_PACKAGE(opkg)
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(am);
+    } else {
+      FF_PRINT_PACKAGE_NAME(amSystem, "am")
+      FF_PRINT_PACKAGE_NAME(amUser, "appman")
+    }
+    FF_PRINT_PACKAGE(sorcery)
+    FF_PRINT_PACKAGE(lpkg)
+    FF_PRINT_PACKAGE(lpkgbuild)
+    if (options->combined) {
+      FF_PRINT_PACKAGE_ALL(guix);
+    } else {
+      FF_PRINT_PACKAGE_NAME(guixSystem, "guix-system")
+      FF_PRINT_PACKAGE_NAME(guixUser, "guix-user")
+      FF_PRINT_PACKAGE_NAME(guixHome, "guix-home")
+    }
+    FF_PRINT_PACKAGE(linglong)
+    FF_PRINT_PACKAGE(pacstall)
+    FF_PRINT_PACKAGE(mport)
+    FF_PRINT_PACKAGE(pisi)
+    FF_PRINT_PACKAGE(soar)
+
+    putchar('\n');
+  } else {
+    FF_PRINT_FORMAT_CHECKED(
+        FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT,
+        ((FFformatarg[]){
             FF_FORMAT_ARG(counts.all, "all"),
             FF_FORMAT_ARG(counts.pacman, "pacman"),
             FF_FORMAT_ARG(counts.pacmanBranch, "pacman-branch"),
@@ -202,267 +182,304 @@ bool ffPrintPackages(FFPackagesOptions* options)
             FF_FORMAT_ARG(guixAll, "guix-all"),
             FF_FORMAT_ARG(hpkgAll, "hpkg-all"),
         }));
-    }
+  }
 
-    ffStrbufDestroy(&counts.pacmanBranch);
+  ffStrbufDestroy(&counts.pacmanBranch);
 
-    return true;
+  return true;
 }
 
-void ffParsePackagesJsonObject(FFPackagesOptions* options, yyjson_val* module)
-{
-    yyjson_val *key, *val;
-    size_t idx, max;
-    yyjson_obj_foreach(module, idx, max, key, val)
-    {
-        if (ffJsonConfigParseModuleArgs(key, val, &options->moduleArgs))
+void ffParsePackagesJsonObject(FFPackagesOptions *options, yyjson_val *module) {
+  yyjson_val *key, *val;
+  size_t idx, max;
+  yyjson_obj_foreach(module, idx, max, key, val) {
+    if (ffJsonConfigParseModuleArgs(key, val, &options->moduleArgs))
+      continue;
+
+    if (unsafe_yyjson_equals_str(key, "disabled")) {
+      if (!yyjson_is_null(val) && !yyjson_is_arr(val)) {
+        ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs,
+                     FF_PRINT_TYPE_DEFAULT, "Invalid JSON value for %s",
+                     unsafe_yyjson_get_str(key));
+        continue;
+      }
+
+      options->disabled = FF_PACKAGES_FLAG_NONE;
+
+      if (yyjson_is_arr(val)) {
+        yyjson_val *flagObj;
+        size_t flagIdx, flagMax;
+        yyjson_arr_foreach(val, flagIdx, flagMax, flagObj) {
+          if (!yyjson_is_str(flagObj)) {
+            ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs,
+                         FF_PRINT_TYPE_DEFAULT, "Invalid JSON value for %s",
+                         unsafe_yyjson_get_str(key));
             continue;
+          }
+          const char *flag = unsafe_yyjson_get_str(flagObj);
 
-        if (unsafe_yyjson_equals_str(key, "disabled"))
-        {
-            if (!yyjson_is_null(val) && !yyjson_is_arr(val))
-            {
-                ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, "Invalid JSON value for %s", unsafe_yyjson_get_str(key));
-                continue;
-            }
-
-            options->disabled = FF_PACKAGES_FLAG_NONE;
-
-            if (yyjson_is_arr(val))
-            {
-                yyjson_val* flagObj;
-                size_t flagIdx, flagMax;
-                yyjson_arr_foreach(val, flagIdx, flagMax, flagObj)
-                {
-                    if (!yyjson_is_str(flagObj))
-                    {
-                        ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, "Invalid JSON value for %s", unsafe_yyjson_get_str(key));
-                        continue;
-                    }
-                    const char* flag = unsafe_yyjson_get_str(flagObj);
-
-                    #define FF_TEST_PACKAGE_NAME(name) else if (ffStrEqualsIgnCase(flag, #name)) { options->disabled |= FF_PACKAGES_FLAG_ ## name ## _BIT; }
-                    switch (toupper(flag[0]))
-                    {
-                        case 'A': if (false);
-                            FF_TEST_PACKAGE_NAME(APK)
-                            FF_TEST_PACKAGE_NAME(AM)
-                            break;
-                        case 'B': if (false);
-                            FF_TEST_PACKAGE_NAME(BREW)
-                            break;
-                        case 'C': if (false);
-                            FF_TEST_PACKAGE_NAME(CHOCO)
-                            break;
-                        case 'D': if (false);
-                            FF_TEST_PACKAGE_NAME(DPKG)
-                            break;
-                        case 'E': if (false);
-                            FF_TEST_PACKAGE_NAME(EMERGE)
-                            FF_TEST_PACKAGE_NAME(EOPKG)
-                            break;
-                        case 'F': if (false);
-                            FF_TEST_PACKAGE_NAME(FLATPAK)
-                            break;
-                        case 'G': if (false);
-                            FF_TEST_PACKAGE_NAME(GUIX)
-                            break;
-                        case 'H': if (false);
-                            FF_TEST_PACKAGE_NAME(HPKG)
-                            break;
-                        case 'K': if (false);
-                            FF_TEST_PACKAGE_NAME(KISS)
-                            break;
-                        case 'L': if (false);
-                            FF_TEST_PACKAGE_NAME(LPKG)
-                            FF_TEST_PACKAGE_NAME(LPKGBUILD)
-                            FF_TEST_PACKAGE_NAME(LINGLONG)
-                            break;
-                        case 'M': if (false);
-                            FF_TEST_PACKAGE_NAME(MACPORTS)
-                            FF_TEST_PACKAGE_NAME(MPORT)
-                            break;
-                        case 'N': if (false);
-                            FF_TEST_PACKAGE_NAME(NIX)
-                            break;
-                        case 'O': if (false);
-                            FF_TEST_PACKAGE_NAME(OPKG)
-                            break;
-                        case 'P': if (false);
-                            FF_TEST_PACKAGE_NAME(PACMAN)
-                            FF_TEST_PACKAGE_NAME(PACSTALL)
-                            FF_TEST_PACKAGE_NAME(PALUDIS)
-                            FF_TEST_PACKAGE_NAME(PISI)
-                            FF_TEST_PACKAGE_NAME(PKG)
-                            FF_TEST_PACKAGE_NAME(PKGTOOL)
-                            FF_TEST_PACKAGE_NAME(PKGSRC)
-                            break;
-                        case 'R': if (false);
-                            FF_TEST_PACKAGE_NAME(RPM)
-                            break;
-                        case 'S': if (false);
-                            FF_TEST_PACKAGE_NAME(SCOOP)
-                            FF_TEST_PACKAGE_NAME(SNAP)
-                            FF_TEST_PACKAGE_NAME(SOAR)
-                            FF_TEST_PACKAGE_NAME(SORCERY)
-                            break;
-                        case 'W': if (false);
-                            FF_TEST_PACKAGE_NAME(WINGET)
-                            break;
-                        case 'X': if (false);
-                            FF_TEST_PACKAGE_NAME(XBPS)
-                            break;
-                    }
-                    #undef FF_TEST_PACKAGE_NAME
-                }
-                continue;
-            }
+#define FF_TEST_PACKAGE_NAME(name)                                             \
+  else if (ffStrEqualsIgnCase(flag, #name)) {                                  \
+    options->disabled |= FF_PACKAGES_FLAG_##name##_BIT;                        \
+  }
+          switch (toupper(flag[0])) {
+          case 'A':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(APK)
+            FF_TEST_PACKAGE_NAME(AM)
+            break;
+          case 'B':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(BREW)
+            break;
+          case 'C':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(CHOCO)
+            break;
+          case 'D':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(DPKG)
+            break;
+          case 'E':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(EMERGE)
+            FF_TEST_PACKAGE_NAME(EOPKG)
+            break;
+          case 'F':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(FLATPAK)
+            break;
+          case 'G':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(GUIX)
+            break;
+          case 'H':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(HPKG)
+            break;
+          case 'K':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(KISS)
+            break;
+          case 'L':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(LPKG)
+            FF_TEST_PACKAGE_NAME(LPKGBUILD)
+            FF_TEST_PACKAGE_NAME(LINGLONG)
+            break;
+          case 'M':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(MACPORTS)
+            FF_TEST_PACKAGE_NAME(MPORT)
+            break;
+          case 'N':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(NIX)
+            break;
+          case 'O':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(OPKG)
+            break;
+          case 'P':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(PACMAN)
+            FF_TEST_PACKAGE_NAME(PACSTALL)
+            FF_TEST_PACKAGE_NAME(PALUDIS)
+            FF_TEST_PACKAGE_NAME(PISI)
+            FF_TEST_PACKAGE_NAME(PKG)
+            FF_TEST_PACKAGE_NAME(PKGTOOL)
+            FF_TEST_PACKAGE_NAME(PKGSRC)
+            break;
+          case 'R':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(RPM)
+            break;
+          case 'S':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(SCOOP)
+            FF_TEST_PACKAGE_NAME(SNAP)
+            FF_TEST_PACKAGE_NAME(SOAR)
+            FF_TEST_PACKAGE_NAME(SORCERY)
+            break;
+          case 'W':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(WINGET)
+            break;
+          case 'X':
+            if (false)
+              ;
+            FF_TEST_PACKAGE_NAME(XBPS)
+            break;
+          }
+#undef FF_TEST_PACKAGE_NAME
         }
-
-        if (unsafe_yyjson_equals_str(key, "combined"))
-        {
-            options->combined = yyjson_get_bool(val);
-            continue;
-        }
-
-        ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs, FF_PRINT_TYPE_DEFAULT, "Unknown JSON key %s", unsafe_yyjson_get_str(key));
-    }
-}
-
-void ffGeneratePackagesJsonConfig(FFPackagesOptions* options, yyjson_mut_doc* doc, yyjson_mut_val* module)
-{
-    ffJsonConfigGenerateModuleArgsConfig(doc, module, &options->moduleArgs);
-
-    FF_STRBUF_AUTO_DESTROY buf = ffStrbufCreate();
-    yyjson_mut_val* arr = yyjson_mut_obj_add_arr(doc, module, "disabled");
-    #define FF_TEST_PACKAGE_NAME(name) else if ((options->disabled & FF_PACKAGES_FLAG_ ## name ## _BIT)) { \
-        ffStrbufSetS(&buf, #name); \
-        ffStrbufLowerCase(&buf); \
-        yyjson_mut_arr_add_strbuf(doc, arr, &buf); \
-    }
-    if (false);
-    FF_TEST_PACKAGE_NAME(AM)
-    FF_TEST_PACKAGE_NAME(APK)
-    FF_TEST_PACKAGE_NAME(BREW)
-    FF_TEST_PACKAGE_NAME(CHOCO)
-    FF_TEST_PACKAGE_NAME(DPKG)
-    FF_TEST_PACKAGE_NAME(EMERGE)
-    FF_TEST_PACKAGE_NAME(EOPKG)
-    FF_TEST_PACKAGE_NAME(FLATPAK)
-    FF_TEST_PACKAGE_NAME(GUIX)
-    FF_TEST_PACKAGE_NAME(HPKG)
-    FF_TEST_PACKAGE_NAME(KISS)
-    FF_TEST_PACKAGE_NAME(LINGLONG)
-    FF_TEST_PACKAGE_NAME(LPKG)
-    FF_TEST_PACKAGE_NAME(LPKGBUILD)
-    FF_TEST_PACKAGE_NAME(MACPORTS)
-    FF_TEST_PACKAGE_NAME(MPORT)
-    FF_TEST_PACKAGE_NAME(NIX)
-    FF_TEST_PACKAGE_NAME(OPKG)
-    FF_TEST_PACKAGE_NAME(PACMAN)
-    FF_TEST_PACKAGE_NAME(PACSTALL)
-    FF_TEST_PACKAGE_NAME(PALUDIS)
-    FF_TEST_PACKAGE_NAME(PISI)
-    FF_TEST_PACKAGE_NAME(PKG)
-    FF_TEST_PACKAGE_NAME(PKGTOOL)
-    FF_TEST_PACKAGE_NAME(PKGSRC)
-    FF_TEST_PACKAGE_NAME(RPM)
-    FF_TEST_PACKAGE_NAME(SCOOP)
-    FF_TEST_PACKAGE_NAME(SNAP)
-    FF_TEST_PACKAGE_NAME(SOAR)
-    FF_TEST_PACKAGE_NAME(SORCERY)
-    FF_TEST_PACKAGE_NAME(WINGET)
-    FF_TEST_PACKAGE_NAME(XBPS)
-    #undef FF_TEST_PACKAGE_NAME
-
-    yyjson_mut_obj_add_bool(doc, module, "combined", options->combined);
-}
-
-bool ffGeneratePackagesJsonResult(FF_MAYBE_UNUSED FFPackagesOptions* options, yyjson_mut_doc* doc, yyjson_mut_val* module)
-{
-    FFPackagesResult counts = {};
-    ffStrbufInit(&counts.pacmanBranch);
-
-    const char* error = ffDetectPackages(&counts, options);
-
-    if(error)
-    {
-        yyjson_mut_obj_add_str(doc, module, "error", error);
-        return false;
+        continue;
+      }
     }
 
-    yyjson_mut_val* obj = yyjson_mut_obj_add_obj(doc, module, "result");
+    if (unsafe_yyjson_equals_str(key, "combined")) {
+      options->combined = yyjson_get_bool(val);
+      continue;
+    }
 
-    #define FF_APPEND_PACKAGE_COUNT(name) yyjson_mut_obj_add_uint(doc, obj, #name, counts.name);
-
-    FF_APPEND_PACKAGE_COUNT(all)
-    FF_APPEND_PACKAGE_COUNT(amSystem)
-    FF_APPEND_PACKAGE_COUNT(amUser)
-    FF_APPEND_PACKAGE_COUNT(apk)
-    FF_APPEND_PACKAGE_COUNT(brew)
-    FF_APPEND_PACKAGE_COUNT(brewCask)
-    FF_APPEND_PACKAGE_COUNT(choco)
-    FF_APPEND_PACKAGE_COUNT(dpkg)
-    FF_APPEND_PACKAGE_COUNT(emerge)
-    FF_APPEND_PACKAGE_COUNT(eopkg)
-    FF_APPEND_PACKAGE_COUNT(flatpakSystem)
-    FF_APPEND_PACKAGE_COUNT(flatpakUser)
-    FF_APPEND_PACKAGE_COUNT(guixSystem)
-    FF_APPEND_PACKAGE_COUNT(guixUser)
-    FF_APPEND_PACKAGE_COUNT(guixHome)
-    FF_APPEND_PACKAGE_COUNT(hpkgSystem)
-    FF_APPEND_PACKAGE_COUNT(hpkgUser)
-    FF_APPEND_PACKAGE_COUNT(linglong)
-    FF_APPEND_PACKAGE_COUNT(mport)
-    FF_APPEND_PACKAGE_COUNT(nixDefault)
-    FF_APPEND_PACKAGE_COUNT(nixSystem)
-    FF_APPEND_PACKAGE_COUNT(nixUser)
-    FF_APPEND_PACKAGE_COUNT(opkg)
-    FF_APPEND_PACKAGE_COUNT(pacman)
-    FF_APPEND_PACKAGE_COUNT(pacstall)
-    FF_APPEND_PACKAGE_COUNT(paludis)
-    FF_APPEND_PACKAGE_COUNT(pisi)
-    FF_APPEND_PACKAGE_COUNT(pkg)
-    FF_APPEND_PACKAGE_COUNT(pkgtool)
-    FF_APPEND_PACKAGE_COUNT(pkgsrc)
-    FF_APPEND_PACKAGE_COUNT(macports)
-    FF_APPEND_PACKAGE_COUNT(rpm)
-    FF_APPEND_PACKAGE_COUNT(scoopUser)
-    FF_APPEND_PACKAGE_COUNT(scoopGlobal)
-    FF_APPEND_PACKAGE_COUNT(snap)
-    FF_APPEND_PACKAGE_COUNT(soar)
-    FF_APPEND_PACKAGE_COUNT(kiss)
-    FF_APPEND_PACKAGE_COUNT(sorcery)
-    FF_APPEND_PACKAGE_COUNT(winget)
-    FF_APPEND_PACKAGE_COUNT(xbps)
-    yyjson_mut_obj_add_strbuf(doc, obj, "pacmanBranch", &counts.pacmanBranch);
-
-    return true;
+    ffPrintError(FF_PACKAGES_MODULE_NAME, 0, &options->moduleArgs,
+                 FF_PRINT_TYPE_DEFAULT, "Unknown JSON key %s",
+                 unsafe_yyjson_get_str(key));
+  }
 }
 
-void ffInitPackagesOptions(FFPackagesOptions* options)
-{
-    ffOptionInitModuleArg(&options->moduleArgs, "󰏖");
+void ffGeneratePackagesJsonConfig(FFPackagesOptions *options,
+                                  yyjson_mut_doc *doc, yyjson_mut_val *module) {
+  ffJsonConfigGenerateModuleArgsConfig(doc, module, &options->moduleArgs);
 
-    options->disabled = FF_PACKAGES_DISABLE_LIST;
-    options->combined = false;
+  FF_STRBUF_AUTO_DESTROY buf = ffStrbufCreate();
+  yyjson_mut_val *arr = yyjson_mut_obj_add_arr(doc, module, "disabled");
+#define FF_TEST_PACKAGE_NAME(name)                                             \
+  else if ((options->disabled & FF_PACKAGES_FLAG_##name##_BIT)) {              \
+    ffStrbufSetS(&buf, #name);                                                 \
+    ffStrbufLowerCase(&buf);                                                   \
+    yyjson_mut_arr_add_strbuf(doc, arr, &buf);                                 \
+  }
+  if (false)
+    ;
+  FF_TEST_PACKAGE_NAME(AM)
+  FF_TEST_PACKAGE_NAME(APK)
+  FF_TEST_PACKAGE_NAME(BREW)
+  FF_TEST_PACKAGE_NAME(CHOCO)
+  FF_TEST_PACKAGE_NAME(DPKG)
+  FF_TEST_PACKAGE_NAME(EMERGE)
+  FF_TEST_PACKAGE_NAME(EOPKG)
+  FF_TEST_PACKAGE_NAME(FLATPAK)
+  FF_TEST_PACKAGE_NAME(GUIX)
+  FF_TEST_PACKAGE_NAME(HPKG)
+  FF_TEST_PACKAGE_NAME(KISS)
+  FF_TEST_PACKAGE_NAME(LINGLONG)
+  FF_TEST_PACKAGE_NAME(LPKG)
+  FF_TEST_PACKAGE_NAME(LPKGBUILD)
+  FF_TEST_PACKAGE_NAME(MACPORTS)
+  FF_TEST_PACKAGE_NAME(MPORT)
+  FF_TEST_PACKAGE_NAME(NIX)
+  FF_TEST_PACKAGE_NAME(OPKG)
+  FF_TEST_PACKAGE_NAME(PACMAN)
+  FF_TEST_PACKAGE_NAME(PACSTALL)
+  FF_TEST_PACKAGE_NAME(PALUDIS)
+  FF_TEST_PACKAGE_NAME(PISI)
+  FF_TEST_PACKAGE_NAME(PKG)
+  FF_TEST_PACKAGE_NAME(PKGTOOL)
+  FF_TEST_PACKAGE_NAME(PKGSRC)
+  FF_TEST_PACKAGE_NAME(RPM)
+  FF_TEST_PACKAGE_NAME(SCOOP)
+  FF_TEST_PACKAGE_NAME(SNAP)
+  FF_TEST_PACKAGE_NAME(SOAR)
+  FF_TEST_PACKAGE_NAME(SORCERY)
+  FF_TEST_PACKAGE_NAME(WINGET)
+  FF_TEST_PACKAGE_NAME(XBPS)
+#undef FF_TEST_PACKAGE_NAME
+
+  yyjson_mut_obj_add_bool(doc, module, "combined", options->combined);
 }
 
-void ffDestroyPackagesOptions(FFPackagesOptions* options)
-{
-    ffOptionDestroyModuleArg(&options->moduleArgs);
+bool ffGeneratePackagesJsonResult(FF_MAYBE_UNUSED FFPackagesOptions *options,
+                                  yyjson_mut_doc *doc, yyjson_mut_val *module) {
+  FFPackagesResult counts = {};
+  ffStrbufInit(&counts.pacmanBranch);
+
+  const char *error = ffDetectPackages(&counts, options);
+
+  if (error) {
+    yyjson_mut_obj_add_str(doc, module, "error", error);
+    return false;
+  }
+
+  yyjson_mut_val *obj = yyjson_mut_obj_add_obj(doc, module, "result");
+
+#define FF_APPEND_PACKAGE_COUNT(name)                                          \
+  yyjson_mut_obj_add_uint(doc, obj, #name, counts.name);
+
+  FF_APPEND_PACKAGE_COUNT(all)
+  FF_APPEND_PACKAGE_COUNT(amSystem)
+  FF_APPEND_PACKAGE_COUNT(amUser)
+  FF_APPEND_PACKAGE_COUNT(apk)
+  FF_APPEND_PACKAGE_COUNT(brew)
+  FF_APPEND_PACKAGE_COUNT(brewCask)
+  FF_APPEND_PACKAGE_COUNT(choco)
+  FF_APPEND_PACKAGE_COUNT(dpkg)
+  FF_APPEND_PACKAGE_COUNT(emerge)
+  FF_APPEND_PACKAGE_COUNT(eopkg)
+  FF_APPEND_PACKAGE_COUNT(flatpakSystem)
+  FF_APPEND_PACKAGE_COUNT(flatpakUser)
+  FF_APPEND_PACKAGE_COUNT(guixSystem)
+  FF_APPEND_PACKAGE_COUNT(guixUser)
+  FF_APPEND_PACKAGE_COUNT(guixHome)
+  FF_APPEND_PACKAGE_COUNT(hpkgSystem)
+  FF_APPEND_PACKAGE_COUNT(hpkgUser)
+  FF_APPEND_PACKAGE_COUNT(linglong)
+  FF_APPEND_PACKAGE_COUNT(mport)
+  FF_APPEND_PACKAGE_COUNT(nixDefault)
+  FF_APPEND_PACKAGE_COUNT(nixSystem)
+  FF_APPEND_PACKAGE_COUNT(nixUser)
+  FF_APPEND_PACKAGE_COUNT(opkg)
+  FF_APPEND_PACKAGE_COUNT(pacman)
+  FF_APPEND_PACKAGE_COUNT(pacstall)
+  FF_APPEND_PACKAGE_COUNT(paludis)
+  FF_APPEND_PACKAGE_COUNT(pisi)
+  FF_APPEND_PACKAGE_COUNT(pkg)
+  FF_APPEND_PACKAGE_COUNT(pkgtool)
+  FF_APPEND_PACKAGE_COUNT(pkgsrc)
+  FF_APPEND_PACKAGE_COUNT(macports)
+  FF_APPEND_PACKAGE_COUNT(rpm)
+  FF_APPEND_PACKAGE_COUNT(scoopUser)
+  FF_APPEND_PACKAGE_COUNT(scoopGlobal)
+  FF_APPEND_PACKAGE_COUNT(snap)
+  FF_APPEND_PACKAGE_COUNT(soar)
+  FF_APPEND_PACKAGE_COUNT(kiss)
+  FF_APPEND_PACKAGE_COUNT(sorcery)
+  FF_APPEND_PACKAGE_COUNT(winget)
+  FF_APPEND_PACKAGE_COUNT(xbps)
+  yyjson_mut_obj_add_strbuf(doc, obj, "pacmanBranch", &counts.pacmanBranch);
+
+  return true;
+}
+
+void ffInitPackagesOptions(FFPackagesOptions *options) {
+  ffOptionInitModuleArg(&options->moduleArgs, "󰏖");
+
+  options->disabled = FF_PACKAGES_DISABLE_LIST;
+  options->combined = false;
+}
+
+void ffDestroyPackagesOptions(FFPackagesOptions *options) {
+  ffOptionDestroyModuleArg(&options->moduleArgs);
 }
 
 FFModuleBaseInfo ffPackagesModuleInfo = {
     .name = FF_PACKAGES_MODULE_NAME,
-    .description = "List installed package managers and count of installed packages",
-    .initOptions = (void*) ffInitPackagesOptions,
-    .destroyOptions = (void*) ffDestroyPackagesOptions,
-    .parseJsonObject = (void*) ffParsePackagesJsonObject,
-    .printModule = (void*) ffPrintPackages,
-    .generateJsonResult = (void*) ffGeneratePackagesJsonResult,
-    .generateJsonConfig = (void*) ffGeneratePackagesJsonConfig,
-    .formatArgs = FF_FORMAT_ARG_LIST(((FFModuleFormatArg[]) {
+    .description =
+        "List installed package managers and count of installed packages",
+    .initOptions = (void *)ffInitPackagesOptions,
+    .destroyOptions = (void *)ffDestroyPackagesOptions,
+    .parseJsonObject = (void *)ffParsePackagesJsonObject,
+    .printModule = (void *)ffPrintPackages,
+    .generateJsonResult = (void *)ffGeneratePackagesJsonResult,
+    .generateJsonConfig = (void *)ffGeneratePackagesJsonConfig,
+    .formatArgs = FF_FORMAT_ARG_LIST(((FFModuleFormatArg[]){
         {"Number of all packages", "all"},
         {"Number of pacman packages", "pacman"},
         {"Pacman branch on manjaro", "pacman-branch"},
@@ -511,5 +528,4 @@ FFModuleBaseInfo ffPackagesModuleInfo = {
         {"Total number of all brew packages", "brew-all"},
         {"Total number of all guix packages", "guix-all"},
         {"Total number of all hpkg packages", "hpkg-all"},
-    }))
-};
+    }))};


### PR DESCRIPTION

## Summary

Replace the original hardcoded pacman database path. Now it will auto detect the DBPath directory configured by `/etc/pacman.conf`. If `DBPath` is not set, it will fall back to the default `/var/lib/pacman/local`.


## Related issue

Closes #2068


## Changes

- Modified `src/detection/packages/packages_linux.c`. Added a static function `getPacmanPackages `


## Checklist

- [x] I have tested my changes locally.
