### PR TITLE
(BSD) Exclude reclaimable ARC usage from used memory

### DIFF
--- a/src/detection/memory/memory_bsd.c
+++ b/src/detection/memory/memory_bsd.c
@@ -7,10 +7,17 @@ const char* ffDetectMemory(FFMemoryResult* ram)
     if (sysctl((int[]){ CTL_HW, HW_PHYSMEM }, 2, &ram->bytesTotal, &length, NULL, 0))
         return "Failed to read hw.physmem";
 
+    // calculates the reclaimable ARC pages.
+    int64_t arcSize = ffSysctlGetInt64("kstat.zfs.misc.arcstats.size", 0);
+    int64_t arcMin = ffSysctlGetInt64("vfs.zfs.arc_min", 0);
+    int64_t arcPages = (arcSize > arcMin) ? (arcSize - arcMin)
+        / instance.state.platform.sysinfo.pageSize : 0;
+
     // vm.stats.vm.* are int values
     int32_t pagesFree = ffSysctlGetInt("vm.stats.vm.v_free_count", 0)
         + ffSysctlGetInt("vm.stats.vm.v_inactive_count", 0)
-        + ffSysctlGetInt("vm.stats.vm.v_cache_count", 0);
+        + ffSysctlGetInt("vm.stats.vm.v_cache_count", 0)
+        + (int32_t) arcPages;
 
     ram->bytesUsed = ram->bytesTotal - (uint64_t) pagesFree * instance.state.platform.sysinfo.pageSize;
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does. -->
Add logic that calculates the memory usage except for reclaimable ARC pages on BSD

`ffDetectMemory` function on Linux systems looks like this.
It calculates memory usage except for *buffers* and *cached* memory.
```c
// src/memory/memory_linux.c:48
memAvailable = memFree + buffers + cached + sReclaimable - shmem;
```
BSD systems don't support those two pieces of information(it's just a *wired* in BSD).
Also the existing logic includes *wired* usage in memory usage! So the BSD's memory usage is calculated way more conservatively than on Linux. But the amount of wired memory is reclaimable by the kernel, because the kernel reclaims memory to the system when memory load is too high. [More Information](https://forums.freebsd.org/threads/question-about-wired-memory.58074/) Reclaimable ARC pages are the wired usage and also same as the cached memory. And so on, we can add more *pseudo cache* calculating codes in the function.

P.S I think [btop](https://github.com/aristocratos/btop/blob/main/src/freebsd/btop_collect.cpp) excludes wired memory usage for used memory section.

I tested with one firefox tab after the bootup on i3.
### Before
<img width="423" height="300" alt="image" src="https://github.com/user-attachments/assets/a357e12b-6013-4b61-8bc3-1e43bed3ea71" />

### After
<img width="423" height="300" alt="image" src="https://github.com/user-attachments/assets/a2c9524d-46ff-49a5-a3d0-f533ea7525e3" />


The memory usage decreased from 20% (3.13 GiB) to 16% (2.54 GiB)!

## Related issue (required for new logos for new distros)

<!--
If this PR adds a new logo, it MUST be linked to an existing "Logo Request" issue and has the requests fulfilled.

Use one of the following formats so GitHub links it properly:
- Closes #1234
- Fixes #1234
- Resolves #1234

PRs that add logos without an associated Logo Request issue will not be accepted.
-->

Closes #N/A

## Changes

- Add `arcPages` to `pagesFree` in `ffDetectMemory` function.

## Checklist

- [x] I have tested my changes locally.
