### PR TITLE
Add Zerene OS logo

### DIFF
--- a/src/logo/ascii/zerene.txt
+++ b/src/logo/ascii/zerene.txt
@@ -1,0 +1,17 @@
+$1          ''
+$1        .:kNK,
+$1      ,dKWMMWd
+$1    .lXMMMMMMK,
+$1     .,lkKWMMWd.
+$1         .;oONK,
+$1             ':,...           ..,c,
+$1              .l0X0Oo. ..,:ldOKNWMd
+$1              '0MMMMX:.cONMMMMMMMWc
+$1               ,oxdo:.  .;oONMMMMX;
+$1             .l;            'cd0N0'
+$1          .:xXWc               .,,
+$1        ,oKWMMX;
+$1     .cONMMMMM0'
+$1      ,lkXWMMMk.
+$1         .:d0Wd
+$1            .,.

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -5515,6 +5515,16 @@ static const FFlogo Y[] = {
 };
 
 static const FFlogo Z[] = {
+    // Zerene
+    {
+        .names = { "zerene", "zeluxos" },
+        .lines = FASTFETCH_DATATEXT_LOGO_ZERENE,
+        .colors = {
+            FF_COLOR_FG_RGB "40;0;255"
+        },
+        .colorKeys = FF_COLOR_FG_RGB "40;0;255",
+        .colorTitle = FF_COLOR_FG_RGB "40;0;255",
+    },
     // Zorin
     {
         .names = { "Zorin" },


### PR DESCRIPTION
## Summary

Adds the Zerene OS ASCII logo.

## Related issue

Closes #2292

## Changes

- Added the Zerene OS ASCII logo
- Added `$1` placeholders to the original ASCII logo, as none were provided
- Registered the logo under `zerene` and `zeluxos`
- Used the RGB color from the issue's provided `ANSI_COLOR`: `40;0;255`
### Provided ASCII Art


              ''
           .:kNK,
         ,dKWMMWd
       .lXMMMMMMK,
        .,lkKWMMWd.
            .;oONK,
                ':,...           ..,c,
                 .l0X0Oo. ..,:ldOKNWMd
                 '0MMMMX:.cONMMMMMMMWc
                  ,oxdo:.  .;oONMMMMX;
                .l;            'cd0N0'
             .:xXWc               .,,
           ,oKWMMX;
        .cONMMMMM0'
         ,lkXWMMMk.
            .:d0Wd
               .,.


### 


## Checklist

- [x] I have tested my changes locally.

Tested with:

```sh
cmake --build build
./build/fastfetch --logo zerene
./build/fastfetch --logo zeluxos
./build/fastfetch --list-logos | grep -i zerene
```