### PR TITLE
fix(localip): use assigned netlink port id on Linux

### DIFF
--- a/src/common/impl/netif_linux.c
+++ b/src/common/impl/netif_linux.c
@@ -7,6 +7,19 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 
+static bool ffNetifGetNetlinkPortId(int sock_fd, uint32_t* pid) {
+    struct sockaddr_nl addr = {};
+    socklen_t addrLen = sizeof(addr);
+    if (getsockname(sock_fd, (struct sockaddr*) &addr, &addrLen) < 0) {
+        FF_DEBUG("Failed to query netlink socket address: %s", strerror(errno));
+        return false;
+    }
+
+    *pid = addr.nl_pid;
+    FF_DEBUG("Netlink port ID: %u", *pid);
+    return true;
+}
+
 bool ffNetifGetDefaultRouteImplV4(FFNetifDefaultRouteResult* result) {
     FF_DEBUG("Starting IPv4 default route detection");
 
@@ -16,9 +29,6 @@ bool ffNetifGetDefaultRouteImplV4(FFNetifDefaultRouteResult* result) {
         return false;
     }
     FF_DEBUG("Created netlink socket: fd=%d", sock_fd);
-
-    uint32_t pid = instance.state.platform.pid;
-    FF_DEBUG("Process PID: %u", pid);
 
     // Bind socket
     struct sockaddr_nl addr = {
@@ -32,6 +42,11 @@ bool ffNetifGetDefaultRouteImplV4(FFNetifDefaultRouteResult* result) {
         return false;
     }
     FF_DEBUG("Successfully bound socket");
+
+    uint32_t pid;
+    if (!ffNetifGetNetlinkPortId(sock_fd, &pid)) {
+        return false;
+    }
 
     struct __attribute__((__packed__)) {
         struct nlmsghdr nlh;
@@ -228,9 +243,6 @@ bool ffNetifGetDefaultRouteImplV6(FFNetifDefaultRouteResult* result) {
     }
     FF_DEBUG("Created netlink socket: fd=%d", sock_fd);
 
-    uint32_t pid = instance.state.platform.pid;
-    FF_DEBUG("Process PID: %u", pid);
-
     // Bind socket
     struct sockaddr_nl addr = {
         .nl_family = AF_NETLINK,
@@ -243,6 +255,11 @@ bool ffNetifGetDefaultRouteImplV6(FFNetifDefaultRouteResult* result) {
         return false;
     }
     FF_DEBUG("Successfully bound socket");
+
+    uint32_t pid;
+    if (!ffNetifGetNetlinkPortId(sock_fd, &pid)) {
+        return false;
+    }
 
     struct __attribute__((__packed__)) {
         struct nlmsghdr nlh;

--- a/src/common/impl/netif_linux.c
+++ b/src/common/impl/netif_linux.c
@@ -7,17 +7,16 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 
-static bool ffNetifGetNetlinkPortId(int sock_fd, uint32_t* pid) {
+static uint32_t ffNetifGetNetlinkPortId(int sock_fd) {
     struct sockaddr_nl addr = {};
     socklen_t addrLen = sizeof(addr);
     if (getsockname(sock_fd, (struct sockaddr*) &addr, &addrLen) < 0) {
-        FF_DEBUG("Failed to query netlink socket address: %s", strerror(errno));
-        return false;
+        FF_DEBUG("Failed to query netlink socket address (use PID instead): %s", strerror(errno));
+        return instance.state.platform.pid;
+    } else {
+        FF_DEBUG("Netlink port ID: %u", addr.nl_pid);
+        return addr.nl_pid;
     }
-
-    *pid = addr.nl_pid;
-    FF_DEBUG("Netlink port ID: %u", *pid);
-    return true;
 }
 
 bool ffNetifGetDefaultRouteImplV4(FFNetifDefaultRouteResult* result) {
@@ -43,10 +42,7 @@ bool ffNetifGetDefaultRouteImplV4(FFNetifDefaultRouteResult* result) {
     }
     FF_DEBUG("Successfully bound socket");
 
-    uint32_t pid;
-    if (!ffNetifGetNetlinkPortId(sock_fd, &pid)) {
-        return false;
-    }
+    uint32_t pid = ffNetifGetNetlinkPortId(sock_fd);
 
     struct __attribute__((__packed__)) {
         struct nlmsghdr nlh;
@@ -256,10 +252,7 @@ bool ffNetifGetDefaultRouteImplV6(FFNetifDefaultRouteResult* result) {
     }
     FF_DEBUG("Successfully bound socket");
 
-    uint32_t pid;
-    if (!ffNetifGetNetlinkPortId(sock_fd, &pid)) {
-        return false;
-    }
+    uint32_t pid = ffNetifGetNetlinkPortId(sock_fd);
 
     struct __attribute__((__packed__)) {
         struct nlmsghdr nlh;


### PR DESCRIPTION
## Summary
- read the kernel-assigned netlink port ID after `bind()`
- use that assigned port for both IPv4 and IPv6 route request/reply matching on Linux

Closes #2252