### PR TITLE
fix: correct typo in WPA Personal Mixed security string

### DIFF
--- a/src/detection/wifi/wifi_apple.m
+++ b/src/detection/wifi/wifi_apple.m
@@ -108,7 +108,7 @@ const char* ffDetectWifi(FFlist* result)
                 ffStrbufSetStatic(&item->conn.security, "WPA Personal");
                 break;
             case kCWSecurityWPAPersonalMixed:
-                ffStrbufSetStatic(&item->conn.security, "WPA Persional Mixed");
+                ffStrbufSetStatic(&item->conn.security, "WPA Personal Mixed");
                 break;
             case kCWSecurityWPA2Personal:
                 ffStrbufSetStatic(&item->conn.security, "WPA2 Personal");


### PR DESCRIPTION
kCWSecurityWPAPersonalMixed was mapped to "WPA Persional Mixed" — "Persional" contains an extraneous 'i'.