### PR TITLE
Fix version reporting for Niri window manager

### DIFF
--- a/src/detection/wm/wm_linux.c
+++ b/src/detection/wm/wm_linux.c
@@ -169,9 +169,10 @@ static const char* getNiri(FFstrbuf* result)
         "--version",
         NULL
     }) == NULL)
-    { // niri 25.11 (b35bcae)
+    { // niri 25.11 (commit b35bcae)
         ffStrbufSubstrAfterFirstC(result, ' ');
-        ffStrbufSubstrBeforeLastC(result, ' ');
+        ffStrbufSubstrBeforeLastC(result, '(');
+        ffStrbufTrimRightSpace(result);
         return NULL;
     }
 


### PR DESCRIPTION
## Summary

This PR corrects the way the version for the Niri WM is parsed and output.

## Changes

Currently, the Niri version is parsed as `niri v25.11 (<commit-hash>)` by cutting off after the last space, which should result in `niri v25.11`, but for my Niri version (v25.08, on NixOS), it outputs `niri stable v25.08 (commit <commit-hash>)`, so cutting off after the last space results in an extra "` (commit`" at the end, which obviously should not be there.

- Instead of cutting off after the last space, cut off before the last opening parenthesis and trim left-over space to the right. This resolves boths cases, where the output contains the string "`commit `" before the actual hash and those, where it does not.

## Checklist

- [x] I have tested my changes locally.
