### PR TITLE
Display: fixes scale calculation for displays rotated 90 or 270 degrees

### DIFF
--- a/src/modules/display/display.c
+++ b/src/modules/display/display.c
@@ -17,6 +17,21 @@ static int sortByNameDesc(FFDisplayResult* a, FFDisplayResult* b)
     return -ffStrbufComp(&a->name, &b->name);
 }
 
+static bool isOrthogonal(FFDisplayResult* display)
+{
+    return display->rotation % 180 == 90;
+}
+
+static uint32_t rotatedHeight(FFDisplayResult* display)
+{
+    return isOrthogonal(display) ? display->width : display->height;
+}
+
+static uint32_t rotatedWidth(FFDisplayResult* display)
+{
+    return isOrthogonal(display) ? display->height : display->width;
+}
+
 bool ffPrintDisplay(FFDisplayOptions* options)
 {
     const FFDisplayServerResult* dsResult = ffConnectDisplayServer();
@@ -101,17 +116,17 @@ bool ffPrintDisplay(FFDisplayOptions* options)
 
         FF_STRBUF_AUTO_DESTROY buffer = ffStrbufCreate();
         double inch = sqrt(result->physicalWidth * result->physicalWidth + result->physicalHeight * result->physicalHeight) / 25.4;
-        double scaleFactor = (double) result->height / (double) result->scaledHeight;
+        double scaleFactor = (double) rotatedHeight(result) / (double) result->scaledHeight;
 
         if(options->moduleArgs.outputFormat.length == 0)
         {
             ffPrintLogoAndKey(key.chars, 0, &options->moduleArgs, FF_PRINT_TYPE_NO_CUSTOM_KEY);
 
-            ffStrbufAppendF(&buffer, "%ix%i", result->width, result->height);
+            ffStrbufAppendF(&buffer, "%ix%i", rotatedWidth(result), rotatedHeight(result));
 
             if(
-                result->scaledWidth > 0 && result->scaledWidth != result->width &&
-                result->scaledHeight > 0 && result->scaledHeight != result->height)
+                result->scaledWidth > 0 && result->scaledWidth != rotatedWidth(result) &&
+                result->scaledHeight > 0 && result->scaledHeight != rotatedHeight(result))
             {
                 ffStrbufAppendS(&buffer, " @ ");
                 ffStrbufAppendDouble(&buffer, scaleFactor, instance.config.display.fractionNdigits, instance.config.display.fractionTrailingZeros == FF_FRACTION_TRAILING_ZEROS_TYPE_ALWAYS);


### PR DESCRIPTION
## Summary
This makes the scale calculations swap display's width and height for rotated displays for correct results.

### The issue
The scale calculation always uses display's native height. This leads for issues for rotated displays. For example, my display setup is the following:
<img width="631" height="256" alt="image" src="https://github.com/user-attachments/assets/2b818c83-a4ef-4b45-b324-6ad2f2d8492c" />

All displays are set to their native 1× scale, yet fastfetch reports the rotated one having 0.56×, as its scaled size is 1080×1920, and the scale is calculated as original height (1080) over scaled height (1920):

```
$ fastfetch -l none -s display 
Display (DELL S2522HG): 1920x1080 in 25", 240 Hz [External] *
Display (BenQ GW2270): 1920x1080 @ 0.56x in 22", 60 Hz [External] <=======
Display (LG HDR WFHD): 2560x1080 in 34", 75 Hz [External]
```

I've also tested this on my laptop's display 1920×1080 with 1.25× scaling enabled (scaled size 1536×864): if the screen is rotated, the reported scale is 0.7× (1080/1536).

### The solution
Note: this change only applies to the default non-compact mode.

With my patch applied, the scale display is correct:
```
$ ./fastfetch -l none -s display
Display (DELL S2522HG): 1920x1080 in 25", 240 Hz [External] *
Display (BenQ GW2270): 1080x1920 in 22", 60 Hz [External]
Display (LG HDR WFHD): 2560x1080 in 34", 75 Hz [External]
```

The resolution display is also changed to show the rotation (this part is probably optional, let me know what you think).

## Related issue (required for new logos for new distros)
None, I went straight for a pull.

## Changes
- Made the scale calculations aware of the fact that for displays rotated 90° or 270°, width and height are effectively swapped.
- Made the default output mode show effective resolution for rotated displays.

## Checklist
- [x] I have tested my changes locally.


I'm not really a C dev, so I'd be grateful for any feedback.