### PR TITLE
TerminalShell: skip zellij process in terminal
  detection (#2348)

### DIFF
--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -107,6 +107,7 @@ static pid_t getTerminalInfo(FFTerminalResult* result, pid_t pid) {
             ffStrbufEqualS(&result->processName, "chezmoi") || // #762
             ffStrbufEqualS(&result->processName, "proot") ||
             ffStrbufEqualS(&result->processName, "script") ||
+            ffStrbufEqualS(&result->processName, "zellij") ||   // #2348
 #ifdef __linux__
             ffStrbufStartsWithS(&result->processName, "Relay(") ||   // Unknown process in WSL2
             ffStrbufStartsWithS(&result->processName, "flatpak-") || // #707


### PR DESCRIPTION
When zellij runs inside alacritty, the process tree is alacritty -> zellij -> bash -> fastfetch. zellij was not in the
  skip list, so it was incorrectly detected as the terminal, causing font detection to fail with 'Unknown terminal: zellij'.

  Added zellij to the process skip list so detection walks past it to the actual terminal emulator.

  Fixes #2348