### PR TITLE
Add "command-raw" to schema

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -611,7 +611,7 @@
                                 },
                                 {
                                     "const": "command-raw",
-                                    "decription": "Command to generate text data, printed as is"
+                                    "description": "Command to generate text data, printed as is"
                                 },
                                 {
                                     "const": "sixel",

--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -610,6 +610,10 @@
                                     "description": "Text data, printed as is"
                                 },
                                 {
+                                    "const": "command-raw",
+                                    "decription": "Command to generate text data, printed as is"
+                                },
+                                {
                                     "const": "sixel",
                                     "description": "Image file, printed as sixel codes"
                                 },


### PR DESCRIPTION
## Summary

Add "command-raw" as an option for logo.type in json_schema.json
The description is taken from [logo.h](https://github.com/fastfetch-cli/fastfetch/blob/b4e6688dfe5549358ba7d853dcdaaad1fcebff64/src/options/logo.h#L16)


## Checklist

- [x] I have tested my changes locally.
I tested in VS Code and it works.