### PR TITLE
fix(strbuf): resolve potential use-after-free and UB in ffStrbufSetNS

### DIFF
--- a/src/common/impl/FFstrbuf.c
+++ b/src/common/impl/FFstrbuf.c
@@ -248,14 +248,17 @@ void ffStrbufSetNS(FFstrbuf* strbuf, uint32_t length, const char* value) {
     assert(value != NULL);
 
     if (strbuf->allocated < length + 1) {
+        char* newBuf = malloc(sizeof(char) * (length + 1));
+        memcpy(newBuf, value, length);
         if (strbuf->allocated > 0) {
             free(strbuf->chars);
         }
+        strbuf->chars = newBuf;
         strbuf->allocated = length + 1;
-        strbuf->chars = malloc(sizeof(char) * strbuf->allocated);
+    } else {
+        memmove(strbuf->chars, value, length);
     }
 
-    memcpy(strbuf->chars, value, length);
     strbuf->length = length;
     strbuf->chars[length] = '\0';
 }


### PR DESCRIPTION
## Summary

This PR fixes a "Potential use after free" security alert flagged by CodeQL and addresses Undefined Behavior (UB) when setting a buffer to a substring of itself.

## Related issue (required for new logos for new distros)

Fixes a CodeQL security alert (no public issue was found).

## Changes

- **Use-After-Free Fix:** Modified `ffStrbufSetNS` to allocate and copy into a new buffer *before* freeing the old one. This ensures that if the source `value` points into the current buffer, it remains valid during the copy even if reallocation is required.
- **Overlap Safety:** Replaced `memcpy` with `memmove` in the non-reallocating path to safely handle cases where `value` points to an overlapping memory region within the same buffer.

## Checklist

- [x] I have tested my changes locally. (Verified with `fastfetch-test-strbuf`)