### PR TITLE
Chore (Windows): Add missing header.

### DIFF
--- a/src/common/windows/variant.hpp
+++ b/src/common/windows/variant.hpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <string_view>
 #include <cassert>
+#include <cstdint>
 
 template <typename TVariant>
 struct FFBaseVariant: TVariant


### PR DESCRIPTION
## Summary

Fixes a build issue complaining about missing header:

```
In file included from src/common/windows/variant.cpp:1:
src/common/windows/variant.hpp: In member function ‘T FFBaseVariant<TVariant>::get()’:
src/common/windows/variant.hpp:28:46: error: ‘int8_t’ was not declared in this scope
   28 |         else if constexpr (std::is_same_v<T, int8_t>) {
      |                                              ^~~~~~
src/common/windows/variant.hpp:7:1: note: ‘int8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    6 | #include <cassert>
  +++ |+#include <cstdint>
    7 | 
src/common/windows/variant.hpp:32:46: error: ‘int16_t’ was not declared in this scope
   32 |         else if constexpr (std::is_same_v<T, int16_t>) {
      |                                              ^~~~~~~
src/common/windows/variant.hpp:32:46: note: ‘int16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
src/common/windows/variant.hpp:36:46: error: ‘int32_t’ was not declared in this scope
   36 |         else if constexpr (std::is_same_v<T, int32_t>) {
      |                                              ^~~~~~~
src/common/windows/variant.hpp:36:46: note: ‘int32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
src/common/windows/variant.hpp:40:46: error: ‘int64_t’ was not declared in this scope
   40 |         else if constexpr (std::is_same_v<T, int64_t>) {
      |                                              ^~~~~~~
src/common/windows/variant.hpp:40:46: note: ‘int64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’

``` 

## Checklist

- [ x] I have tested my changes locally.
