### PR TITLE
Add Zerene OS Mainline logo

### DIFF
--- a/src/logo/ascii/z.inc
+++ b/src/logo/ascii/z.inc
@@ -3,6 +3,18 @@
 #include "common/color.h"
 
 static const FFlogo Z[] = {
+    #ifdef FASTFETCH_DATATEXT_LOGO_ZERENE
+    // Zerene
+    {
+        .names = { "Zerene, Zerene OS, zerene" },
+        .lines = FASTFETCH_DATATEXT_LOGO_ZORIN,
+        .colors = {
+            FF_COLOR_FG_BLUE,
+        },
+        .colorKeys = FF_COLOR_FG_BLUE,
+        .colorTitle = FF_COLOR_FG_BLUE,
+    },
+    #endif
     #ifdef FASTFETCH_DATATEXT_LOGO_ZORIN
     // Zorin
     {

--- a/src/logo/ascii/z/zerene.txt
+++ b/src/logo/ascii/z/zerene.txt
@@ -1,0 +1,18 @@
+           MMM
+           MMMM
+           MMMMM
+           MMMMMM
+           MMMMMMa
+           MMMMMMMa
+           MMMMMMM
+            MMMMMM
+             MMMM
+                M
+               oxdo aMa
+           aMd     aMMMMMMMMM
+         aMMMMM     MMMMMMMMMMMMMMa
+       MMMMMMMa       MMMMMMMMMMMMMMMa
+     MMMMMMMMa
+   MMMMMMMMa
+ MMMMMMM
+MMMM


### PR DESCRIPTION
## Summary

Adds the logo of Zerene OS Mainline
- Resolves #2402

## Screenshots

None

## Checklist

- [X ] I have tested my changes locally.

using "cmake build build"
cd build
./fastfetch --logo zerene