### PR TITLE
Improved terminal name detection for nix packages

### DIFF
--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -294,11 +294,16 @@ static void setShellInfoDetails(FFShellResult* result) {
 }
 
 static void setTerminalInfoDetails(FFTerminalResult* result) {
-    if (ffStrbufStartsWithC(&result->processName, '.') && ffStrbufContainS(&result->processName, "-wrap")) {
-        // For NixOS. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
-        // We use processName when detecting version and font, overriding it for simplification
-        ffStrbufSubstrBeforeLastC(&result->processName, '-');
+    // For NixOS. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
+    // We use processName when detecting version and font, overriding it for simplification
+    if (ffStrbufStartsWithC(&result->processName, '.')) {
         ffStrbufSubstrAfter(&result->processName, 0);
+        if (ffStrbufContainS(&result->processName, "-wra")) {
+            ffStrbufSubstrBeforeLastC(&result->processName, '-');
+        }
+        if (ffStrbufEndsWithC(&result->processName, '-')) {
+            ffStrbufSubstrBefore(&result->processName, result->processName.length - 1);
+        }
     }
 
     if (ffStrbufEqualS(&result->processName, "wezterm-gui")) {

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -296,7 +296,7 @@ static void setShellInfoDetails(FFShellResult* result) {
 static void setTerminalInfoDetails(FFTerminalResult* result) {
     // For Nixpkgs. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
     // We use processName when detecting version and font, overriding it for simplification
-    if (ffStrbufStartsWithS(&result->exePath,"/nix/store") && ffStrbufStartsWithC(&result->processName, '.')) {
+    if (ffStrbufStartsWithC(&result->processName, '.') && ffStrbufStartsWithS(&result->exePath,"/nix/store")) {
         ffStrbufSubstrAfter(&result->processName, 0);
         if (strlen(result->exeName) < 15) {
             ffStrbufSubstrBeforeLastC(&result->processName, '-');

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -294,15 +294,12 @@ static void setShellInfoDetails(FFShellResult* result) {
 }
 
 static void setTerminalInfoDetails(FFTerminalResult* result) {
-    // For NixOS. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
+    // For Nixpkgs. Ref: #510 and https://github.com/NixOS/nixpkgs/pull/249428
     // We use processName when detecting version and font, overriding it for simplification
-    if (ffStrbufStartsWithC(&result->processName, '.')) {
+    if (ffStrbufStartsWithS(&result->exePath,"/nix/store") && ffStrbufStartsWithC(&result->processName, '.')) {
         ffStrbufSubstrAfter(&result->processName, 0);
-        if (ffStrbufContainS(&result->processName, "-wra")) {
+        if (strlen(result->exeName) < 15) {
             ffStrbufSubstrBeforeLastC(&result->processName, '-');
-        }
-        if (ffStrbufEndsWithC(&result->processName, '-')) {
-            ffStrbufSubstrBefore(&result->processName, result->processName.length - 1);
         }
     }
 
@@ -362,7 +359,7 @@ static void setTerminalInfoDetails(FFTerminalResult* result) {
 
 #endif
 
-    else if (strncmp(result->exeName, result->processName.chars, result->processName.length) == 0) { // if exeName starts with processName, print it. Otherwise print processName
+    else if (strncmp(result->exeName, result->processName.chars, result->processName.length) == 0 || (ffStrbufStartsWithS(&result->exePath,"/nix/store") && strlen(result->exeName) > 15)) { // if exeName starts with processName, print it. Otherwise print processName. For nixpkgs, use exeName if processName can't be unwrapped
         ffStrbufInitS(&result->prettyName, result->exeName);
     } else {
         ffStrbufInitCopy(&result->prettyName, &result->processName);


### PR DESCRIPTION
## Summary

This improves terminal name detection when the terminal is installed a nix package

## Related issue (required for new logos for new distros)
- Resolves #2337 

## Changes

Instead of checking if the process name begins with a period and ends with -wrap, and then removing both, this change removes the leading dot if one exists, then checks if the the process name ends with -wra or with a hyphen and removes that. 

This accommodates all but one of the terminal emulators packaged by Nix that I'm aware of; The exception being the elementary-terminal whose name is so long that it would require special handling.


## Screenshots

<!-- Required if this PR introduces visual changes. -->

## Checklist

- [ x] I have tested my changes locally.
