### PR TITLE
linux: enhance Deepin version detection using /etc/os-version

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -308,11 +308,8 @@ static bool detectBedrock(FFOSResult* os) {
 
 static void detectDeepinEnhancement(FFOSResult* result)
 {
-    if (!ffStrbufEqualS(&result->id, "deepin"))
-        return;
-
-    FFstrbuf minor = ffStrbufCreate();
-    FFstrbuf edition = ffStrbufCreate();
+    FF_STRBUF_AUTO_DESTROY minor = ffStrbufCreate();
+    FF_STRBUF_AUTO_DESTROY edition = ffStrbufCreate();
 
     ffParsePropFileValues(
         FASTFETCH_TARGET_DIR_ETC "/os-version",
@@ -332,9 +329,6 @@ static void detectDeepinEnhancement(FFOSResult* result)
         else
             ffStrbufSetF(&result->prettyName, "%s %s", result->name.chars, minor.chars);
     }
-
-    ffStrbufDestroy(&minor);
-    ffStrbufDestroy(&edition);
 }
 
 static void detectOS(FFOSResult* os) {
@@ -353,7 +347,7 @@ static void detectOS(FFOSResult* os) {
     // Refer: https://gist.github.com/natefoo/814c5bf936922dad97ff
 
     parseOsRelease(FASTFETCH_TARGET_DIR_ETC "/os-release", os);
-    detectDeepinEnhancement(os);
+
     if (os->id.length == 0 || os->version.length == 0 || os->prettyName.length == 0 || os->codename.length == 0) {
         parseLsbRelease(FASTFETCH_TARGET_DIR_ETC "/lsb-release", os);
     }
@@ -392,6 +386,8 @@ void ffDetectOSImpl(FFOSResult* os) {
             ffStrbufSetS(&os->id, "lmde");
             ffStrbufSetS(&os->idLike, "linuxmint");
         }
+    } else if (ffStrbufEqualS(&result->id, "deepin")) {
+        detectDeepinEnhancement(&result);
     }
 #endif
 }

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -95,8 +95,7 @@ FF_A_UNUSED static bool getUbuntuFlavour(FFOSResult* result) {
     }
 
     // xdgConfigDirs contains plasma only
-    if (ffPathExists("/var/lib/dpkg/info/ubuntustudio-desktop.list", FF_PATHTYPE_FILE))
-    {
+    if (ffPathExists("/var/lib/dpkg/info/ubuntustudio-desktop.list", FF_PATHTYPE_FILE)) {
         ffStrbufSetStatic(&result->name, "Ubuntu Studio");
         ffStrbufSetStatic(&result->id, "ubuntu-studio");
         ffStrbufSetStatic(&result->idLike, "ubuntu");
@@ -306,28 +305,31 @@ static bool detectBedrock(FFOSResult* os) {
     return parseOsRelease(FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/bedrock/etc/os-release", os);
 }
 
-static void detectDeepinEnhancement(FFOSResult* result)
-{
+static void detectDeepinEnhancement(FFOSResult* result) {
+    if (ffStrbufContainC(&result->prettyName, '(')) {
+        return;
+    }
+
     FF_STRBUF_AUTO_DESTROY minor = ffStrbufCreate();
     FF_STRBUF_AUTO_DESTROY edition = ffStrbufCreate();
 
-    ffParsePropFileValues(
-        FASTFETCH_TARGET_DIR_ETC "/os-version",
-        2,
-        (FFpropquery[]) {
-            { "MinorVersion=", &minor },
-            { "EditionName=", &edition },
-        }
-    );
+    if (!ffParsePropFileValues(
+            FASTFETCH_TARGET_DIR_ETC "/os-version",
+            2,
+            (FFpropquery[]) {
+                { "MinorVersion=", &minor },
+                { "EditionName=", &edition },
+            }) ||
+        minor.length == 0) {
+        return;
+    }
 
-    if (edition.length > 0 && !ffStrbufContainC(&result->prettyName, '('))
-    {
-        ffStrbufSet(&result->versionID, &minor);
+    ffStrbufSet(&result->versionID, &minor);
 
-        if (edition.length > 0)
-            ffStrbufSetF(&result->prettyName, "%s %s (%s)", result->name.chars, minor.chars, edition.chars);
-        else
-            ffStrbufSetF(&result->prettyName, "%s %s", result->name.chars, minor.chars);
+    if (edition.length > 0) {
+        ffStrbufSetF(&result->prettyName, "%s %s (%s)", result->name.chars, minor.chars, edition.chars);
+    } else {
+        ffStrbufSetF(&result->prettyName, "%s %s", result->name.chars, minor.chars);
     }
 }
 
@@ -386,8 +388,8 @@ void ffDetectOSImpl(FFOSResult* os) {
             ffStrbufSetS(&os->id, "lmde");
             ffStrbufSetS(&os->idLike, "linuxmint");
         }
-    } else if (ffStrbufEqualS(&result->id, "deepin")) {
-        detectDeepinEnhancement(&result);
+    } else if (ffStrbufEqualS(&os->id, "deepin")) {
+        detectDeepinEnhancement(os);
     }
 #endif
 }

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -328,9 +328,9 @@ static void detectDeepinEnhancement(FFOSResult* result)
         ffStrbufSet(&result->versionID, &minor);
 
         if (edition.length > 0)
-            ffStrbufSetF(&result->prettyName, "Deepin %s (%s)", minor.chars, edition.chars);
+            ffStrbufSetF(&result->prettyName, "%s %s (%s)", result->name.chars, minor.chars, edition.chars);
         else
-            ffStrbufSetF(&result->prettyName, "Deepin %s", minor.chars);
+            ffStrbufSetF(&result->prettyName, "%s %s", result->name.chars, minor.chars);
     }
 
     ffStrbufDestroy(&minor);

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -306,6 +306,37 @@ static bool detectBedrock(FFOSResult* os) {
     return parseOsRelease(FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/bedrock/etc/os-release", os);
 }
 
+static void detectDeepinEnhancement(FFOSResult* result)
+{
+    if (!ffStrbufEqualS(&result->id, "deepin"))
+        return;
+
+    FFstrbuf minor = ffStrbufCreate();
+    FFstrbuf edition = ffStrbufCreate();
+
+    ffParsePropFileValues(
+        FASTFETCH_TARGET_DIR_ETC "/os-version",
+        2,
+        (FFpropquery[]) {
+            { "MinorVersion=", &minor },
+            { "EditionName=", &edition },
+        }
+    );
+
+    if (minor.length > 0)
+    {
+        ffStrbufSet(&result->versionID, &minor);
+
+        if (edition.length > 0)
+            ffStrbufSetF(&result->prettyName, "Deepin %s (%s)", minor.chars, edition.chars);
+        else
+            ffStrbufSetF(&result->prettyName, "Deepin %s", minor.chars);
+    }
+
+    ffStrbufDestroy(&minor);
+    ffStrbufDestroy(&edition);
+}
+
 static void detectOS(FFOSResult* os) {
 #ifdef FF_CUSTOM_OS_RELEASE_PATH
     parseOsRelease(FF_STR(FF_CUSTOM_OS_RELEASE_PATH), os);
@@ -322,6 +353,7 @@ static void detectOS(FFOSResult* os) {
     // Refer: https://gist.github.com/natefoo/814c5bf936922dad97ff
 
     parseOsRelease(FASTFETCH_TARGET_DIR_ETC "/os-release", os);
+    detectDeepinEnhancement(os);
     if (os->id.length == 0 || os->version.length == 0 || os->prettyName.length == 0 || os->codename.length == 0) {
         parseLsbRelease(FASTFETCH_TARGET_DIR_ETC "/lsb-release", os);
     }

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -323,7 +323,7 @@ static void detectDeepinEnhancement(FFOSResult* result)
         }
     );
 
-    if (minor.length > 0)
+    if (edition.length > 0 && !ffStrbufContainC(&result->prettyName, '('))
     {
         ffStrbufSet(&result->versionID, &minor);
 


### PR DESCRIPTION
Enhance Deepin OS detection by parsing /etc/os-version.

This adds support for:
- MinorVersion (e.g. 25.1.0)
- EditionName (e.g. Community)

Instead of overriding the entire prettyName, this patch updates versionID
and appends edition information safely.

Example before:
OS: Deepin 25 x86_64

Example after:
OS: Deepin 25.1.0 (Community) x86_64