### PR TITLE
Correctly detect GNOME OS

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -2058,7 +2058,7 @@ static const FFlogo G[] = {
     },
     // GNOME
     {
-        .names = { "GNOME" },
+        .names = { "GNOME", "GNOME OS" },
         .lines = FASTFETCH_DATATEXT_LOGO_GNOME,
         .colors = {
             FF_COLOR_FG_BLUE,

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -2056,9 +2056,9 @@ static const FFlogo G[] = {
         .colorKeys = FF_COLOR_FG_BLUE,
         .colorTitle = FF_COLOR_FG_BLUE,
     },
-    // GNOME
+    // GNOME OS
     {
-        .names = { "GNOME", "GNOME OS" },
+        .names = { "GNOME OS" }, // matches "NAME"
         .lines = FASTFETCH_DATATEXT_LOGO_GNOME,
         .colors = {
             FF_COLOR_FG_BLUE,


### PR DESCRIPTION
## Summary

This PR allows correct detection of GNOME OS ( https://os.gnome.org/)

## Related issue (required for new logos for new distros)

<!--
If this PR adds a new logo, it MUST be linked to an existing "Logo Request" issue and has the requests fulfilled.

Use one of the following formats so GitHub links it properly:
- Closes #1234
- Fixes #1234
- Resolves #1234

PRs that add logos without an associated Logo Request issue will not be accepted.
-->

N/A

## Changes

- Shows the correct logo for GNOME OS

## Checklist

- [x] I have tested my changes locally.
