### PR TITLE
fix(os): detect Ubuntu Studio before Kubuntu on KDE systems

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -99,7 +99,7 @@ FF_A_UNUSED static bool getUbuntuFlavour(FFOSResult* result) {
         return false;
     }
 
-    if (ffPathExists("/usr/share/doc/ubuntustudio-desktop", FF_PATHTYPE_DIRECTORY))
+    if (ffPathExists("/var/lib/dpkg/info/ubuntustudio-desktop.list", FF_PATHTYPE_FILE))
     {
         ffStrbufSetStatic(&result->name, "Ubuntu Studio");
         ffStrbufSetStatic(&result->id, "ubuntu-studio");

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -99,6 +99,14 @@ FF_A_UNUSED static bool getUbuntuFlavour(FFOSResult* result) {
         return false;
     }
 
+    if (ffPathExists("/usr/share/doc/ubuntustudio-desktop", FF_PATHTYPE_DIRECTORY))
+    {
+        ffStrbufSetStatic(&result->name, "Ubuntu Studio");
+        ffStrbufSetStatic(&result->id, "ubuntu-studio");
+        ffStrbufSetStatic(&result->idLike, "ubuntu");
+        return false;
+    }
+
     if (ffStrContains(xdgConfigDirs, "kde") || ffStrContains(xdgConfigDirs, "plasma") || ffStrContains(xdgConfigDirs, "kubuntu")) {
         ffStrbufSetStatic(&result->name, "Kubuntu");
         ffStrbufSetStatic(&result->id, "kubuntu");


### PR DESCRIPTION
Fixes #2297

Ubuntu Studio 26.04 has `ID=ubuntu` in `/etc/os-release`.
Fastfetch was detecting KDE/Plasma from `XDG_CONFIG_DIRS` and overriding it as Kubuntu.

This adds a fallback check for `ubuntustudio-desktop` before the Kubuntu detection.