### PR TITLE
add dpkg detection to macOS

### DIFF
--- a/src/detection/packages/packages_apple.c
+++ b/src/detection/packages/packages_apple.c
@@ -6,11 +6,9 @@
 
 static void countBrewPackages(FFstrbuf* baseDir, FFPackagesResult* result) {
     uint32_t baseDirLength = baseDir->length;
-
     ffStrbufAppendS(baseDir, "/Caskroom");
     result->brewCask += ffPackagesGetNumElements(baseDir->chars, true);
     ffStrbufSubstrBefore(baseDir, baseDirLength);
-
     ffStrbufAppendS(baseDir, "/Cellar");
     result->brew += ffPackagesGetNumElements(baseDir->chars, true);
     ffStrbufSubstrBefore(baseDir, baseDirLength);
@@ -21,8 +19,28 @@ static uint32_t getMacPortsPackages(FFstrbuf* baseDir) {
     return ffPackagesGetNumElements(baseDir->chars, true);
 }
 
+static uint32_t getDpkgPackages(FFstrbuf* baseDir) {
+    ffStrbufSetS(baseDir, "/opt/procursus/var/lib/dpkg/status");
+
+    FF_STRBUF_AUTO_DESTROY content = ffStrbufCreate();
+    if (!ffReadFileBuffer(baseDir->chars, &content)) {
+        return 0;
+    }
+
+    const char* needle = "Status: install ok installed";
+    size_t needleLength = strlen(needle);
+    uint32_t count = 0;
+    char* iter = content.chars;
+    while ((iter = memmem(iter, content.length - (size_t)(iter - content.chars), needle, needleLength)) != NULL) {
+        ++count;
+        iter += needleLength;
+    }
+    return count;
+}
+
 void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) {
     FF_STRBUF_AUTO_DESTROY baseDir = ffStrbufCreate();
+
     if (!(options->disabled & FF_PACKAGES_FLAG_BREW_BIT)) {
         const char* prefix = getenv("HOMEBREW_PREFIX");
         if (ffStrSet(prefix)) {
@@ -36,6 +54,7 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) 
         }
         countBrewPackages(&baseDir, result);
     }
+
     if (!(options->disabled & FF_PACKAGES_FLAG_MACPORTS_BIT)) {
         const char* prefix = getenv("MACPORTS_PREFIX");
         if (ffStrSet(prefix)) {
@@ -43,9 +62,13 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) 
         } else {
             ffStrbufSetS(&baseDir, FASTFETCH_TARGET_DIR_ROOT "/opt/local");
         }
-
         result->macports = getMacPortsPackages(&baseDir);
     }
+
+    if (!(options->disabled & FF_PACKAGES_FLAG_DPKG_BIT)) {
+        result->dpkg += getDpkgPackages(&baseDir);
+    }
+
     if (!(options->disabled & FF_PACKAGES_FLAG_NIX_BIT)) {
         ffStrbufSetS(&baseDir, FASTFETCH_TARGET_DIR_ROOT);
         result->nixDefault += ffPackagesGetNix(&baseDir, "/nix/var/nix/profiles/default");


### PR DESCRIPTION
## Summary
Add dpkg package detection for macOS via Procursus bootstrap.

## Related issue
Closes #

## Changes
- `src/detection/packages/packages_apple.c`: Added `getDpkgPackages()` to detect Procursus dpkg packages

## Checklist
- [ ✓ ] I have tested my changes locally.

<img width="800" height="529" alt="image" src="https://github.com/user-attachments/assets/24380681-b79f-43c8-b0ec-d6518f3ece46" />