### PR TITLE
Improve HarmonyOS Detection Code

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -330,6 +330,140 @@ static bool detectBedrock(FFOSResult* os)
     return false;
 }
 
+static bool detectHarmonyOS(FFOSResult* os)
+{
+    // HarmonyOS 5+ uses param command to read system parameters
+    // Check for const.product.os.dist.name=HarmonyOS
+    FF_STRBUF_AUTO_DESTROY osName = ffStrbufCreate();
+    if (ffProcessAppendStdOut(&osName, (char* const[]) {
+        "param", "get", "const.product.os.dist.name",
+        NULL,
+    }) != NULL)
+        return false;
+
+    ffStrbufTrimRightSpace(&osName);
+    if (!ffStrbufEqualS(&osName, "HarmonyOS"))
+        return false;
+
+    // Detected HarmonyOS - read version and other info
+    ffStrbufSetS(&os->id, "harmonyos");
+    ffStrbufSetS(&os->idLike, "harmonyos");
+    ffStrbufSetS(&os->name, "HarmonyOS");
+
+    // Read base version (e.g., 6.0.0)
+    FF_STRBUF_AUTO_DESTROY baseVersion = ffStrbufCreate();
+    if (ffProcessAppendStdOut(&baseVersion, (char* const[]) {
+        "param", "get", "const.product.os.dist.version",
+        NULL,
+    }) == NULL)
+    {
+        ffStrbufTrimRightSpace(&baseVersion);
+        if (baseVersion.length > 0)
+            ffStrbufSet(&os->version, &baseVersion);
+    }
+
+    // Read full incremental version (e.g., 6.0.1.112) - this is the complete version
+    FF_STRBUF_AUTO_DESTROY fullVersion = ffStrbufCreate();
+    if (ffProcessAppendStdOut(&fullVersion, (char* const[]) {
+        "param", "get", "const.product.incremental.version",
+        NULL,
+    }) == NULL)
+    {
+        ffStrbufTrimRightSpace(&fullVersion);
+        if (fullVersion.length > 0)
+            ffStrbufSet(&os->versionID, &fullVersion);
+        else if (baseVersion.length > 0)
+            ffStrbufSet(&os->versionID, &baseVersion);
+    }
+    else if (baseVersion.length > 0)
+    {
+        ffStrbufSet(&os->versionID, &baseVersion);
+    }
+
+    // Read API version - store in variant field
+    FF_STRBUF_AUTO_DESTROY apiVersion = ffStrbufCreate();
+    if (ffProcessAppendStdOut(&apiVersion, (char* const[]) {
+        "param", "get", "const.ohos.apiversion",
+        NULL,
+    }) == NULL)
+    {
+        ffStrbufTrimRightSpace(&apiVersion);
+        if (apiVersion.length > 0)
+        {
+            ffStrbufSet(&os->variant, &apiVersion);
+        }
+    }
+
+    // Read pretty name (full version name)
+    FF_STRBUF_AUTO_DESTROY prettyName = ffStrbufCreate();
+    bool hasPrettyName = (ffProcessAppendStdOut(&prettyName, (char* const[]) {
+        "param", "get", "const.product.software.version.name",
+        NULL,
+    }) == NULL);
+
+    if (hasPrettyName)
+    {
+        ffStrbufTrimRightSpace(&prettyName);
+        if (prettyName.length > 0)
+        {
+            // Append versionID if available
+            if (os->versionID.length > 0)
+            {
+                ffStrbufAppendC(&prettyName, ' ');
+                ffStrbufAppend(&prettyName, &os->versionID);
+            }
+            // Append API level (variant) if available
+            if (os->variant.length > 0)
+            {
+                ffStrbufAppendS(&prettyName, " (API ");
+                ffStrbufAppend(&prettyName, &os->variant);
+                ffStrbufAppendC(&prettyName, ')');
+            }
+            ffStrbufSet(&os->prettyName, &prettyName);
+        }
+    }
+
+    // Fallback: construct pretty name from version if we don't have one yet
+    if (os->prettyName.length == 0)
+    {
+        if (os->versionID.length > 0)
+        {
+            if (os->variant.length > 0)
+                ffStrbufSetF(&os->prettyName, "HarmonyOS %s (API %s)", os->versionID.chars, os->variant.chars);
+            else
+                ffStrbufSetF(&os->prettyName, "HarmonyOS %s", os->versionID.chars);
+        }
+        else
+            ffStrbufSetS(&os->prettyName, "HarmonyOS");
+    }
+
+    // Read build ID
+    FF_STRBUF_AUTO_DESTROY buildID = ffStrbufCreate();
+    if (ffProcessAppendStdOut(&buildID, (char* const[]) {
+        "param", "get", "const.product.software.version",
+        NULL,
+    }) == NULL)
+    {
+        ffStrbufTrimRightSpace(&buildID);
+        if (buildID.length > 0)
+            ffStrbufSet(&os->buildID, &buildID);
+    }
+
+    // Read security patch date
+    FF_STRBUF_AUTO_DESTROY securityPatch = ffStrbufCreate();
+    if (ffProcessAppendStdOut(&securityPatch, (char* const[]) {
+        "param", "get", "const.ohos.version.security_patch",
+        NULL,
+    }) == NULL)
+    {
+        ffStrbufTrimRightSpace(&securityPatch);
+        if (securityPatch.length > 0)
+            ffStrbufSet(&os->codename, &securityPatch);
+    }
+
+    return true;
+}
+
 static void detectOS(FFOSResult* os)
 {
     #ifdef FF_CUSTOM_OS_RELEASE_PATH
@@ -343,6 +477,10 @@ static void detectOS(FFOSResult* os)
     if (detectBedrock(os))
         return;
 
+    // Check for HarmonyOS 5+ first (uses param command)
+    if (detectHarmonyOS(os))
+        return;
+
     // Refer: https://gist.github.com/natefoo/814c5bf936922dad97ff
 
     parseOsRelease(FASTFETCH_TARGET_DIR_ETC "/os-release", os);
@@ -353,6 +491,7 @@ static void detectOS(FFOSResult* os)
     if (os->id.length == 0 && os->name.length == 0 && os->prettyName.length == 0)
     {
         // HarmonyOS has no os-release file
+        // This fallback checks sysinfo.name which may still work for older versions
         if (ffStrbufEqualS(&instance.state.platform.sysinfo.name, "HarmonyOS"))
         {
             ffStrbufSetS(&os->id, "harmonyos");


### PR DESCRIPTION
## Summary

Current HarmonyOS detection code assumes that `uname` will accurately identify the OS. However, this is not the case on more recent emulators (as they seem to just use the Linux kernel):

```
# uname -a
Linux localhost 5.10.210 #1 SMP Tue Nov 11 15:26:56 CST 2025 x86_64
```

Real hardware still identifies itself correctly:

```
$ uname -a
HarmonyOS localhost HongMeng Kernel 1.10.5 #1 SMP Wed Dec 24 05:34:51 UTC 2025 aarch64
```

Instead of `uname`, we should rely on `param` output - we can get the OS name, version, API version, and security patch like so:

Emulator:
```
# param get const.product.os.dist.name
HarmonyOS
# param get const.product.os.dist.version
6.0.0
# param get const.product.incremental.version
6.0.1.112
# param get const.ohos.apiversion
21
# param get const.product.software.version.name
HarmonyOS NEXT Developer Beta1
# param get const.product.software.version
emulator 6.0.0.112(SP3DEVC00E112R4P11)
# param get const.ohos.version.security_patch
2025/11/01
```

Real hardware (note `param get const.product.software.version.name` appears to be a recent addition, so it's missing here):
```
$ param get const.product.os.dist.name
HarmonyOS
$ param get const.product.os.dist.version
5.1.0
$ param get const.product.incremental.version
5.1.1.208
$ param get const.ohos.apiversion
19
$ param get const.product.software.version.name
Get parameter "const.product.software.version.name" fail! errNum is:106!
$ param get const.product.software.version
TXZ-W10M 5.1.0.151(C00E151R4P1)
$ param get const.ohos.version.security_patch
2026/01/01
```

Tested on multiple Huawei emulators [6.0.1(21), 5.1.1(19), 5.1.0(18)] and a Huawei MatePad 11.5 running HarmonyOS 5.1.0.151

Example output from a current emulator:

<img width="2414" height="926" alt="image" src="https://github.com/user-attachments/assets/0c84f15c-3569-4bd1-b868-f73e663180b7" />
 

## Changes

- Introduce HarmonyOS detection logic based on `param` output, falling back to existing `uname` logic as a last resort.

## Checklist

- [x] I have tested my changes locally.
