### PR TITLE
Add Zerene OS mainline (with more polished changes)

### DIFF
--- a/src/logo/ascii/z.inc
+++ b/src/logo/ascii/z.inc
@@ -3,6 +3,18 @@
 #include "common/color.h"
 
 static const FFlogo Z[] = {
+    #ifdef FASTFETCH_DATATEXT_LOGO_ZERENE
+    // Zerene
+    {
+        .names = { "Zerene, Zerene OS, zerene" },
+        .lines = FASTFETCH_DATATEXT_LOGO_ZORIN,
+        .colors = {
+            FF_COLOR_FG_BLUE,
+        },
+        .colorKeys = FF_COLOR_FG_BLUE,
+        .colorTitle = FF_COLOR_FG_BLUE,
+    },
+    #endif
     #ifdef FASTFETCH_DATATEXT_LOGO_ZORIN
     // Zorin
     {

--- a/src/logo/ascii/z.inc
+++ b/src/logo/ascii/z.inc
@@ -6,7 +6,7 @@ static const FFlogo Z[] = {
     #ifdef FASTFETCH_DATATEXT_LOGO_ZERENE
     // Zerene
     {
-        .names = { "Zerene", "Zerene OS" },
+        .names = { "Zerene" },
         .lines = FASTFETCH_DATATEXT_LOGO_ZERENE,
         .colors = {
             FF_COLOR_FG_BLUE,

--- a/src/logo/ascii/z.inc
+++ b/src/logo/ascii/z.inc
@@ -6,7 +6,7 @@ static const FFlogo Z[] = {
     #ifdef FASTFETCH_DATATEXT_LOGO_ZERENE
     // Zerene
     {
-        .names = { "Zerene, Zerene OS" },
+        .names = { "Zerene", "Zerene OS" },
         .lines = FASTFETCH_DATATEXT_LOGO_ZERENE,
         .colors = {
             FF_COLOR_FG_BLUE,

--- a/src/logo/ascii/z.inc
+++ b/src/logo/ascii/z.inc
@@ -7,7 +7,7 @@ static const FFlogo Z[] = {
     // Zerene
     {
         .names = { "Zerene, Zerene OS, zerene" },
-        .lines = FASTFETCH_DATATEXT_LOGO_ZORIN,
+        .lines = FASTFETCH_DATATEXT_LOGO_ZERENE,
         .colors = {
             FF_COLOR_FG_BLUE,
         },

--- a/src/logo/ascii/z.inc
+++ b/src/logo/ascii/z.inc
@@ -6,7 +6,7 @@ static const FFlogo Z[] = {
     #ifdef FASTFETCH_DATATEXT_LOGO_ZERENE
     // Zerene
     {
-        .names = { "Zerene, Zerene OS, zerene" },
+        .names = { "Zerene, Zerene OS" },
         .lines = FASTFETCH_DATATEXT_LOGO_ZERENE,
         .colors = {
             FF_COLOR_FG_BLUE,

--- a/src/logo/ascii/z/zerene.txt
+++ b/src/logo/ascii/z/zerene.txt
@@ -1,0 +1,18 @@
+           MMM
+           MMMM
+           MMMMM
+           MMMMMM
+           MMMMMMa
+           MMMMMMMa
+           MMMMMMM
+            MMMMMM
+             MMMM
+                M
+               oxdo aMa
+           aMd     aMMMMMMMMM
+         aMMMMM     MMMMMMMMMMMMMMa
+       MMMMMMMa       MMMMMMMMMMMMMMMa
+     MMMMMMMMa
+   MMMMMMMMa
+ MMMMMMM
+MMMM


### PR DESCRIPTION
## Summary

This PR properly incorporates the Zerene OS logo into fastfetch.


- Closes #2402 
- Resolves #2403 


## Changes

- Fixed errors in z.inc from the previous port attempt
- Properly adds the Zerene OS logo

## Screenshots

<img width="1920" height="1080" alt="Screenshot_20260617_161748" src="https://github.com/user-attachments/assets/f34593c6-5c66-4f9b-9561-c5d7742859a4" />

## Checklist

- [ X] I have tested my changes locally.

Here is what I have done to properly test my changes :

git clone https://github.com/gretagen/fastfetch-
cd fastfetch-
mkdir -p build
cd build
cmake ..
cmake --build . --target fastfetch
./fastfetch --list-logos
./fastfetch --logo Zerene
