### PR TITLE
Add Wayland on Mac/Darwin support

### DIFF
--- a/src/detection/displayserver/displayserver_apple.c
+++ b/src/detection/displayserver/displayserver_apple.c
@@ -191,6 +191,16 @@ void ffConnectDisplayServerImpl(FFDisplayServerResult* ds) {
             ffStrbufSetStatic(&ds->wmProcessName, "WindowServer");
             ffStrbufSetStatic(&ds->wmPrettyName, "Quartz Compositor");
         }
+        if (getenv("WAYLAND_DISPLAY")) { // Is user on wayland?
+            const char *desktop = getenv("XDG_CURRENT_DESKTOP");
+
+            ffStrbufSetStatic(&ds->wmProcessName, "Wayland");
+            if (desktop  && *desktop) { // If user is on a custom WM that sets XDG_CURRENT_DESKTOP?
+                ffStrbufSetStatic(&ds->wmPrettyName, desktop);
+            } // if not it says Quartz Compositor
+
+            ffStrbufSetS(&ds->wmProtocolName, FF_WM_PROTOCOL_WAYLAND); // Adds (Wayland) at the end of WM
+        }
     }
 
     detectDisplays(ds);


### PR DESCRIPTION
## Summary

Adds Wayland on MacOS support via XDG variables :3

see [Wawona](https://github.com/aspauldingcode/Wawona) and [iLand](https://github.com/CoreBedtime/iland).

## Related issue (required for new logos for new distros)

N/A

## Changes

- MacOS displayserver detection

## Screenshots

<img width="1284" height="625" alt="CleanShot 2026-06-11 at 12 09 36" src="https://github.com/user-attachments/assets/04f12b6d-5b8c-4afe-b163-13bddda12bb1" />

## Checklist

- [x] I have tested my changes locally.
