### PR TITLE
Add Support for ENux

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -297,12 +297,24 @@ FF_A_UNUSED static bool detectFedoraVariant(FFOSResult* result) {
     return false;
 }
 
-FF_A_UNUSED static bool detectBedrock(FFOSResult* os) {
+static bool detectBedrock(FFOSResult* os)
+{
     const char* bedrockRestrict = getenv("BEDROCK_RESTRICT");
-    if (bedrockRestrict && bedrockRestrict[0] == '1') {
+    if (bedrockRestrict && bedrockRestrict[0] == '1')
         return false;
+
+    if (ffPathExists(
+            FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/enux",
+            FF_PATHTYPE_DIRECTORY))
+    {
+        return parseOsRelease(
+            FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/enux/etc/os-release",
+            os);
     }
-    return parseOsRelease(FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/bedrock/etc/os-release", os);
+
+    return parseOsRelease(
+        FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/bedrock/etc/os-release",
+        os);
 }
 
 FF_A_UNUSED static void detectDeepinEnhancement(FFOSResult* result) {

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -305,11 +305,12 @@ static bool detectBedrock(FFOSResult* os)
 
     if (ffPathExists(
             FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/enux",
-            FF_PATHTYPE_DIRECTORY))
-    {
-        return parseOsRelease(
+            FF_PATHTYPE_DIRECTORY) &&
+        parseOsRelease(
             FASTFETCH_TARGET_DIR_ROOT "/bedrock/strata/enux/etc/os-release",
-            os);
+            os))
+    {
+        return true;
     }
 
     return parseOsRelease(

--- a/src/logo/ascii/e.inc
+++ b/src/logo/ascii/e.inc
@@ -152,6 +152,19 @@ static const FFlogo E[] = {
         .colorTitle = FF_COLOR_FG_DEFAULT,
     },
     #endif
+    #ifdef FASTFETCH_DATATEXT_LOGO_ENUX
+    // ENux
+    {
+        .names = { "enux" },
+        .lines = FASTFETCH_DATATEXT_LOGO_ENUX,
+        // ENux renders entirely black: logo, keys, and title.
+        .colors = {
+            FF_COLOR_FG_BLACK,
+        },
+        .colorKeys = FF_COLOR_FG_BLACK,
+        .colorTitle = FF_COLOR_FG_BLACK,
+    },
+    #endif
     #ifdef FASTFETCH_DATATEXT_LOGO_ESHANIZEDOS
     // EshanizedOS
     {

--- a/src/logo/ascii/e/enux.txt
+++ b/src/logo/ascii/e/enux.txt
@@ -1,0 +1,12 @@
+eeeeeeeeeeeeeeeeeeeeeeee
+eeeeeeeeeeeeeeeeeeeeeeee
+eeeee
+eeeee
+eeeee
+eeeeeeeeeeeeeeeeeeeeeeee
+eeeeeeeeeeeeeeeeeeeeeeee
+eeeee
+eeeee
+eeeee
+eeeeeeeeeeeeeeeeeeeeeeee
+eeeeeeeeeeeeeeeeeeeeeeee


### PR DESCRIPTION
# Add Support for ENux

## What this does

- Adds a builtin ASCII logo for [ENux](https://github.com/ENux-Distro/ENux) (`src/logo/ascii/e/enux.txt`) and registers it
  in `src/logo/ascii/e.inc` under the name `enux`. The logo, module keys, and title
  all render in black (`FF_COLOR_FG_BLACK`), matching ENux's all-black branding.
- The logo is auto-selected by OS `ID`, so no extra wiring is needed: when
  `/etc/os-release` reports `ID=enux`, fastfetch picks this logo automatically.

## How ENux is detected

ENux ships with Bedrock Linux pre-integrated, so the OS-release lookup needed a patch
in `detectBedrock()` (`src/detection/os/os_linux.c`). On a Bedrock system the default
`os-release` comes from the `bedrock` stratum, which would make fastfetch report
"Bedrock" instead of the actual distro. The patched logic checks for the `enux` stratum
first and reads its `os-release` when present:

```c
if (ffPathExists(".../bedrock/strata/enux", FF_PATHTYPE_DIRECTORY))
    return parseOsRelease(".../bedrock/strata/enux/etc/os-release", os);
// otherwise fall back to the bedrock stratum
return parseOsRelease(".../bedrock/strata/bedrock/etc/os-release", os);
```

This makes fastfetch report ENux (`ID=enux`) on a Bedrock-based ENux install, which in
turn triggers the ENux logo.
