### PR TITLE
Support for Redrose.

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -345,5 +345,9 @@ void ffDetectOSImpl(FFOSResult* os) {
             ffStrbufSetS(&os->idLike, "linuxmint");
         }
     }
+    else if(ffStrbufEqualS(&os->id, "redrose"))
+    {
+        ffStrbufSetStatic(&os->idLike, "redrose");
+    }
 #endif
 }

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -345,9 +345,5 @@ void ffDetectOSImpl(FFOSResult* os) {
             ffStrbufSetS(&os->idLike, "linuxmint");
         }
     }
-    else if(ffStrbufEqualS(&os->id, "redrose"))
-    {
-        ffStrbufSetStatic(&os->idLike, "redrose");
-    }
 #endif
 }

--- a/src/logo/ascii/redrose.txt
+++ b/src/logo/ascii/redrose.txt
@@ -1,0 +1,17 @@
+      $1xxrjr  ftttt
+      $1xxxxxjjfffft
+      $1xxxxxxxjjjjj
+      $1xxxxxxxjjjjj
+      $1xxxxxxxxxnxx
+        $1xxxxxxxn
+           $2[[
+    $2////   $2[[
+    $2////   $2[[
+    $2///////[[
+      $2/////]]
+           $2[[
+           $2[[
+           $2[[
+           $2[[
+           $2[[
+           $2[]

--- a/src/logo/ascii/redrose.txt
+++ b/src/logo/ascii/redrose.txt
@@ -1,17 +1,17 @@
-      $1xxrjr  ftttt
-      $1xxxxxjjfffft
-      $1xxxxxxxjjjjj
-      $1xxxxxxxjjjjj
-      $1xxxxxxxxxnxx
-        $1xxxxxxxn
-           $2[[
-    $2////   $2[[
-    $2////   $2[[
-    $2///////[[
-      $2/////]]
-           $2[[
-           $2[[
-           $2[[
-           $2[[
-           $2[[
-           $2[]
+  xxrjr  ftttt
+  xxxxxjjfffft
+  xxxxxxxjjjjj
+  xxxxxxxjjjjj
+  xxxxxxxxxnxx
+    xxxxxxxn
+       $2[[
+////   [[
+////   [[
+///////[[
+  /////]]
+       [[
+       [[
+       [[
+       [[
+       [[
+       []

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -4232,6 +4232,17 @@ static const FFlogo R[] = {
         .colorKeys = FF_COLOR_FG_RED,
         .colorTitle = FF_COLOR_FG_RED,
     },
+    // Redrose Linux
+    {
+        .names = {"redrose"},
+        .lines = FASTFETCH_DATATEXT_LOGO_REDROSE,
+        .colors = {
+            FF_COLOR_FG_RED,
+            FF_COLOR_FG_GREEN,
+        },
+        .colorKeys = FF_COLOR_FG_RED,
+        .colorTitle = FF_COLOR_FG_RED,
+    },
     // Refracta
     {
         .names = {"Refracta"},

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -4232,9 +4232,9 @@ static const FFlogo R[] = {
         .colorKeys = FF_COLOR_FG_RED,
         .colorTitle = FF_COLOR_FG_RED,
     },
-    // Redrose Linux
+    // Redrose
     {
-        .names = {"redrose"},
+        .names = {"Redrose"},
         .lines = FASTFETCH_DATATEXT_LOGO_REDROSE,
         .colors = {
             FF_COLOR_FG_RED,


### PR DESCRIPTION
### Summary

Adds support for Redrose Linux.

### Related issue

Closes #2235

### Changes

- Added Redrose Linux support. (Detection and Logo only)

### Checklist

- [x] I have tested my changes locally.

### Logo preview
Using NixOS right now and tricked fastfetch into thinking I'm running Redrose (lore accurate), that's why it says `nix-system` and `nix-user`.

<img width="930" height="559" alt="Screenshot From 2026-03-31 09-25-31" src="https://github.com/user-attachments/assets/9ecb4580-8c41-4a46-9dd6-0fac65af462c" />