### PR TITLE
feat: add SDKMAN! package count support

### DIFF
--- a/src/detection/packages/packages.h
+++ b/src/detection/packages/packages.h
@@ -43,6 +43,7 @@ typedef struct FFPackagesResult {
     uint32_t rpm;
     uint32_t scoopGlobal;
     uint32_t scoopUser;
+    uint32_t sdkman;
     uint32_t snap;
     uint32_t soar;
     uint32_t sorcery;

--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -431,7 +431,7 @@ static uint32_t getPacmanPackages(FFstrbuf* baseDir) {
     uint32_t baseDirLen = baseDir->length;
     ffStrbufAppendS(baseDir, "/etc/pacman.conf");
 
-    bool confFound = ffParsePropFileValues(baseDir->chars, 2, (FFpropquery[]) {
+    bool confFound = ffParsePropFileValues(baseDir->chars, 2, (FFpropquery[]){
                                                                   { "DBPath =", &dbPath },
                                                                   { "RootDir =", &rootDir },
                                                               });
@@ -647,5 +647,38 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) 
     if (!(options->disabled & FF_PACKAGES_FLAG_APPIMAGE_BIT)) {
         result->appimage += getNumElementsBySuffix(&baseDir, "/AppImages", ".appimage");
         result->appimage += getNumElementsBySuffix(&baseDir, "/Applications", ".appimage");
+    }
+    if (!(options->disabled & FF_PACKAGES_FLAG_SDKMAN_BIT)) {
+        const char* sdkmanDir = getenv("SDKMAN_CANDIDATES_DIR");
+        if (sdkmanDir != NULL && sdkmanDir[0] != '\0') {
+            DIR* dir = opendir(sdkmanDir);
+            if (dir != NULL) {
+                struct dirent* entry;
+                while ((entry = readdir(dir)) != NULL) {
+                    if (entry->d_name[0] == '.') {
+                        continue;
+                    }
+
+                    char path[512];
+                    snprintf(path, sizeof(path), "%s/%s", sdkmanDir, entry->d_name);
+                    DIR* subdir = opendir(path);
+                    if (subdir != NULL) {
+                        bool hasContent = false;
+                        struct dirent* subentry;
+                        while ((subentry = readdir(subdir)) != NULL) {
+                            if (subentry->d_name[0] != '.') {
+                                hasContent = true;
+                                break;
+                            }
+                        }
+                        closedir(subdir);
+                        if (hasContent) {
+                            result->sdkman++;
+                        }
+                    }
+                }
+                closedir(dir);
+            }
+        }
     }
 }

--- a/src/modules/packages/option.h
+++ b/src/modules/packages/option.h
@@ -39,6 +39,7 @@ typedef enum FF_A_PACKED FFPackagesFlags {
     FF_PACKAGES_FLAG_MOSS_BIT = 1ULL << 32,
     FF_PACKAGES_FLAG_APPIMAGE_BIT = 1ULL << 33,
     FF_PACKAGES_FLAG_CARDS_BIT = 1ULL << 34,
+    FF_PACKAGES_FLAG_SDKMAN_BIT = 1ULL << 35,
     FF_PACKAGES_FLAG_FORCE_UNSIGNED = UINT64_MAX,
 } FFPackagesFlags;
 static_assert(sizeof(FFPackagesFlags) == sizeof(uint64_t), "");

--- a/src/modules/packages/packages.c
+++ b/src/modules/packages/packages.c
@@ -128,6 +128,7 @@ bool ffPrintPackages(FFPackagesOptions* options) {
         } else {
             FF_PRINT_PACKAGE_NAME(scoopUser, "scoop")
         }
+        FF_PRINT_PACKAGE_NAME(sdkman, "sdk")
         FF_PRINT_PACKAGE(snap)
         FF_PRINT_PACKAGE(soar)
         FF_PRINT_PACKAGE(sorcery)
@@ -190,6 +191,7 @@ bool ffPrintPackages(FFPackagesOptions* options) {
                 FF_ARG(counts.rpm, "rpm"),
                 FF_ARG(counts.scoopGlobal, "scoop-global"),
                 FF_ARG(counts.scoopUser, "scoop-user"),
+                FF_ARG(counts.sdkman, "sdkman"),
                 FF_ARG(counts.snap, "snap"),
                 FF_ARG(counts.soar, "soar"),
                 FF_ARG(counts.sorcery, "sorcery"),
@@ -327,6 +329,7 @@ void ffParsePackagesJsonObject(FFPackagesOptions* options, yyjson_val* module) {
                             if (false)
                                 ;
                             FF_TEST_PACKAGE_NAME(SCOOP)
+                            FF_TEST_PACKAGE_NAME(SDKMAN)
                             FF_TEST_PACKAGE_NAME(SNAP)
                             FF_TEST_PACKAGE_NAME(SOAR)
                             FF_TEST_PACKAGE_NAME(SORCERY)
@@ -466,6 +469,7 @@ bool ffGeneratePackagesJsonResult(FF_A_UNUSED FFPackagesOptions* options, yyjson
     FF_APPEND_PACKAGE_COUNT(rpm)
     FF_APPEND_PACKAGE_COUNT(scoopGlobal)
     FF_APPEND_PACKAGE_COUNT(scoopUser)
+    FF_APPEND_PACKAGE_COUNT(sdkman)
     FF_APPEND_PACKAGE_COUNT(snap)
     FF_APPEND_PACKAGE_COUNT(soar)
     FF_APPEND_PACKAGE_COUNT(sorcery)


### PR DESCRIPTION
## Summary

Adds support for counting installed SDKMAN! candidates in the Package module.

## Related issue

Closes #2027

## Changes

- Added `iunt32_t sdkman` field to `FFPackagesResult` in `packages.h`
- Added `FF_PACKAGES_FLAG_SDKMAN_BIT` flag to `option.h`
- Added detection logic in `packages_linux.c` that reads `$SDKMAN_CANDIDATES_DIR` and counts non-empty subdirectories
- Updated `packages.c` to print and export the sdkman count

## Checklist

- [X] I have tested my changes locally.
