### PR TITLE
add global.ndigits fallback for all ndigits settings

### DIFF
--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -1392,6 +1392,19 @@
                         }
                     }
                 },
+                "global": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "Set global fallback values for display formatting",
+                    "properties": {
+                        "ndigits": {
+                            "type": "integer",
+                            "description": "Set the default number of digits to keep after the decimal point for all value types. Can be overridden per category (size, temp, percent, freq, fraction)",
+                            "minimum": 0,
+                            "maximum": 9
+                        }
+                    }
+                },
                 "noBuffer": {
                     "type": "boolean",
                     "description": "Whether to disable the stdout application buffer",

--- a/doc/json_schema.json
+++ b/doc/json_schema.json
@@ -1398,10 +1398,18 @@
                     "description": "Set global fallback values for display formatting",
                     "properties": {
                         "ndigits": {
-                            "type": "integer",
-                            "description": "Set the default number of digits to keep after the decimal point for all value types. Can be overridden per category (size, temp, percent, freq, fraction)",
-                            "minimum": 0,
-                            "maximum": 9
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "description": "Set the default number of digits to keep after the decimal point for all value types. Can be overridden per category (size, temp, percent, freq, fraction)",
+                                    "minimum": 0,
+                                    "maximum": 9
+                                },
+                                {
+                                    "type": "null",
+                                    "description": "Use the normal fallback behavior instead of forcing a global default number of digits"
+                                }
+                            ]
                         }
                     }
                 },

--- a/src/common/impl/format.c
+++ b/src/common/impl/format.c
@@ -30,10 +30,10 @@ void ffFormatAppendFormatArg(FFstrbuf* buffer, const FFformatarg* formatarg) {
             ffStrbufAppend(buffer, (const FFstrbuf*) formatarg->value);
             break;
         case FF_ARG_TYPE_FLOAT:
-            ffStrbufAppendDouble(buffer, *(float*) formatarg->value, instance.config.display.fractionNdigits, instance.config.display.fractionTrailingZeros != FF_FRACTION_TRAILING_ZEROS_TYPE_NEVER);
+            ffStrbufAppendDouble(buffer, *(float*) formatarg->value, ffNdigitsResolveInt8(instance.config.display.fractionNdigits, instance.config.display.globalNdigits, 2), instance.config.display.fractionTrailingZeros != FF_FRACTION_TRAILING_ZEROS_TYPE_NEVER);
             break;
         case FF_ARG_TYPE_DOUBLE:
-            ffStrbufAppendDouble(buffer, *(double*) formatarg->value, instance.config.display.fractionNdigits, instance.config.display.fractionTrailingZeros != FF_FRACTION_TRAILING_ZEROS_TYPE_NEVER);
+            ffStrbufAppendDouble(buffer, *(double*) formatarg->value, ffNdigitsResolveInt8(instance.config.display.fractionNdigits, instance.config.display.globalNdigits, 2), instance.config.display.fractionTrailingZeros != FF_FRACTION_TRAILING_ZEROS_TYPE_NEVER);
             break;
         case FF_ARG_TYPE_BOOL:
             ffStrbufAppendS(buffer, *(bool*) formatarg->value ? "true" : "false");

--- a/src/common/impl/frequency.c
+++ b/src/common/impl/frequency.c
@@ -8,6 +8,8 @@ bool ffFreqAppendNum(uint32_t mhz, FFstrbuf* result) {
     const FFOptionsDisplay* options = &instance.config.display;
     bool spaceBeforeUnit = options->freqSpaceBeforeUnit != FF_SPACE_BEFORE_UNIT_NEVER;
     int8_t ndigits = options->freqNdigits;
+    if (ndigits == INT8_MIN)
+        ndigits = (options->globalNdigits >= 0) ? options->globalNdigits : 2;
 
     if (ndigits >= 0) {
         ffStrbufAppendDouble(result, mhz / 1000., ndigits, true);

--- a/src/common/impl/percent.c
+++ b/src/common/impl/percent.c
@@ -190,7 +190,7 @@ void ffPercentAppendNum(FFstrbuf* buffer, double percent, FFPercentageModuleConf
             }
         }
     }
-    ffStrbufAppendF(buffer, "%*.*f%s%%", options->percentWidth, options->percentNdigits, percent, options->percentSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_ALWAYS ? " " : "");
+    ffStrbufAppendF(buffer, "%*.*f%s%%", options->percentWidth, ffNdigitsResolve(options->percentNdigits, options->globalNdigits, 0), percent, options->percentSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_ALWAYS ? " " : "");
 
     if (colored && !options->pipe) {
         ffStrbufAppendS(buffer, FASTFETCH_TEXT_MODIFIER_RESET);

--- a/src/common/impl/size.c
+++ b/src/common/impl/size.c
@@ -15,7 +15,7 @@ static void appendNum(FFstrbuf* result, uint64_t bytes, uint32_t base, const cha
     if (counter == 0) {
         ffStrbufAppendUInt(result, bytes);
     } else {
-        ffStrbufAppendDouble(result, size, (int8_t) options->sizeNdigits, true);
+        ffStrbufAppendDouble(result, size, (int8_t) ffNdigitsResolve(options->sizeNdigits, options->globalNdigits, 2), true);
     }
     if (options->sizeSpaceBeforeUnit != FF_SPACE_BEFORE_UNIT_NEVER) {
         ffStrbufAppendC(result, ' ');

--- a/src/common/impl/temps.c
+++ b/src/common/impl/temps.c
@@ -38,13 +38,13 @@ void ffTempsAppendNum(double celsius, FFstrbuf* buffer, FFColorRangeConfig confi
     switch (options->tempUnit) {
         case FF_TEMPERATURE_UNIT_DEFAULT:
         case FF_TEMPERATURE_UNIT_CELSIUS:
-            ffStrbufAppendF(buffer, "%.*f%s°C", options->tempNdigits, celsius, options->tempSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_ALWAYS ? " " : "");
+            ffStrbufAppendF(buffer, "%.*f%s°C", ffNdigitsResolve(options->tempNdigits, options->globalNdigits, 1), celsius, options->tempSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_ALWAYS ? " " : "");
             break;
         case FF_TEMPERATURE_UNIT_FAHRENHEIT:
-            ffStrbufAppendF(buffer, "%.*f%s°F", options->tempNdigits, celsius * 1.8 + 32, options->tempSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_ALWAYS ? " " : "");
+            ffStrbufAppendF(buffer, "%.*f%s°F", ffNdigitsResolve(options->tempNdigits, options->globalNdigits, 1), celsius * 1.8 + 32, options->tempSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_ALWAYS ? " " : "");
             break;
         case FF_TEMPERATURE_UNIT_KELVIN:
-            ffStrbufAppendF(buffer, "%.*f%sK", options->tempNdigits, celsius + 273.15, options->tempSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_NEVER ? "" : " ");
+            ffStrbufAppendF(buffer, "%.*f%sK", ffNdigitsResolve(options->tempNdigits, options->globalNdigits, 1), celsius + 273.15, options->tempSpaceBeforeUnit == FF_SPACE_BEFORE_UNIT_NEVER ? "" : " ");
             break;
     }
 

--- a/src/modules/localip/localip.c
+++ b/src/modules/localip/localip.c
@@ -31,10 +31,10 @@ static void formatKey(const FFLocalIpOptions* options, FFLocalIpResult* ip, uint
 
 static void appendSpeed(FFLocalIpResult* ip, FFstrbuf* strbuf) {
     if (ip->speed >= 1000000) {
-        ffStrbufAppendDouble(strbuf, ip->speed / 1e6, instance.config.display.fractionNdigits, instance.config.display.fractionTrailingZeros == FF_FRACTION_TRAILING_ZEROS_TYPE_ALWAYS);
+        ffStrbufAppendDouble(strbuf, ip->speed / 1e6, ffNdigitsResolveInt8(instance.config.display.fractionNdigits, instance.config.display.globalNdigits, 2), instance.config.display.fractionTrailingZeros == FF_FRACTION_TRAILING_ZEROS_TYPE_ALWAYS);
         ffStrbufAppendS(strbuf, " Tbps");
     } else if (ip->speed >= 1000) {
-        ffStrbufAppendDouble(strbuf, ip->speed / 1e3, instance.config.display.fractionNdigits, instance.config.display.fractionTrailingZeros == FF_FRACTION_TRAILING_ZEROS_TYPE_ALWAYS);
+        ffStrbufAppendDouble(strbuf, ip->speed / 1e3, ffNdigitsResolveInt8(instance.config.display.fractionNdigits, instance.config.display.globalNdigits, 2), instance.config.display.fractionTrailingZeros == FF_FRACTION_TRAILING_ZEROS_TYPE_ALWAYS);
         ffStrbufAppendS(strbuf, " Gbps");
     } else {
         ffStrbufAppendF(strbuf, "%u Mbps", (unsigned) ip->speed);

--- a/src/options/display.c
+++ b/src/options/display.c
@@ -511,6 +511,26 @@ const char* ffOptionsParseDisplayJsonConfig(FFOptionsDisplay* options, yyjson_va
                 }
                 options->freqSpaceBeforeUnit = (FFSpaceBeforeUnitType) value;
             }
+        } else if (unsafe_yyjson_equals_str(key, "global")) {
+            if (!yyjson_is_obj(val)) {
+                return "display.global must be an object";
+            }
+
+            yyjson_val* ndigits = yyjson_obj_get(val, "ndigits");
+            if (ndigits) {
+                if (yyjson_is_null(ndigits)) {
+                    options->globalNdigits = -1;
+                } else {
+                    if (!yyjson_is_uint(ndigits)) {
+                        return "display.global.ndigits must be an unsigned integer";
+                    }
+                    uint64_t val = yyjson_get_uint(ndigits);
+                    if (val > 9) {
+                        return "display.global.ndigits must be between 0 and 9";
+                    }
+                    options->globalNdigits = (int8_t) val;
+                }
+            }
         } else {
             return "Unknown display property";
         }
@@ -619,7 +639,12 @@ bool ffOptionsParseDisplayCommandLine(FFOptionsDisplay* options, const char* key
         if (ffStrEqualsIgnCase(subkey, "binary-prefix")) {
             options->sizeBinaryPrefix = (FFSizeBinaryPrefixType) ffOptionParseEnum(key, value, (FFKeyValuePair[]) { { "iec", FF_SIZE_BINARY_PREFIX_TYPE_IEC }, { "si", FF_SIZE_BINARY_PREFIX_TYPE_SI }, { "jedec", FF_SIZE_BINARY_PREFIX_TYPE_JEDEC }, {} });
         } else if (ffStrEqualsIgnCase(subkey, "ndigits")) {
-            options->sizeNdigits = (uint8_t) ffOptionParseUInt32(key, value);
+            uint32_t ndigits = ffOptionParseUInt32(key, value);
+            if (ndigits > 9) {
+                fprintf(stderr, "Error: %s must be between 0 and 9\n", key);
+                exit(477);
+            }
+            options->sizeNdigits = (uint8_t) ndigits;
         } else if (ffStrEqualsIgnCase(subkey, "max-prefix")) {
             options->sizeMaxPrefix = (uint8_t) ffOptionParseEnum(key, value, (FFKeyValuePair[]) { { "B", 0 }, { "kB", 1 }, { "MB", 2 }, { "GB", 3 }, { "TB", 4 }, { "PB", 5 }, { "EB", 6 }, { "ZB", 7 }, { "YB", 8 }, {} });
         } else if (ffStrEqualsIgnCase(subkey, "space-before-unit")) {
@@ -647,7 +672,12 @@ bool ffOptionsParseDisplayCommandLine(FFOptionsDisplay* options, const char* key
                                                                                       {},
                                                                                   });
         } else if (ffStrEqualsIgnCase(subkey, "ndigits")) {
-            options->tempNdigits = (uint8_t) ffOptionParseUInt32(key, value);
+            uint32_t ndigits = ffOptionParseUInt32(key, value);
+            if (ndigits > 9) {
+                fprintf(stderr, "Error: %s must be between 0 and 9\n", key);
+                exit(477);
+            }
+            options->tempNdigits = (uint8_t) ndigits;
         } else if (ffStrEqualsIgnCase(subkey, "color-green")) {
             ffOptionParseColor(value, &options->tempColorGreen);
         } else if (ffStrEqualsIgnCase(subkey, "color-yellow")) {
@@ -669,7 +699,12 @@ bool ffOptionsParseDisplayCommandLine(FFOptionsDisplay* options, const char* key
         if (ffStrEqualsIgnCase(subkey, "type")) {
             options->percentType = (uint8_t) ffOptionParseUInt32(key, value);
         } else if (ffStrEqualsIgnCase(subkey, "ndigits")) {
-            options->percentNdigits = (uint8_t) ffOptionParseUInt32(key, value);
+            uint32_t ndigits = ffOptionParseUInt32(key, value);
+            if (ndigits > 9) {
+                fprintf(stderr, "Error: %s must be between 0 and 9\n", key);
+                exit(477);
+            }
+            options->percentNdigits = (uint8_t) ndigits;
         } else if (ffStrEqualsIgnCase(subkey, "color-green")) {
             ffOptionParseColor(value, &options->percentColorGreen);
         } else if (ffStrEqualsIgnCase(subkey, "color-yellow")) {
@@ -689,7 +724,19 @@ bool ffOptionsParseDisplayCommandLine(FFOptionsDisplay* options, const char* key
             return false;
         }
     } else if (ffStrEqualsIgnCase(key, "--fraction-ndigits")) {
-        options->fractionNdigits = (int8_t) ffOptionParseInt32(key, value);
+        int32_t ndigits = ffOptionParseInt32(key, value);
+        if (ndigits < -1 || ndigits > 9) {
+            fprintf(stderr, "Error: %s must be between -1 and 9\n", key);
+            exit(477);
+        }
+        options->fractionNdigits = (int8_t) ndigits;
+    } else if (ffStrEqualsIgnCase(key, "--ndigits")) {
+        uint32_t ndigits = ffOptionParseUInt32(key, value);
+        if (ndigits > 9) {
+            fprintf(stderr, "Error: %s must be between 0 and 9\n", key);
+            exit(477);
+        }
+        options->globalNdigits = (int8_t) ndigits;
     } else if (ffStrEqualsIgnCase(key, "--fraction-trailing-zeros")) {
         options->fractionTrailingZeros = (FFFractionTrailingZerosType) ffOptionParseEnum(key, value, (FFKeyValuePair[]) {
                                                                                                          { "default", FF_FRACTION_TRAILING_ZEROS_TYPE_DEFAULT },
@@ -733,7 +780,12 @@ bool ffOptionsParseDisplayCommandLine(FFOptionsDisplay* options, const char* key
     } else if (ffStrStartsWithIgnCase(key, "--freq-")) {
         const char* subkey = key + strlen("--freq-");
         if (ffStrEqualsIgnCase(subkey, "ndigits")) {
-            options->freqNdigits = (int8_t) ffOptionParseInt32(key, value);
+            int32_t ndigits = ffOptionParseInt32(key, value);
+            if (ndigits < -1 || ndigits > 9) {
+                fprintf(stderr, "Error: %s must be between -1 and 9\n", key);
+                exit(477);
+            }
+            options->freqNdigits = (int8_t) ndigits;
         } else if (ffStrEqualsIgnCase(subkey, "space-before-unit")) {
             options->freqSpaceBeforeUnit = (FFSpaceBeforeUnitType) ffOptionParseEnum(key, value, (FFKeyValuePair[]) {
                                                                                                      { "default", FF_SPACE_BEFORE_UNIT_DEFAULT },
@@ -771,7 +823,7 @@ void ffOptionsInitDisplay(FFOptionsDisplay* options) {
     options->durationSpaceBeforeUnit = FF_SPACE_BEFORE_UNIT_DEFAULT;
     options->hideCursor = false;
     options->sizeBinaryPrefix = FF_SIZE_BINARY_PREFIX_TYPE_IEC;
-    options->sizeNdigits = 2;
+    options->sizeNdigits = UINT8_MAX;
     options->sizeMaxPrefix = 8; // YB
     options->sizeSpaceBeforeUnit = FF_SPACE_BEFORE_UNIT_DEFAULT;
 
@@ -782,7 +834,7 @@ void ffOptionsInitDisplay(FFOptionsDisplay* options) {
     options->keyType = FF_MODULE_KEY_TYPE_STRING;
 
     options->tempUnit = FF_TEMPERATURE_UNIT_DEFAULT;
-    options->tempNdigits = 1;
+    options->tempNdigits = UINT8_MAX;
     ffStrbufInitStatic(&options->tempColorGreen, FF_COLOR_FG_GREEN);
     ffStrbufInitStatic(&options->tempColorYellow, instance.state.terminalLightTheme ? FF_COLOR_FG_YELLOW : FF_COLOR_FG_LIGHT_YELLOW);
     ffStrbufInitStatic(&options->tempColorRed, instance.state.terminalLightTheme ? FF_COLOR_FG_RED : FF_COLOR_FG_LIGHT_RED);
@@ -802,16 +854,17 @@ void ffOptionsInitDisplay(FFOptionsDisplay* options) {
     options->durationAbbreviation = false;
     options->durationSpaceBeforeUnit = FF_SPACE_BEFORE_UNIT_DEFAULT;
     options->percentType = 9;
-    options->percentNdigits = 0;
+    options->percentNdigits = UINT8_MAX;
     ffStrbufInitStatic(&options->percentColorGreen, FF_COLOR_FG_GREEN);
     ffStrbufInitStatic(&options->percentColorYellow, instance.state.terminalLightTheme ? FF_COLOR_FG_YELLOW : FF_COLOR_FG_LIGHT_YELLOW);
     ffStrbufInitStatic(&options->percentColorRed, instance.state.terminalLightTheme ? FF_COLOR_FG_RED : FF_COLOR_FG_LIGHT_RED);
     options->percentSpaceBeforeUnit = FF_SPACE_BEFORE_UNIT_DEFAULT;
     options->percentWidth = 0;
 
-    options->freqNdigits = 2;
+    options->freqNdigits = INT8_MIN;
     options->freqSpaceBeforeUnit = FF_SPACE_BEFORE_UNIT_DEFAULT;
-    options->fractionNdigits = 2;
+    options->fractionNdigits = INT8_MIN;
+    options->globalNdigits = -1;
     options->fractionTrailingZeros = FF_FRACTION_TRAILING_ZEROS_TYPE_DEFAULT;
 
     ffListInit(&options->constants, sizeof(FFstrbuf));
@@ -901,7 +954,8 @@ void ffOptionsGenerateDisplayJsonConfig(FFdata* data, FFOptionsDisplay* options)
                 yyjson_mut_obj_add_str(doc, size, "binaryPrefix", "jedec");
                 break;
         }
-        yyjson_mut_obj_add_uint(doc, size, "ndigits", options->sizeNdigits);
+        if (options->sizeNdigits != UINT8_MAX)
+            yyjson_mut_obj_add_uint(doc, size, "ndigits", options->sizeNdigits);
         switch (options->sizeSpaceBeforeUnit) {
             case FF_SPACE_BEFORE_UNIT_DEFAULT:
                 yyjson_mut_obj_add_str(doc, size, "spaceBeforeUnit", "default");
@@ -931,7 +985,8 @@ void ffOptionsGenerateDisplayJsonConfig(FFdata* data, FFOptionsDisplay* options)
                 yyjson_mut_obj_add_str(doc, obj, "unit", "K");
                 break;
         }
-        yyjson_mut_obj_add_uint(doc, temperature, "ndigits", options->tempNdigits);
+        if (options->tempNdigits != UINT8_MAX)
+            yyjson_mut_obj_add_uint(doc, temperature, "ndigits", options->tempNdigits);
         {
             yyjson_mut_val* color = yyjson_mut_obj_add_obj(doc, temperature, "color");
             yyjson_mut_obj_add_strbuf(doc, color, "green", &options->tempColorGreen);
@@ -971,14 +1026,15 @@ void ffOptionsGenerateDisplayJsonConfig(FFdata* data, FFOptionsDisplay* options)
                 yyjson_mut_arr_add_str(doc, type, "bar-monochrome");
             }
         }
-        yyjson_mut_obj_add_uint(doc, percent, "ndigits", options->percentNdigits);
+        if (options->percentNdigits != UINT8_MAX)
+            yyjson_mut_obj_add_uint(doc, percent, "ndigits", options->percentNdigits);
         {
             yyjson_mut_val* color = yyjson_mut_obj_add_obj(doc, percent, "color");
             yyjson_mut_obj_add_strbuf(doc, color, "green", &options->percentColorGreen);
             yyjson_mut_obj_add_strbuf(doc, color, "yellow", &options->percentColorYellow);
             yyjson_mut_obj_add_strbuf(doc, color, "red", &options->percentColorRed);
         }
-        switch (options->percentSpaceBeforeUnit) {
+        switch (options->freqSpaceBeforeUnit) {
             case FF_SPACE_BEFORE_UNIT_DEFAULT:
                 yyjson_mut_obj_add_str(doc, percent, "spaceBeforeUnit", "default");
                 break;
@@ -1016,10 +1072,11 @@ void ffOptionsGenerateDisplayJsonConfig(FFdata* data, FFOptionsDisplay* options)
     {
         yyjson_mut_val* fraction = yyjson_mut_obj_add_obj(doc, obj, "fraction");
 
-        if (options->fractionNdigits < 0) {
-            yyjson_mut_obj_add_null(doc, fraction, "ndigits");
-        } else {
-            yyjson_mut_obj_add_uint(doc, fraction, "ndigits", (uint8_t) options->fractionNdigits);
+        if (options->fractionNdigits != INT8_MIN) {
+            if (options->fractionNdigits < 0)
+                yyjson_mut_obj_add_null(doc, fraction, "ndigits");
+            else 
+                yyjson_mut_obj_add_uint(doc, fraction, "ndigits", (uint8_t) options->fractionNdigits);
         }
     }
 
@@ -1048,7 +1105,8 @@ void ffOptionsGenerateDisplayJsonConfig(FFdata* data, FFOptionsDisplay* options)
 
     {
         yyjson_mut_val* freq = yyjson_mut_obj_add_obj(doc, obj, "freq");
-        yyjson_mut_obj_add_int(doc, freq, "ndigits", options->freqNdigits);
+        if (options->freqNdigits != INT8_MIN)
+            yyjson_mut_obj_add_int(doc, freq, "ndigits", options->freqNdigits);
         switch (options->percentSpaceBeforeUnit) {
             case FF_SPACE_BEFORE_UNIT_DEFAULT:
                 yyjson_mut_obj_add_str(doc, freq, "spaceBeforeUnit", "default");
@@ -1060,6 +1118,11 @@ void ffOptionsGenerateDisplayJsonConfig(FFdata* data, FFOptionsDisplay* options)
                 yyjson_mut_obj_add_str(doc, freq, "spaceBeforeUnit", "never");
                 break;
         }
+    }
+
+    if (options->globalNdigits >= 0) {
+        yyjson_mut_val* global = yyjson_mut_obj_add_obj(doc, obj, "global");
+        yyjson_mut_obj_add_uint(doc, global, "ndigits", (uint8_t) options->globalNdigits);
     }
 
     {

--- a/src/options/display.h
+++ b/src/options/display.h
@@ -5,6 +5,18 @@
 #include "common/FFstrbuf.h"
 #include "common/FFlist.h"
 
+static inline uint8_t ffNdigitsResolve(uint8_t specific, int8_t global, uint8_t hardcoded) {
+    if (specific != UINT8_MAX) return specific;
+    if (global >= 0) return (uint8_t) global;
+    return hardcoded;
+}
+
+static inline int8_t ffNdigitsResolveInt8(int8_t specific, int8_t global, int8_t hardcoded) {
+    if (specific != INT8_MIN) return specific;
+    if (global >= 0) return global;
+    return hardcoded;
+}
+
 typedef enum FF_A_PACKED FFSizeBinaryPrefixType {
     FF_SIZE_BINARY_PREFIX_TYPE_IEC,   // 1024 Bytes = 1 KiB, 1024 KiB = 1 MiB, ... (standard)
     FF_SIZE_BINARY_PREFIX_TYPE_SI,    // 1000 Bytes = 1 kB, 1000 kB = 1 MB, ...
@@ -86,6 +98,7 @@ typedef struct FFOptionsDisplay {
     FFSpaceBeforeUnitType freqSpaceBeforeUnit;
     int8_t fractionNdigits;
     FFFractionTrailingZerosType fractionTrailingZeros;
+    int8_t globalNdigits;
 
     FFlist constants; // list of FFstrbuf
 } FFOptionsDisplay;


### PR DESCRIPTION
## Summary

Adds `display.global.ndigits` (JSON) and `--ndigits` (CLI) as a single fallback for decimal precision across all value types. Before this, you had to repeat `ndigits` on every category individually to get consistent output. Per-category settings still take full priority over the global.

## Additional fixes
- Fixed missing range validation (0–9) for `--size-ndigits`, `--temp-ndigits`, 
  `--percent-ndigits`, and `--ndigits` CLI flags
- Fixed `--freq-ndigits` and `--fraction-ndigits` CLI flags accepting out-of-range 
  values that could collide with internal sentinels (`INT8_MIN`)
- Fixed `ffOptionsGenerateDisplayJsonConfig` emitting sentinel values (`255`/`INT8_MIN`) 
  for unset ndigits fields in `--gen-config-full` output
- Fixed `src/modules/localip/localip.c` passing `fractionNdigits` directly to 
  `ffStrbufAppendDouble` without sentinel resolution, which would produce incorrect 
  output when `fractionNdigits` is unset
- Fixed `display.freq.spaceBeforeUnit` in gen-config incorrectly reading from 
  `percentSpaceBeforeUnit` instead of `freqSpaceBeforeUnit` (pre-existing bug)

## Related issue
Closes #2234

## Changes
- Added `globalNdigits` field to `FFOptionsDisplay`
- Added `ffNdigitsResolve` and `ffNdigitsResolveInt8` helper functions in `display.h`
- Added `display.global` JSON config block with `ndigits` support
- Added `--ndigits` CLI flag
- Applied global fallback in `size.c`, `temps.c`, `percent.c`, `frequency.c`, `format.c`
- `--gen-config` emits `global.ndigits` when set


## Checklist

- [x] I have tested my changes locally.
