### PR TITLE
Fix TDE Konsole version

### DIFF
--- a/src/detection/terminalshell/terminalshell.c
+++ b/src/detection/terminalshell/terminalshell.c
@@ -365,7 +365,13 @@ FF_A_UNUSED static bool getTerminalVersionKonsole(FFstrbuf* exe, FFstrbuf* versi
         }
     }
 
-    return getExeVersionGeneral(exe, version);
+    if (!getExeVersionRaw(exe, version)) {
+            return false;
+    }
+
+    ffStrbufSubstrAfterFirstS(version, "Konsole: ");
+    ffStrbufSubstrBeforeFirstC(version, ' ');
+    return true;
 }
 
 FF_A_UNUSED static bool getTerminalVersionFoot(FFstrbuf* exe, FFstrbuf* version) {


### PR DESCRIPTION
Fix for TDE Konsole version

## Summary

When using fastfetch in TDE (Trinity Desktop Environment) version of Konsole, the terminal version messes up the output of fastfetch and prints something like this:
```
                               Terminal: konsole 3.5.0
TDE:
```
This is because the output of `/opt/trinity/bin/konsole --version` is
```
Qt: 3.5.0
TDE: R14.1.6
Konsole: 1.6.6
```

## Changes

To fix this, I changed the fallback behavior of `getTerminalVersionKonsole` to set the version to the string between "Konsole: " and " ", instead of the old behavior where the first string between whitespaces is returned (in that case "3.5.0\nTDE:" is wrongly set which explains the unexpected newline in the output of FF)

## Checklist

- [x] I have tested my changes locally.
