### PR TITLE
Fix segmentation fault triggered by negative-index value dereference

### DIFF
--- a/src/common/impl/format.c
+++ b/src/common/impl/format.c
@@ -204,7 +204,7 @@ void ffParseFormatString(FFstrbuf* buffer, const FFstrbuf* formatstr, uint32_t n
             uint32_t index = getArgumentIndex(placeholderValue.chars, numArgs, arguments);
 
             // testing for an invalid index
-            if (index > numArgs)
+            if (index > numArgs || index < 1)
             {
                 appendInvalidPlaceholder(buffer, "{?", &placeholderValue, i, formatstr->length);
                 continue;
@@ -230,7 +230,7 @@ void ffParseFormatString(FFstrbuf* buffer, const FFstrbuf* formatstr, uint32_t n
             uint32_t index = getArgumentIndex(placeholderValue.chars, numArgs, arguments);
 
             // testing for an invalid index
-            if (index > numArgs)
+            if (index > numArgs || index < 1)
             {
                 appendInvalidPlaceholder(buffer, "{/", &placeholderValue, i, formatstr->length);
                 continue;


### PR DESCRIPTION
…ndex

## Summary

During a review, I located an off-by-one error that causes an invalid memory read (segmentation fault). Since I've determined that the address read can't be manipulated, this is only a denial-of-service, and highly unlikely to be exploited beyond this in the wild. The vector here, i.e. the way an attacker might use this bug, is by crafting a malicious configuration file and convincing users to use it - however, since the `Command` module exists, I don't think this bug has any impact as a security issue, thus this public PR to fix it.

All that's required to trigger this invalid memory read is passing the following config file to `fastfetch`:

```json
{
  "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
  "modules": [
    {
      "type": "terminal",
      "format": "{?0}│"
    }
  ]
}
```

I will likely upload a more detailed breakdown of this bug to my blog (see profile) in the coming days, but I figured I should just get a fix in sooner rather than later.

UPDATE: This detailed breakdown can now be found here: https://s0s.sh/fuzzing-fastfetch-part-1/

## Related issue (required for new logos for new distros)

Fixes #2193

## Changes

- Introduces checks to prevent dereferencing value at a negative index.

## Checklist

- [X] I have tested my changes locally.
