### PR TITLE
Global (macOS): enable X11 related stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,13 +71,13 @@ include(CMakeDependentOption)
 
 cmake_dependent_option(ENABLE_VULKAN "Enable vulkan" ON "LINUX OR APPLE OR FreeBSD OR OpenBSD OR NetBSD OR WIN32 OR ANDROID OR SunOS OR Haiku OR GNU" OFF)
 cmake_dependent_option(ENABLE_WAYLAND "Enable wayland-client" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR GNU" OFF)
-cmake_dependent_option(ENABLE_XCB_RANDR "Enable xcb-randr" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR ANDROID OR SunOS OR GNU" OFF)
-cmake_dependent_option(ENABLE_XRANDR "Enable xrandr" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR ANDROID OR SunOS OR GNU" OFF)
+cmake_dependent_option(ENABLE_XCB_RANDR "Enable xcb-randr" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR APPLE OR ANDROID OR SunOS OR GNU" OFF)
+cmake_dependent_option(ENABLE_XRANDR "Enable xrandr" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR APPLE OR ANDROID OR SunOS OR GNU" OFF)
 cmake_dependent_option(ENABLE_DRM "Enable libdrm" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR SunOS OR GNU" OFF)
 cmake_dependent_option(ENABLE_DRM_AMDGPU "Enable libdrm_amdgpu" ON "LINUX OR FreeBSD OR GNU" OFF)
-cmake_dependent_option(ENABLE_GIO "Enable gio-2.0" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR ANDROID OR SunOS OR GNU" OFF)
-cmake_dependent_option(ENABLE_DCONF "Enable dconf" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR ANDROID OR SunOS OR GNU" OFF)
-cmake_dependent_option(ENABLE_DBUS "Enable dbus-1" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR ANDROID OR SunOS OR Haiku OR GNU" OFF)
+cmake_dependent_option(ENABLE_GIO "Enable gio-2.0" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR APPLE OR ANDROID OR SunOS OR GNU" OFF)
+cmake_dependent_option(ENABLE_DCONF "Enable dconf" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR APPLE OR ANDROID OR SunOS OR GNU" OFF)
+cmake_dependent_option(ENABLE_DBUS "Enable dbus-1" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR APPLE OR ANDROID OR SunOS OR Haiku OR GNU" OFF)
 cmake_dependent_option(ENABLE_SQLITE3 "Enable sqlite3" ON "LINUX OR FreeBSD OR APPLE OR OpenBSD OR NetBSD OR SunOS OR GNU" OFF)
 cmake_dependent_option(ENABLE_RPM "Enable rpm" ON "LINUX OR GNU" OFF)
 cmake_dependent_option(ENABLE_IMAGEMAGICK7 "Enable imagemagick 7" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR APPLE OR ANDROID OR WIN32 OR SunOS OR Haiku OR GNU" OFF)
@@ -87,7 +87,7 @@ cmake_dependent_option(ENABLE_EGL "Enable egl" ON "LINUX OR FreeBSD OR OpenBSD O
 cmake_dependent_option(ENABLE_GLX "Enable glx" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR ANDROID OR SunOS OR GNU" OFF)
 cmake_dependent_option(ENABLE_OPENCL "Enable opencl" ON "LINUX OR FreeBSD OR OpenBSD OR NetBSD OR WIN32 OR ANDROID OR SunOS OR Haiku OR GNU" OFF)
 cmake_dependent_option(ENABLE_FREETYPE "Enable freetype" ON "ANDROID" OFF)
-cmake_dependent_option(ENABLE_PULSE "Enable pulse" ON "LINUX OR ANDROID OR GNU" OFF)
+cmake_dependent_option(ENABLE_PULSE "Enable pulse" ON "LINUX OR APPLE OR ANDROID OR GNU" OFF)
 cmake_dependent_option(ENABLE_DDCUTIL "Enable ddcutil" ON "LINUX" OFF)
 cmake_dependent_option(ENABLE_DIRECTX_HEADERS "Enable DirectX headers for WSL" ON "LINUX" OFF)
 cmake_dependent_option(ENABLE_ELF "Enable libelf" ON "LINUX OR ANDROID OR DragonFly OR Haiku OR GNU" OFF)
@@ -931,6 +931,7 @@ elseif(OpenBSD)
     )
 elseif(APPLE)
     list(APPEND LIBFASTFETCH_SRC
+        src/common/impl/dbus.c
         src/common/impl/io_unix.c
         src/common/impl/netif_apple.c
         src/common/impl/networking_linux.c
@@ -954,18 +955,26 @@ elseif(APPLE)
         src/detection/cpucache/cpucache_apple.c
         src/detection/cpuusage/cpuusage_apple.c
         src/detection/cursor/cursor_apple.m
+        src/detection/cursor/cursor_linux.c
         src/detection/disk/disk_bsd.c
         src/detection/dns/dns_apple.c
         src/detection/physicaldisk/physicaldisk_apple.c
         src/detection/physicalmemory/physicalmemory_apple.m
         src/detection/diskio/diskio_apple.c
         src/detection/displayserver/displayserver_apple.c
+        src/detection/displayserver/linux/common.c
+        src/detection/displayserver/linux/wmde.c
+        src/detection/displayserver/linux/xcb.c
+        src/detection/displayserver/linux/xlib.c
+        src/detection/gtk_qt/gtk.c
+        src/detection/gtk_qt/qt.c
         src/detection/font/font_apple.m
+        src/detection/font/font_linux.c
         src/detection/gpu/gpu_apple.c
         src/detection/gpu/gpu_apple.m
         src/detection/host/host_apple.c
         src/detection/host/host_mac.c
-        src/detection/icons/icons_nosupport.c
+        src/detection/icons/icons_linux.c
         src/detection/initsystem/initsystem_linux.c
         src/detection/keyboard/keyboard_apple.c
         src/detection/lm/lm_nosupport.c
@@ -985,19 +994,25 @@ elseif(APPLE)
         src/detection/poweradapter/poweradapter_apple.c
         src/detection/processes/processes_bsd.c
         src/detection/sound/sound_apple.c
+        src/detection/sound/sound_linux.c
         src/detection/swap/swap_apple.c
         src/detection/terminalfont/terminalfont_apple.m
+        src/detection/terminalfont/terminalfont_linux.c
         src/detection/terminalshell/terminalshell_linux.c
         src/detection/terminalsize/terminalsize_linux.c
         src/detection/theme/theme_apple.c
+        src/detection/theme/theme_linux.c
         src/detection/tpm/tpm_apple.c
         src/detection/uptime/uptime_bsd.c
         src/detection/users/users_linux.c
         src/detection/wallpaper/wallpaper_apple.m
+        src/detection/wallpaper/wallpaper_linux.c
         src/detection/wifi/wifi_apple.m
         src/detection/wm/wm_apple.m
-        src/detection/de/de_nosupport.c
+        src/detection/wm/wm_linux.c
+        src/detection/de/de_linux.c
         src/detection/wmtheme/wmtheme_apple.m
+        src/detection/wmtheme/wmtheme_linux.c
         src/detection/camera/camera_apple.m
     )
 elseif(WIN32)

--- a/src/detection/cursor/cursor_apple.m
+++ b/src/detection/cursor/cursor_apple.m
@@ -1,5 +1,7 @@
 #include "cursor.h"
 
+#include "detection/displayserver/displayserver.h"
+
 #import <Foundation/Foundation.h>
 
 static void appendColor(FFstrbuf* str, NSDictionary* dict)
@@ -30,6 +32,14 @@ static void appendColor(FFstrbuf* str, NSDictionary* dict)
 
 void ffDetectCursor(FFCursorResult* result)
 {
+    const FFDisplayServerResult* wmde = ffConnectDisplayServer();
+
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_X11)) {
+        void ffDetectCursorLinux(FFCursorResult* result);
+        ffDetectCursorLinux(result);
+        return;
+    }
+
     NSError* error;
     NSString* fileName = [NSString stringWithFormat:@"file://%s/Library/Preferences/com.apple.universalaccess.plist", instance.state.platform.homeDir.chars];
     NSDictionary* dict = [NSDictionary dictionaryWithContentsOfURL:[NSURL URLWithString:fileName]

--- a/src/detection/cursor/cursor_linux.c
+++ b/src/detection/cursor/cursor_linux.c
@@ -81,12 +81,20 @@ static bool detectCursorHyprcursor(FFCursorResult* result)
     return true;
 }
 
-void ffDetectCursor(FFCursorResult* result)
+void
+#ifdef __APPLE__
+ffDetectCursorLinux
+#else
+ffDetectCursor
+#endif
+(FFCursorResult* result)
 {
     const FFDisplayServerResult* wmde = ffConnectDisplayServer();
 
     if(ffStrbufEqualS(&wmde->wmPrettyName, FF_WM_PRETTY_WSLG))
         ffStrbufAppendS(&result->error, "WSLg uses native windows cursor");
+    else if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_COREGRAPHICS))
+        ffStrbufAppendS(&result->error, "Linux cursor isn't supported in macOS unless running X11");
     else if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_TTY))
         ffStrbufAppendS(&result->error, "Cursor isn't supported in TTY");
     else if(ffStrbufIgnCaseEqualS(&wmde->dePrettyName, FF_DE_PRETTY_PLASMA))

--- a/src/detection/displayserver/displayserver.h
+++ b/src/detection/displayserver/displayserver.h
@@ -45,6 +45,7 @@
 #define FF_WM_PROTOCOL_X11 "X11"
 #define FF_WM_PROTOCOL_WAYLAND "Wayland"
 #define FF_WM_PROTOCOL_SURFACEFLINGER "SurfaceFlinger"
+#define FF_WM_PROTOCOL_COREGRAPHICS "CoreGraphics"
 
 typedef enum __attribute__((__packed__)) FFDisplayType {
     FF_DISPLAY_TYPE_UNKNOWN,

--- a/src/detection/displayserver/displayserver_apple.c
+++ b/src/detection/displayserver/displayserver_apple.c
@@ -3,6 +3,7 @@
 #include "common/stringUtils.h"
 #include "common/edidHelper.h"
 #include "detection/os/os.h"
+#include "linux/displayserver_linux.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -187,12 +188,22 @@ static void detectDisplays(FFDisplayServerResult* ds)
 
 void ffConnectDisplayServerImpl(FFDisplayServerResult* ds)
 {
+    const char* error = ffdsConnectXcbRandr(ds);
+    if (error)
+        error = ffdsConnectXrandr(ds);
+    if (!error)
+    {
+        ffdsDetectWMDE(ds);
+        return;
+    }
+
     {
         FF_CFTYPE_AUTO_RELEASE CFMachPortRef port = CGWindowServerCreateServerPort();
         if (port)
         {
             ffStrbufSetStatic(&ds->wmProcessName, "WindowServer");
             ffStrbufSetStatic(&ds->wmPrettyName, "Quartz Compositor");
+            ffStrbufSetStatic(&ds->wmProtocolName, FF_WM_PROTOCOL_COREGRAPHICS);
         }
     }
 

--- a/src/detection/displayserver/linux/wmde.c
+++ b/src/detection/displayserver/linux/wmde.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#if __FreeBSD__
+#if __FreeBSD__ || __APPLE__
     #include <sys/sysctl.h>
     #include <sys/types.h>
     #include <sys/user.h>
@@ -268,9 +268,12 @@ static const char* getFromProcesses(FFDisplayServerResult* result)
 {
     uint32_t userId = instance.state.platform.uid;
 
-#if __FreeBSD__
+#if __FreeBSD__ || __APPLE__
     #ifdef __DragonFly__
         #define ki_comm kp_comm
+    #endif
+    #ifdef __APPLE__
+        #define ki_comm kp_proc.p_comm
     #endif
 
     int request[] = {CTL_KERN, KERN_PROC, KERN_PROC_UID, (int) userId};
@@ -435,6 +438,11 @@ void ffdsDetectWMDE(FFDisplayServerResult* result)
 {
     #if __ANDROID__
     if(ffStrbufIgnCaseEqualS(&result->wmProtocolName, FF_WM_PROTOCOL_SURFACEFLINGER))
+        return; // Only supported when connected to X11
+    #endif
+
+    #if __APPLE__
+    if(ffStrbufIgnCaseEqualS(&result->wmProtocolName, FF_WM_PROTOCOL_COREGRAPHICS))
         return; // Only supported when connected to X11
     #endif
 

--- a/src/detection/font/font_apple.m
+++ b/src/detection/font/font_apple.m
@@ -23,6 +23,11 @@ static void generateString(FFFontResult* font)
 
 const char* ffDetectFontImpl(FFFontResult* result)
 {
+    const char* ffDetectFontImplLinux(FFFontResult* result);
+    const char* error = ffDetectFontImplLinux(result);
+
+    if(!error) return NULL;
+
     ffStrbufAppendS(&result->fonts[0], [NSFont systemFontOfSize:12].familyName.UTF8String);
     ffStrbufAppendS(&result->fonts[1], [NSFont userFontOfSize:12].familyName.UTF8String);
     #ifdef MAC_OS_X_VERSION_10_15

--- a/src/detection/font/font_linux.c
+++ b/src/detection/font/font_linux.c
@@ -24,12 +24,23 @@ static void generateString(FFFontResult* font)
     ffParseGTK(&font->display, &font->fonts[1], &font->fonts[2], &font->fonts[3]);
 }
 
-const char* ffDetectFontImpl(FFFontResult* result)
+const char*
+#if __APPLE__
+ffDetectFontImplLinux
+#else
+ffDetectFontImpl
+#endif
+(FFFontResult* result)
 {
     const FFDisplayServerResult* wmde = ffConnectDisplayServer();
 
     if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_TTY))
         return "Font isn't supported in TTY";
+
+    #if __APPLE__
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_COREGRAPHICS))
+        return "Linux font isn't supported in macOS unless running X11";
+    #endif
 
     FFfont qt;
     ffFontInitQt(&qt, ffDetectQt()->font.chars);

--- a/src/detection/icons/icons_linux.c
+++ b/src/detection/icons/icons_linux.c
@@ -10,6 +10,11 @@ const char* ffDetectIcons(FFIconsResult* result)
     if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_TTY))
         return "Icons aren't supported in TTY";
 
+    #if __APPLE__
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_COREGRAPHICS))
+        return "Linux icons aren't supported in macOS unless running X11";
+    #endif
+
     const FFstrbuf* plasma = &ffDetectQt()->icons;
     const FFstrbuf* gtk2 = &ffDetectGTK2()->icons;
     const FFstrbuf* gtk3 = &ffDetectGTK3()->icons;

--- a/src/detection/sound/sound_apple.c
+++ b/src/detection/sound/sound_apple.c
@@ -10,6 +10,9 @@
 
 const char* ffDetectSound(FFlist* devices /* List of FFSoundDevice */)
 {
+    const char* ffDetectSoundLinux(FFlist* devices);
+    ffDetectSoundLinux(devices);
+
     AudioDeviceID mainDeviceId;
     UInt32 dataSize = sizeof(mainDeviceId);
     if(AudioObjectGetPropertyData(kAudioObjectSystemObject, &(AudioObjectPropertyAddress){

--- a/src/detection/sound/sound_linux.c
+++ b/src/detection/sound/sound_linux.c
@@ -127,7 +127,13 @@ static const char* detectSound(FFlist* devices)
 
 #endif // FF_HAVE_PULSE
 
-const char* ffDetectSound(FFlist* devices)
+const char*
+#ifdef __APPLE__
+ffDetectSoundLinux
+#else
+ffDetectSound
+#endif
+(FFlist* devices)
 {
     #ifdef FF_HAVE_PULSE
         return detectSound(devices);

--- a/src/detection/terminalfont/terminalfont_apple.m
+++ b/src/detection/terminalfont/terminalfont_apple.m
@@ -100,7 +100,10 @@ bool ffDetectTerminalFontPlatform(const FFTerminalResult* terminal, FFTerminalFo
         detectAppleTerminal(terminalFont);
     else if(ffStrbufIgnCaseEqualS(&terminal->processName, "WarpTerminal"))
         detectWarpTerminal(terminalFont);
-    else
-        return false;
+    else {
+        bool ffDetectTerminalFontPlatformLinux(const FFTerminalResult* terminal, FFTerminalFontResult* terminalFont);
+        return ffDetectTerminalFontPlatformLinux(terminal, terminalFont);
+    }
+
     return true;
 }

--- a/src/detection/terminalfont/terminalfont_linux.c
+++ b/src/detection/terminalfont/terminalfont_linux.c
@@ -504,7 +504,7 @@ static void detectHaikuTerminal(FFTerminalFontResult* terminalFont)
 #endif
 
 bool
-#ifdef __ANDROID__
+#if __ANDROID__ || __APPLE__
 ffDetectTerminalFontPlatformLinux
 #else
 ffDetectTerminalFontPlatform

--- a/src/detection/theme/theme_apple.c
+++ b/src/detection/theme/theme_apple.c
@@ -1,9 +1,17 @@
 #include "theme.h"
 
 #include "detection/os/os.h"
+#include "detection/displayserver/displayserver.h"
 
 const char* ffDetectTheme(FFThemeResult* result)
 {
+    const FFDisplayServerResult* wmde = ffConnectDisplayServer();
+
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_X11)) {
+        const char* ffDetectThemeLinux(FFThemeResult* result);
+        return ffDetectThemeLinux(result);
+    }
+
     const FFOSResult* os = ffDetectOS();
 
     char* str_end;

--- a/src/detection/theme/theme_linux.c
+++ b/src/detection/theme/theme_linux.c
@@ -3,7 +3,13 @@
 #include "detection/gtk_qt/gtk_qt.h"
 #include "detection/displayserver/displayserver.h"
 
-const char* ffDetectTheme(FFThemeResult* result)
+const char*
+#if __APPLE__
+ffDetectThemeLinux
+#else
+ffDetectTheme
+#endif
+(FFThemeResult* result)
 {
     const FFDisplayServerResult* wmde = ffConnectDisplayServer();
 

--- a/src/detection/wallpaper/wallpaper_apple.m
+++ b/src/detection/wallpaper/wallpaper_apple.m
@@ -1,11 +1,19 @@
 #include "wallpaper.h"
 #include "common/settings.h"
 #include "common/apple/osascript.h"
+#include "detection/displayserver/displayserver.h"
 
 #import <Foundation/Foundation.h>
 
 const char* ffDetectWallpaper(FFstrbuf* result)
 {
+    const FFDisplayServerResult* wmde = ffConnectDisplayServer();
+
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_X11)) {
+        const char* ffDetectWallpaperLinux(FFstrbuf* result);
+        return ffDetectWallpaperLinux(result);
+    }
+
     {
         // For Sonoma
         // https://github.com/JohnCoates/Aerial/issues/1332

--- a/src/detection/wallpaper/wallpaper_linux.c
+++ b/src/detection/wallpaper/wallpaper_linux.c
@@ -2,7 +2,13 @@
 #include "common/settings.h"
 #include "detection/gtk_qt/gtk_qt.h"
 
-const char* ffDetectWallpaper(FFstrbuf* result)
+const char*
+#if __APPLE__
+ffDetectWallpaperLinux
+#else
+ffDetectWallpaper
+#endif
+(FFstrbuf* result)
 {
     const FFstrbuf* wallpaper = NULL;
     const FFGTKResult* gtk = ffDetectGTK4();

--- a/src/detection/wm/wm_apple.m
+++ b/src/detection/wm/wm_apple.m
@@ -3,6 +3,7 @@
 #include "common/sysctl.h"
 #include "common/mallocHelper.h"
 #include "common/stringUtils.h"
+#include "detection/displayserver/displayserver.h"
 
 #include <ctype.h>
 #import <Foundation/Foundation.h>
@@ -46,6 +47,13 @@ const char* ffDetectWMVersion(const FFstrbuf* wmName, FFstrbuf* result, FF_MAYBE
 {
     if (!wmName)
         return "No WM detected";
+
+    const FFDisplayServerResult* wmde = ffConnectDisplayServer();
+
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_X11)) {
+        const char* ffDetectWMVersionLinux(const FFstrbuf* wmName, FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options);
+        return ffDetectWMVersionLinux(wmName, result, options);
+    }
 
     if (ffStrbufEqualS(wmName, "WindowServer"))
     {

--- a/src/detection/wm/wm_linux.c
+++ b/src/detection/wm/wm_linux.c
@@ -8,10 +8,12 @@
 #include "common/debug.h"
 #include "detection/displayserver/displayserver.h"
 
+#ifndef __APPLE__
 const char* ffDetectWMPlugin(FF_MAYBE_UNUSED FFstrbuf* pluginName)
 {
     return "Not supported on this platform";
 }
+#endif
 
 static bool extractCommonWmVersion(const char* line, FF_MAYBE_UNUSED uint32_t len, void *userdata)
 {
@@ -23,7 +25,7 @@ static bool extractCommonWmVersion(const char* line, FF_MAYBE_UNUSED uint32_t le
     return false;
 }
 
-#if !__ANDROID__
+#if !__ANDROID__ && !__APPLE__
 static bool extractHyprlandVersion(const char* line, uint32_t len, void *userdata)
 {
     if (line[0] != 'v') return true;
@@ -195,7 +197,7 @@ static const char* getWslg(FFstrbuf* result)
 }
 #endif
 
-#endif // !__ANDROID__
+#endif // !__ANDROID__ && !__APPLE__
 
 static bool extractI3Version(const char* line, FF_MAYBE_UNUSED uint32_t len, void *userdata)
 {
@@ -299,12 +301,18 @@ static const char* getOpenbox(FFstrbuf* result)
     return "Failed to run command `openbox --version`";
 }
 
-const char* ffDetectWMVersion(const FFstrbuf* wmName, FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options)
+const char*
+#ifdef __APPLE__
+ffDetectWMVersionLinux
+#else
+ffDetectWMVersion
+#endif
+(const FFstrbuf* wmName, FFstrbuf* result, FF_MAYBE_UNUSED FFWMOptions* options)
 {
     if (!wmName)
         return "No WM detected";
 
-    #if !__ANDROID__
+    #if !__ANDROID__ && !__APPLE__
     // Wayland compositors
     if (ffStrbufIgnCaseEqualS(wmName, "Hyprland"))
         return getHyprland(result);

--- a/src/detection/wmtheme/wmtheme_apple.m
+++ b/src/detection/wmtheme/wmtheme_apple.m
@@ -1,10 +1,18 @@
 #include "fastfetch.h"
 #include "wmtheme.h"
+#include "detection/displayserver/displayserver.h"
 
 #import <Foundation/Foundation.h>
 
 bool ffDetectWmTheme(FFstrbuf* themeOrError)
 {
+    const FFDisplayServerResult* wmde = ffConnectDisplayServer();
+
+    if(ffStrbufIgnCaseEqualS(&wmde->wmProtocolName, FF_WM_PROTOCOL_X11)) {
+        bool ffDetectWmThemeLinux(FFstrbuf* themeOrError);
+        return ffDetectWmThemeLinux(themeOrError);
+    }
+
     NSError* error;
     NSString* fileName = [NSString stringWithFormat:@"file://%s/Library/Preferences/.GlobalPreferences.plist", instance.state.platform.homeDir.chars];
     NSDictionary* dict = [NSDictionary dictionaryWithContentsOfURL:[NSURL URLWithString:fileName]

--- a/src/detection/wmtheme/wmtheme_linux.c
+++ b/src/detection/wmtheme/wmtheme_linux.c
@@ -187,7 +187,13 @@ name_not_found:
     return false;
 }
 
-bool ffDetectWmTheme(FFstrbuf* themeOrError)
+bool
+#if __APPLE__
+ffDetectWmThemeLinux
+#else
+ffDetectWmTheme
+#endif
+(FFstrbuf* themeOrError)
 {
     const FFDisplayServerResult* wm = ffConnectDisplayServer();
 


### PR DESCRIPTION
## Summary

https://github.com/fastfetch-cli/fastfetch/commit/7d92da88294cc3f71dbe1e5dc9203f331a42836e but for macOS

## Changes

- Enable on macOS the detection of:
  - X11
  - DBus
  - PulseAudio

- Enable printing window manager protocol name on macOS when X11 is not running as "CoreGraphics"

## Checklist

- [x] I have tested my changes locally.
