### PR TITLE
MiNT (Atari) port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Haiku")
     set(Haiku TRUE CACHE BOOL "..." FORCE)
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "GNU")
     set(GNU TRUE CACHE BOOL "..." FORCE)
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "MINT")
+    set(MINT TRUE CACHE BOOL "..." FORCE)
 elseif(NOT APPLE AND NOT WIN32)
     message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
 endif()
@@ -92,6 +94,7 @@ cmake_dependent_option(ENABLE_PULSE "Enable pulse" ON "LINUX OR ANDROID OR GNU" 
 cmake_dependent_option(ENABLE_DDCUTIL "Enable ddcutil" ON "LINUX" OFF)
 cmake_dependent_option(ENABLE_ELF "Enable libelf" ON "LINUX OR ANDROID OR DragonFly OR Haiku OR GNU" OFF)
 cmake_dependent_option(ENABLE_THREADS "Enable multithreading" ON "Threads_FOUND" OFF)
+cmake_dependent_option(ENABLE_LIBZFS "Enable libzfs" ON "NOT MINT" OFF)
 
 option(ENABLE_ZLIB "Enable zlib" ON)
 option(ENABLE_SYSTEM_YYJSON "Use system provided (instead of fastfetch embedded) yyjson library" OFF)
@@ -105,7 +108,6 @@ option(INSTALL_LICENSE "Install license into /usr/share/licenses" ON)
 option(ENABLE_EMBEDDED_PCIIDS "Embed pci.ids into fastfetch, requires `python`" OFF)
 option(ENABLE_EMBEDDED_AMDGPUIDS "Embed amdgpu.ids into fastfetch, requires `python`" OFF)
 option(ENABLE_WORDEXP "Enable using of wordexp(3) if available, instead of glob(3)" ON)
-option(ENABLE_LIBZFS "Enable libzfs" ON)
 if(WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     option(ENABLE_WIN81_COMPAT "Enable legacy Windows compatibility (Windows 8.1 and later; Windows 7 unsupported)" ON)
 endif()
@@ -1327,6 +1329,74 @@ elseif(GNU)
         src/detection/wmtheme/wmtheme_linux.c
         src/detection/camera/camera_nosupport.c
    )
+elseif(MINT)
+    list(APPEND LIBFASTFETCH_SRC
+        src/common/impl/dbus.c
+        src/common/impl/io_unix.c
+        src/common/impl/netif_nosupport.c
+        src/common/impl/networking_nosupport.c
+        src/common/impl/processing_linux.c
+        src/common/impl/FFPlatform_unix.c
+        src/common/impl/binary_linux.c
+        src/detection/battery/battery_nosupport.c
+        src/detection/bios/bios_mint.c
+        src/detection/board/board_mint.c
+        src/detection/bootmgr/bootmgr_nosupport.c
+        src/detection/brightness/brightness_nosupport.c
+        src/detection/btrfs/btrfs_nosupport.c
+        src/detection/chassis/chassis_nosupport.c
+        src/detection/cpu/cpu_mint.c
+        src/detection/cpucache/cpucache_nosupport.c
+        src/detection/cpuusage/cpuusage_nosupport.c
+        src/detection/cursor/cursor_nosupport.c
+        src/detection/bluetooth/bluetooth_nosupport.c
+        src/detection/bluetoothradio/bluetoothradio_nosupport.c
+        src/detection/disk/disk_nosupport.c
+        src/detection/dns/dns_linux.c
+        src/detection/physicaldisk/physicaldisk_nosupport.c
+        src/detection/physicalmemory/physicalmemory_nosupport.c
+        src/detection/diskio/diskio_nosupport.c
+        src/detection/displayserver/displayserver_aes.c
+        src/detection/font/font_nosupport.c
+        src/detection/gpu/gpu_nosupport.c
+        src/detection/gtk_qt/gtk.c
+        src/detection/host/host_nosupport.c
+        src/detection/icons/icons_nosupport.c
+        src/detection/initsystem/initsystem_nosupport.c
+        src/detection/keyboard/keyboard_nosupport.c
+        src/detection/libc/libc_nosupport.c
+        src/detection/lm/lm_nosupport.c
+        src/detection/loadavg/loadavg_linux.c
+        src/detection/locale/locale_linux.c
+        src/detection/localip/localip_nosupport.c
+        src/detection/gamepad/gamepad_nosupport.c
+        src/detection/media/media_nosupport.c
+        src/detection/memory/memory_linux.c
+        src/detection/mouse/mouse_nosupport.c
+        src/detection/netio/netio_nosupport.c
+        src/detection/opengl/opengl_nosupport.c
+        src/detection/os/os_linux.c
+        src/detection/packages/packages_nosupport.c
+        src/detection/poweradapter/poweradapter_nosupport.c
+        src/detection/processes/processes_nosupport.c
+        src/detection/gtk_qt/qt.c
+        src/detection/sound/sound_nosupport.c
+        src/detection/swap/swap_nosupport.c
+        src/detection/terminalfont/terminalfont_linux.c
+        src/detection/terminalshell/terminalshell_linux.c
+        src/detection/terminalsize/terminalsize_linux.c
+        src/detection/theme/theme_nosupport.c
+        src/detection/tpm/tpm_nosupport.c
+        src/detection/uptime/uptime_nosupport.c
+        src/detection/users/users_nosupport.c
+        src/detection/wallpaper/wallpaper_nosupport.c
+        src/detection/wifi/wifi_nosupport.c
+        src/detection/wm/wm_nosupport.c
+        src/detection/de/de_nosupport.c
+        src/detection/wmtheme/wmtheme_nosupport.c
+        src/detection/camera/camera_nosupport.c
+        src/detection/zpool/zpool.c
+    )
 endif()
 
 # Proprietary GPU driver APIs
@@ -1466,6 +1536,9 @@ elseif(Haiku)
 elseif(GNU)
     # On Hurd PATH_MAX is not defined. Set an arbitrary limit as workaround.
     target_compile_definitions(libfastfetch PUBLIC _GNU_SOURCE PATH_MAX=4096 O_PATH=0)
+elseif(MINT)
+    target_compile_definitions(libfastfetch PUBLIC _GNU_SOURCE _XOPEN_SOURCE _POSIX_SOURCE)
+    set(BINARY_LINK_TYPE "static")
 endif()
 
 if(APPLE)
@@ -1839,6 +1912,13 @@ elseif(Haiku)
         PRIVATE "be"
         PRIVATE "gnu"
     )
+elseif(MINT)
+    target_link_libraries(libfastfetch
+        PRIVATE "cflib"
+        PRIVATE "gem"
+        PRIVATE "m"
+        #PRIVATE "mintlib"
+    )
 endif()
 
 target_include_directories(libfastfetch
@@ -1846,9 +1926,11 @@ target_include_directories(libfastfetch
     PUBLIC ${PROJECT_SOURCE_DIR}/src
 )
 
+if(NOT MINT)
 target_link_libraries(libfastfetch
     PRIVATE ${CMAKE_DL_LIBS}
 )
+endif()
 
 target_compile_options(libfastfetch PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions -fno-rtti>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1338,6 +1338,7 @@ elseif(MINT)
         src/common/impl/processing_linux.c
         src/common/impl/FFPlatform_unix.c
         src/common/impl/binary_linux.c
+        src/common/mint/ticks.c
         src/detection/battery/battery_nosupport.c
         src/detection/bios/bios_mint.c
         src/detection/board/board_mint.c
@@ -1422,6 +1423,7 @@ if(NOT HAVE_WCWIDTH)
     list(APPEND LIBFASTFETCH_SRC src/common/impl/wcwidth.c)
 endif()
 if(NOT WIN32)
+    check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
     check_function_exists(pipe2 HAVE_PIPE2)
 endif()
 check_function_exists(memrchr HAVE_MEMRCHR)
@@ -1588,6 +1590,10 @@ endif()
 
 if(HAVE_PIPE2)
     target_compile_definitions(libfastfetch PUBLIC FF_HAVE_PIPE2)
+endif()
+
+if(HAVE_CLOCK_GETTIME)
+    target_compile_definitions(libfastfetch PUBLIC FF_HAVE_CLOCK_GETTIME)
 endif()
 
 if(NOT "${CUSTOM_PCI_IDS_PATH}" STREQUAL "")

--- a/Toolchain-atari-NetSurf.cmake
+++ b/Toolchain-atari-NetSurf.cmake
@@ -1,0 +1,34 @@
+# This Toolchain file is used to cross compile the windows
+# version of Hatari under linux using mingw32
+# use : cmake -DCMAKE_TOOLCHAIN_FILE=Toolchain-atari.cmake
+
+# The name of the target operating system
+SET(CMAKE_SYSTEM_NAME MINT)
+
+# MINT versions of the different tools
+# (change these depending on your system settings)
+SET(CMAKE_C_COMPILER m68k-atari-mint-gcc)
+SET(CMAKE_CXX_COMPILER m68k-atari-mint-g++)
+SET(CMAKE_RC_COMPILER m68k-atari-mint-windres)
+SET(CMAKE_ASM_COMPILER m68k-atari-mint-as)
+SET(CMAKE_STRIP m68k-atari-mint-strip)
+
+# Base directory for the target environment
+SET(CMAKE_FIND_ROOT_PATH /opt/netsurf/m68k-atari-mint/env )
+
+# FindSDL.cmake doesn't search correctly in CMAKE_FIND_ROOT_PATH
+# so we force SDLDIR here
+set ( ENV{SDLDIR} ${CMAKE_FIND_ROOT_PATH}/include/SDL )
+
+# Adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search 
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+#
+set(CMAKE_EXECUTABLE_SUFFIX .prg)
+set(CMAKE_EXECUTABLE_SUFFIX_ASM .prg)
+set(CMAKE_EXECUTABLE_SUFFIX_C .prg)
+set(CMAKE_EXECUTABLE_SUFFIX_CXX .prg)

--- a/Toolchain-atari.cmake
+++ b/Toolchain-atari.cmake
@@ -1,0 +1,39 @@
+# This Toolchain file is used to cross compile the windows
+# version of Hatari under linux using mingw32
+# use : cmake -DCMAKE_TOOLCHAIN_FILE=Toolchain-atari.cmake
+
+# The name of the target operating system
+SET(CMAKE_SYSTEM_NAME MINT)
+
+# MINT versions of the different tools
+# (change these depending on your system settings)
+SET(CMAKE_C_COMPILER m68k-atari-mintelf-gcc)
+SET(CMAKE_CXX_COMPILER m68k-atari-mintelf-g++)
+SET(CMAKE_RC_COMPILER m68k-atari-mintelf-windres)
+SET(CMAKE_ASM_COMPILER m68k-atari-mintelf-as)
+SET(CMAKE_STRIP m68k-atari-mintelf-strip)
+
+# Base directory for the target environment
+SET(CMAKE_FIND_ROOT_PATH /usr/m68k-atari-mintelf )
+
+# FindSDL.cmake doesn't search correctly in CMAKE_FIND_ROOT_PATH
+# so we force SDLDIR here
+set ( ENV{SDLDIR} ${CMAKE_FIND_ROOT_PATH}/include/SDL )
+
+# Force pkg-config search paths as there's no symlink
+set ( ENV{PKG_CONFIG_LIBDIR} ${CMAKE_FIND_ROOT_PATH}/lib/pkgconfig )
+set ( ENV{PKG_CONFIG_SYSTEM_INCLUDE_PATH} ${CMAKE_FIND_ROOT_PATH}/include )
+set ( ENV{PKG_CONFIG_SYSTEM_LIBRARY_PATH} ${CMAKE_FIND_ROOT_PATH}/lib )
+
+# Adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search 
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+#
+set(CMAKE_EXECUTABLE_SUFFIX .prg)
+set(CMAKE_EXECUTABLE_SUFFIX_ASM .prg)
+set(CMAKE_EXECUTABLE_SUFFIX_C .prg)
+set(CMAKE_EXECUTABLE_SUFFIX_CXX .prg)

--- a/src/common/arrayUtils.h
+++ b/src/common/arrayUtils.h
@@ -2,6 +2,10 @@
 
 #include <assert.h>
 
+#ifdef __MINT__
+#define static_assert(x,y)
+#endif
+
 #ifdef __has_builtin
     #if !__cplusplus && FF_SUPPORTS_COUNT_OF
         #define ARRAY_SIZE(x) _Countof(x)

--- a/src/common/attributes.h
+++ b/src/common/attributes.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __MINT__
+#define static_assert(x,y)
+#endif
+
 #ifndef __has_attribute
     #error Unsupported compiler
     #define __attribute__(x)

--- a/src/common/impl/FFPlatform_unix.c
+++ b/src/common/impl/FFPlatform_unix.c
@@ -24,6 +24,9 @@
 #elif defined(__HAIKU__)
     #include <image.h>
     #include <OS.h>
+#elif defined(__MINT__)
+    #include <mint/basepage.h>
+    #include <math.h>
 #endif
 
 static void getExePath(FFPlatform* platform) {
@@ -142,6 +145,9 @@ static void getExePath(FFPlatform* platform) {
             break;
         }
     }
+#elif defined(__MINT__)
+    size_t exePathLen = strnlen(_base->p_cmdlin, sizeof(_base->p_cmdlin) - 1);
+    exePathLen = strlcpy(exePath, _base->p_cmdlin, min(exePathLen, PATH_MAX));
 #endif
     if (exePathLen > 0) {
         ffStrbufEnsureFree(&platform->exePath, PATH_MAX);

--- a/src/common/impl/io_unix.c
+++ b/src/common/impl/io_unix.c
@@ -280,18 +280,22 @@ void listFilesRecursively(uint32_t baseLength, FFstrbuf* folder, uint8_t indenta
         }
 
         bool isDir = false;
-#if !defined(__sun) && !defined(__HAIKU__)
+#if !defined(__sun) && !defined(__HAIKU__) && !defined(__MINT__)
         if (entry->d_type != DT_UNKNOWN && entry->d_type != DT_LNK) {
             isDir = entry->d_type == DT_DIR;
         } else
 #endif
         {
             struct stat stbuf;
+#ifndef __MINT__
             if (fstatat(dfd, entry->d_name, &stbuf, 0) < 0) {
+#endif
                 isDir = false;
+#ifndef __MINT__
             } else {
                 isDir = S_ISDIR(stbuf.st_mode);
             }
+#endif
         }
         if (isDir) {
             ffStrbufAppendS(folder, entry->d_name);

--- a/src/common/impl/netif_nosupport.c
+++ b/src/common/impl/netif_nosupport.c
@@ -1,0 +1,7 @@
+#include "common/netif.h"
+#include "common/io.h"
+
+bool ffNetifGetDefaultRouteImpl(char *iface, uint32_t* ifIndex)
+{
+    return false;
+}

--- a/src/common/impl/networking_nosupport.c
+++ b/src/common/impl/networking_nosupport.c
@@ -1,0 +1,13 @@
+#include "fastfetch.h"
+#include "common/networking.h"
+
+const char* ffNetworkingSendHttpRequest(FFNetworkingState* state, const char* host, const char* path, const char* headers)
+{
+    return "Not supported on this platform";
+}
+
+const char* ffNetworkingRecvHttpResponse(FFNetworkingState* state, FFstrbuf* buffer)
+{
+    return "Not supported on this platform";
+
+}

--- a/src/common/impl/processing_linux.c
+++ b/src/common/impl/processing_linux.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <sys/wait.h>
 
-#if !(__ANDROID__ || __OpenBSD__)
+#if !(__ANDROID__ || __OpenBSD__ || __MINT__)
     #include <spawn.h>
 #endif
 
@@ -66,7 +66,7 @@ const char* ffProcessSpawn(char* const argv[], bool useStdErr, FFProcessHandle* 
     pid_t childPid = -1;
     int nullFile = ffGetNullFD();
 
-#if !(__ANDROID__ || __OpenBSD__)
+#if !(__ANDROID__ || __OpenBSD__ || __MINT__)
 
     // NetBSD / Darwin: native syscall
     // Linux (glibc): clone3-execve

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -40,6 +40,14 @@ HANDLE openat(HANDLE dfd, const char* fileName, int oflag);
 HANDLE openatW(HANDLE dfd, const wchar_t* fileName, uint16_t fileNameLen, bool directory);
 #endif
 
+#ifdef __MINT__
+    #ifndef O_CLOEXEC
+        #warning "O_CLOEXEC missing"
+        #define O_CLOEXEC 0
+    #endif
+    #define openat(dfd, fileName, oflag) ({-1;})
+#endif
+
 static inline bool ffIsValidNativeFD(FFNativeFD fd) {
 #ifndef _WIN32
     return fd >= 0;
@@ -124,12 +132,16 @@ FF_A_NONNULL(1, 3) static inline ssize_t ffReadFileData(const char* fileName, si
 }
 
 FF_A_NONNULL(2, 4) static inline ssize_t ffReadFileDataRelative(FFNativeFD dfd, const char* fileName, size_t dataSize, void* data) {
+#ifndef __MINT__
     FFNativeFD FF_AUTO_CLOSE_FD fd = openat(dfd, fileName, O_RDONLY | O_CLOEXEC);
     if (!ffIsValidNativeFD(fd)) {
+#endif
         return -1;
+#ifndef __MINT__
     }
 
     return ffReadFDData(fd, dataSize, data);
+#endif
 }
 
 FF_A_NONNULL(1, 2) static inline bool ffAppendFileBuffer(const char* fileName, FFstrbuf* buffer) {
@@ -148,12 +160,16 @@ FF_A_NONNULL(1, 2) static inline bool ffAppendFileBuffer(const char* fileName, F
 }
 
 FF_A_NONNULL(2, 3) static inline bool ffAppendFileBufferRelative(FFNativeFD dfd, const char* fileName, FFstrbuf* buffer) {
+#ifndef __MINT__
     FFNativeFD FF_AUTO_CLOSE_FD fd = openat(dfd, fileName, O_RDONLY | O_CLOEXEC);
     if (!ffIsValidNativeFD(fd)) {
+#endif
         return false;
+#ifndef __MINT__
     }
 
     return ffAppendFDBuffer(fd, buffer);
+#endif
 }
 
 FF_A_NONNULL(2) static inline bool ffReadFDBuffer(FFNativeFD fd, FFstrbuf* buffer) {

--- a/src/common/mint/ticks.c
+++ b/src/common/mint/ticks.c
@@ -1,0 +1,11 @@
+#include <mint/sysvars.h>
+#include <mint/osbind.h>
+
+double mint_ticks_ms(void)
+{
+    long oldmode = Super(0L);
+    double ticks = *_hz_200 * 5.;
+    Super(oldmode);
+
+    return ticks;
+}

--- a/src/common/time.h
+++ b/src/common/time.h
@@ -9,6 +9,11 @@
     #include <profileapi.h>
 #elif defined(__HAIKU__)
     #include <OS.h>
+#elif !defined(FF_HAVE_CLOCK_GETTIME)
+    #include <sys/time.h>
+#endif
+#ifdef __MINT__
+extern double mint_ticks_ms(void);
 #endif
 
 #include "common/arrayUtils.h"
@@ -22,10 +27,14 @@ static inline double ffTimeGetTick(void) // In msec
     return (double) start.QuadPart * ffQpcMultiplier;
 #elif defined(__HAIKU__)
     return (double) system_time() / 1000.;
-#else
+#elif defined(__MINT__)
+        return mint_ticks_ms();
+#elif defined(FF_HAVE_CLOCK_GETTIME)
     struct timespec timeNow;
     clock_gettime(CLOCK_MONOTONIC, &timeNow);
     return (double) timeNow.tv_sec * 1000. + (double) timeNow.tv_nsec / 1000000.;
+#else
+    #error UNIMPLEMENTED
 #endif
 }
 
@@ -44,10 +53,14 @@ static inline uint64_t ffTimeGetNow(void) {
     return ffFileTimeToUnixMs((uint64_t) timeNow);
 #elif defined(__HAIKU__)
     return (uint64_t) real_time_clock_usecs() / 1000u;
-#else
+#elif defined(FF_HAVE_CLOCK_GETTIME)
     struct timespec timeNow;
     clock_gettime(CLOCK_REALTIME, &timeNow);
     return (uint64_t) (((uint64_t) timeNow.tv_sec * 1000u) + ((uint64_t) timeNow.tv_nsec / 1000000u));
+#else
+    struct timeval timeNow;
+    (void)gettimeofday(&timeNow, NULL);
+    return (uint64_t) (((uint64_t) timeNow.tv_sec * 1000u) + ((uint64_t) timeNow.tv_usec / 1000u));
 #endif
 }
 

--- a/src/detection/bios/bios_mint.c
+++ b/src/detection/bios/bios_mint.c
@@ -1,0 +1,17 @@
+#include "bios.h"
+
+#include "common/settings.h"
+#include "common/io.h"
+
+#include <mint/sysvars.h>
+
+const char* ffDetectBios(FFBiosResult* bios) {
+    OSHEADER *oh = (OSHEADER *)_sysbase;
+
+    ffStrbufSetF(&bios->version, "%d", oh->os_version);
+    unsigned long d = (unsigned) oh->os_date;
+    ffStrbufSetF(&bios->date, "%04d-%02d-%02d", (d & 0x0ffff), ((d >> 24) & 0x0ff), ((d >> 16) & 0x0ff));
+    ffStrbufSetStatic(&bios->type, "BIOS");
+
+    return NULL;
+}

--- a/src/detection/bios/bios_mint.c
+++ b/src/detection/bios/bios_mint.c
@@ -4,13 +4,22 @@
 #include "common/io.h"
 
 #include <mint/sysvars.h>
+#include <mint/osbind.h>
 
 const char* ffDetectBios(FFBiosResult* bios) {
-    OSHEADER *oh = (OSHEADER *)_sysbase;
+    OSHEADER *oh;
+    unsigned long oldmode = Super(0L);
+    oh    = *(OSHEADER **)_sysbase;
+    Super(oldmode);
 
-    ffStrbufSetF(&bios->version, "%d", oh->os_version);
+    ffStrbufSetF(&bios->version, "%2x.%02x", (oh->os_version >> 8), oh->os_version & 0x0ff);
     unsigned long d = (unsigned) oh->os_date;
-    ffStrbufSetF(&bios->date, "%04d-%02d-%02d", (d & 0x0ffff), ((d >> 24) & 0x0ff), ((d >> 16) & 0x0ff));
+    // Seems like EmuTOS doesn't agree with TOS on the date format?
+    unsigned long y = (d >> 16) & 0x0ffff;
+    if ((y >= 0x1980) && (y < 0x2100))
+        ffStrbufSetF(&bios->date, "%04x-%02x-%02x", ((d >> 16) & 0x0ffff), ((d >> 8) & 0x0ff), (d & 0x0ff));
+    else
+        ffStrbufSetF(&bios->date, "%04x-%02x-%02x", (d & 0x0ffff), ((d >> 24) & 0x0ff), ((d >> 16) & 0x0ff));
     ffStrbufSetStatic(&bios->type, "BIOS");
 
     return NULL;

--- a/src/detection/board/board_mint.c
+++ b/src/detection/board/board_mint.c
@@ -1,0 +1,56 @@
+#include "board.h"
+#include "common/settings.h"
+
+//#include <cflib.h>
+#include <mint/cookie.h>
+
+# define COOKIE__MCH /*(const char *)*/0x5f4d4348L
+// TODO: COOKIE_HADES
+
+const char* ffDetectBoard(FFBoardResult* board) {
+    long value;
+    const char *vendor = "Unknown";
+    const char *product = "Unknown";
+
+    // cf. https://www.exxosforum.co.uk/atari/mirror/toshyp/003007.html#Cookie_2C_20_MCH
+    static struct machine_cookies {
+        long v;
+        const char *vendor;
+        const char *product;
+    } machine_cookies[] = {
+        { 0x00000000, "Atari", "ST" }, // (260 ST,520 ST,1040 ST,Mega ST,...)
+        { 0x00004D34, "Medusa", "T40 without SCSI" },
+        { 0x00010000, "Atari", "STE" }, // (1040 STE, ST-Book)
+        { 0x00010001, "Atari", "ST-Book" }, // (1040 STE, ST-Book)
+        { 0x00010008, "Atari", "STE with IDE" },
+        { 0x00010010, "Atari", "Mega STE" },
+        { 0x00010008, "Atari", "Mega STE with IDE" },
+        { 0x00010100, "Atari", "Sparrow" }, // (Falcon pre-production machine)
+        { 0x00020000, "Atari", "TT or Hades" },
+        { 0x00024D34, "Medusa", "T40 with SCSI" },
+        { 0x00030000, "Atari", "Falcon 030" },
+        { 0x00040000, "Milan", "Milan" },
+        { 0x00050000, "ARAnyM", "ARAnyM"}, // >=v0.8.5beta
+        // ACP / FireBee?
+        // Vampire?
+        { -1, "Unknown", "Non ST compatible" },
+        { -1, NULL, NULL }
+    };
+
+    if (Getcookie(COOKIE__MCH, &value)) {
+        return "getcookie(_MCH) failed";
+    }
+    for (int i = 0; machine_cookies[i].vendor; i++)
+        if (machine_cookies[i].v == value) {
+            vendor = machine_cookies[i].vendor;
+            product = machine_cookies[i].product;
+            break;
+        }
+
+    ffStrbufSetStatic(&board->vendor, vendor);
+    ffStrbufSetStatic(&board->name, product);
+    //ffStrbufSetStatic(&board->version, ""));
+    //ffStrbufSetStatic(&board->serial, "");
+
+    return NULL;
+}

--- a/src/detection/cpu/cpu_mint.c
+++ b/src/detection/cpu/cpu_mint.c
@@ -1,0 +1,44 @@
+#include "cpu.h"
+
+//#include <cflib.h>
+#include <mint/cookie.h>
+
+#define COOKIE__CPU /*(const char *)*/0x5f435055L
+#define COOKIE_CT60 /*(const char *)*/0x43543630L
+
+const char* ffDetectCPUImpl(const FFCPUOptions* options, FFCPUResult* cpu) {
+    long value = -1;
+
+    cpu->temperature = FF_CPU_TEMP_UNSET;
+
+    if (!Getcookie(COOKIE_CT60, &value)) {
+        struct CT60_COOKIE {
+            uint16_t trigger_temp, daystop, timestop, speed_fan;
+            unsigned long cpu_frequency; // in MHz * 10
+            uint16_t beep;
+        } *c = (struct CT60_COOKIE *)value;
+        ffStrbufSetStatic(&cpu->vendor, "Motorola");
+        ffStrbufSetStatic(&cpu->name, "68060");
+        cpu->frequencyBase = c->cpu_frequency / 10;
+
+    } else if (!Getcookie(COOKIE__CPU, &value)) {
+        ffStrbufSetStatic(&cpu->vendor, "Motorola");
+        ffStrbufSetF(&cpu->name, "%d", (68000 + value));
+#if defined(__COLDFIRE__) || defined(__mcoldfire__)
+    } else {
+        ffStrbufSetStatic(&cpu->vendor, "Motorola");
+        ffStrbufSetStatic(&cpu->name, "MCF5407");
+#endif
+    }
+
+    if (value == -1) {
+        return "getcookie(_MCH and CT60) failed";
+    }
+
+    cpu->packages = (uint16_t)1;
+    cpu->coresPhysical = (uint16_t)1;
+    cpu->coresLogical = cpu->coresPhysical;
+    cpu->coresOnline = (uint16_t)1;
+
+    return NULL;
+}

--- a/src/detection/displayserver/displayserver_aes.c
+++ b/src/detection/displayserver/displayserver_aes.c
@@ -1,0 +1,36 @@
+#include "displayserver.h"
+
+#include <mint/cookie.h>
+
+#define COOKIE_nAES /*(const char *)*/0x6e414553L
+
+typedef struct {
+    unsigned int    version;
+    unsigned int    date;
+    unsigned int    time;
+    unsigned int    flags;
+    struct CNF_VAR  **config;
+    unsigned long   unused_2;
+} N_AESINFO;
+
+void ffConnectDisplayServerImpl(FFDisplayServerResult* ds)
+{
+    // cf.
+    // https://www.exxosforum.co.uk/atari/mirror/toshyp/00c002.html#N_AESINFO
+    // TODO?
+    // https://www.exxosforum.co.uk/atari/mirror/toshyp/Application.html#appl_getinfo_str
+    long value = -1;
+    N_AESINFO *aes;
+    if (!Getcookie(COOKIE_nAES, &value)) {
+        aes = (N_AESINFO *)value;
+        // TODO
+        ffStrbufSetStatic(&ds->wmProcessName, "nAES");
+        ffStrbufSetStatic(&ds->wmPrettyName, "nAES");
+    } else {
+        ffStrbufSetStatic(&ds->wmProcessName, "AES");
+        ffStrbufSetStatic(&ds->wmPrettyName, "AES");
+    }
+    ffStrbufSetStatic(&ds->dePrettyName, "GEM");
+
+    //detectDisplays(ds);
+}

--- a/src/detection/loadavg/loadavg_linux.c
+++ b/src/detection/loadavg/loadavg_linux.c
@@ -1,7 +1,15 @@
 #include "detection/loadavg/loadavg.h"
 #include "common/io.h"
 
+#ifndef __MINT__
 #include <sys/sysinfo.h>
+#endif
+
+#ifdef __MINT__
+    #define FF_LOADAVG_PATH "/kern/loadavg"
+#else
+    #define FF_LOADAVG_PATH "/proc/loadavg"
+#endif
 
 const char* ffDetectLoadavg(double result[3]) {
 #ifndef __ANDROID__ // cat: /proc/loadavg: Permission denied
@@ -18,7 +26,7 @@ const char* ffDetectLoadavg(double result[3]) {
     }
 
 #endif
-#ifndef __GNU__
+#if !defined(__GNU__) && !defined(__MINT__)
     // getloadavg requires higher ANDROID_API version
     struct sysinfo si;
     if (sysinfo(&si) < 0) {

--- a/src/detection/localip/localip_nosupport.c
+++ b/src/detection/localip/localip_nosupport.c
@@ -1,0 +1,9 @@
+#include "localip.h"
+#include "common/io.h"
+#include "common/netif.h"
+#include "common/stringUtils.h"
+
+const char* ffDetectLocalIps(const FFLocalIpOptions* options, FFlist* results)
+{
+    return "Not supported on this platform";
+}

--- a/src/detection/media/media_nosupport.c
+++ b/src/detection/media/media_nosupport.c
@@ -1,5 +1,5 @@
 #include "media.h"
 
-void ffDetectMediaImpl(FFMediaResult* media) {
+void ffDetectMediaImpl(FFMediaResult* media, bool saveCover) {
     ffStrbufAppendS(&media->error, "Not supported on this platform");
 }

--- a/src/detection/memory/memory_linux.c
+++ b/src/detection/memory/memory_linux.c
@@ -4,11 +4,17 @@
 
 #include <inttypes.h>
 
+#ifdef __MINT__
+    #define FF_MEMINFO_PATH "/kern/meminfo"
+#else
+    #define FF_MEMINFO_PATH "/proc/meminfo"
+#endif
+
 const char* ffDetectMemory(FFMemoryResult* ram) {
     char buf[PROC_FILE_BUFFSIZ];
-    ssize_t nRead = ffReadFileData("/proc/meminfo", ARRAY_SIZE(buf) - 1, buf);
+    ssize_t nRead = ffReadFileData(FF_MEMINFO_PATH, ARRAY_SIZE(buf) - 1, buf);
     if (nRead < 0) {
-        return "ffReadFileData(\"/proc/meminfo\", ARRAY_SIZE(buf)-1, buf)";
+        return "ffReadFileData(\"" FF_MEMINFO_PATH "\", ARRAY_SIZE(buf)-1, buf)";
     }
     buf[nRead] = '\0';
 
@@ -24,7 +30,7 @@ const char* ffDetectMemory(FFMemoryResult* ram) {
     if ((token = strstr(buf, "MemTotal:")) != NULL) {
         memTotal = strtoul(token + strlen("MemTotal:"), NULL, 10);
     } else {
-        return "MemTotal not found in /proc/meminfo";
+        return "MemTotal not found in " FF_MEMINFO_PATH;
     }
 
     if ((token = strstr(buf, "MemAvailable:")) != NULL) {

--- a/src/detection/opengl/opengl_nosupport.c
+++ b/src/detection/opengl/opengl_nosupport.c
@@ -1,0 +1,8 @@
+#include "fastfetch.h"
+#include "opengl.h"
+#include "common/io.h"
+
+const char* ffDetectOpenGL(FFOpenGLOptions* options, FFOpenGLResult* result)
+{
+    return "Not supported on this platform";
+}

--- a/src/detection/packages/packages.c
+++ b/src/detection/packages/packages.c
@@ -30,11 +30,20 @@ bool ffPackagesReadCache(FFstrbuf* cacheDir, FFstrbuf* cacheContent, const char*
         return true;
     }
 
+    #ifndef __MINT__
     if (__builtin_expect(st.st_mtim.tv_sec <= 0, false)) {
         return false;
     }
+    #else
+    if (__builtin_expect(st.st_mtim.tv_nsec < 1000000000ull, false)) {
+        return false;
+    }
+    #endif
 
-    uint64_t mtime_current = (uint64_t) st.st_mtim.tv_sec * 1000ull + (uint64_t) st.st_mtim.tv_nsec / 1000000ull;
+    uint64_t mtime_current = (uint64_t) st.st_mtim.tv_nsec / 1000000ull;
+    #ifndef __MINT__
+    mtime_current += (uint64_t) st.st_mtim.tv_sec * 1000ull;
+    #endif
 #else
     FF_AUTO_CLOSE_FD HANDLE handle = CreateFileA(filePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 
@@ -96,16 +105,18 @@ uint32_t ffPackagesGetNumElements(const char* dirname, bool isdir) {
         bool ok = false;
 
         if (entry->d_name[0] != '.') {
-    #if !defined(__sun) && !defined(__HAIKU__)
+    #if !defined(__sun) && !defined(__HAIKU__) && !defined(__MINT__)
             if (entry->d_type != DT_UNKNOWN && entry->d_type != DT_LNK) {
                 ok = entry->d_type == (isdir ? DT_DIR : DT_REG);
             } else
     #endif
             {
                 struct stat stbuf;
+    #ifndef __MINT__
                 if (fstatat(dirfd(dirp), entry->d_name, &stbuf, 0) == 0) {
                     ok = isdir ? S_ISDIR(stbuf.st_mode) : S_ISREG(stbuf.st_mode);
                 }
+    #endif
             }
         }
 

--- a/src/detection/sound/sound_nosupport.c
+++ b/src/detection/sound/sound_nosupport.c
@@ -1,5 +1,5 @@
 #include "sound.h"
 
-const char* ffDetectSound(FF_A_UNUSED FFlist* devices /* List of FFSoundDevice */) {
+const char* ffDetectSound(FF_A_UNUSED FFSoundOptions* options, FF_A_UNUSED FFlist* devices /* List of FFSoundDevice */) {
     return "Not supported on this platform";
 }

--- a/src/detection/swap/swap_nosupport.c
+++ b/src/detection/swap/swap_nosupport.c
@@ -1,5 +1,5 @@
 #include "swap.h"
 
-const char* ffDetectSwap(FFSwapResult* swap) {
+const char* ffDetectSwap(FF_A_UNUSED FFlist* result) {
     return "Not supported on this platform";
 }

--- a/src/detection/uptime/uptime_nosupport.c
+++ b/src/detection/uptime/uptime_nosupport.c
@@ -1,0 +1,8 @@
+#include "uptime.h"
+#include "common/time.h"
+#include "common/io.h"
+
+const char* ffDetectUptime(FFUptimeResult* result)
+{
+    return "Not supported on this platform";
+}

--- a/src/modules/separator/separator.c
+++ b/src/modules/separator/separator.c
@@ -9,7 +9,7 @@
 
 #include <locale.h>
 
-#if __SIZEOF_WCHAR_T__ == 4
+#if __SIZEOF_WCHAR_T__ == 4 || (defined (__MINT__) && (__SIZEOF_WCHAR_T__ == 2))
 static inline size_t mbrtoc32(uint32_t* restrict pc32, const char* restrict s, size_t n, mbstate_t* restrict ps) {
     return mbrtowc((wchar_t*) pc32, s, n, ps);
 }


### PR DESCRIPTION
## Summary

This adds support for the Atari MiNT OS (*not* the GNU/Linux distro).

## Changes

- a lot of detection modules,
- some code required to build on the OS which does not support all the fancy new POSIX things.

## Screenshots

<img width="804" height="612" alt="Copie d&#39;écran_20260515_011929" src="https://github.com/user-attachments/assets/257f8686-0d21-4638-a255-56880010d486" />

## Checklist

- [x] I have tested my changes locally.
