### PR TITLE
Packages (Linux): Improve emerge detection speed

### DIFF
--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -458,6 +458,35 @@ static uint32_t getPacmanPackages(FFstrbuf* baseDir) {
     return getNumElements(baseDir, dbPath.chars, true);
 }
 
+static uint32_t getEmergePackagesImpl(FFstrbuf* baseDir)
+{
+    FF_AUTO_CLOSE_DIR DIR* dirp = opendir(baseDir->chars);
+    if (dirp == NULL)
+        return 0;
+
+    uint32_t result = 0;
+
+    struct dirent *entry;
+    while ((entry = readdir(dirp)) != NULL)
+    {
+        if (entry->d_type != DT_DIR || entry->d_name[0] == '.')
+            continue;
+
+        result += getNumElements(baseDir, entry->d_name, true);
+    }
+    return result;
+}
+
+static uint32_t getEmergePackages(FFstrbuf* baseDir, const char* dirname)
+{
+    uint32_t baseDirLength = baseDir->length;
+    ffStrbufAppendS(baseDir, dirname);
+    ffStrbufAppendC(baseDir, '/');
+    uint32_t result = getEmergePackagesImpl(baseDir);
+    ffStrbufSubstrBefore(baseDir, baseDirLength);
+    return result;
+}
+
 static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts, FFPackagesOptions* options) {
     if (FF_PACKAGES_IS_ENABLED(options, APK)) {
         packageCounts->apk += getNumStrings(baseDir, "/lib/apk/db/installed", "C:Q", "apk");
@@ -469,7 +498,7 @@ static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts,
         packageCounts->lpkg += getNumStrings(baseDir, "/opt/Loc-OS-LPKG/installed-lpkg/Listinstalled-lpkg.list", "\n", "lpkg");
     }
     if (FF_PACKAGES_IS_ENABLED(options, EMERGE)) {
-        packageCounts->emerge += countFilesRecursive(baseDir, "/var/db/pkg", "SIZE");
+        packageCounts->emerge += getEmergePackages(baseDir, "/var/db/pkg");
     }
     if (FF_PACKAGES_IS_ENABLED(options, EOPKG)) {
         packageCounts->eopkg += getNumElements(baseDir, "/var/lib/eopkg/package", true);

--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -458,8 +458,7 @@ static uint32_t getPacmanPackages(FFstrbuf* baseDir) {
     return getNumElements(baseDir, dbPath.chars, true);
 }
 
-static uint32_t getEmergePackagesImpl(FFstrbuf* baseDir)
-{
+static uint32_t getEmergePackagesImpl(FFstrbuf* baseDir) {
     FF_AUTO_CLOSE_DIR DIR* dirp = opendir(baseDir->chars);
     if (dirp == NULL)
         return 0;
@@ -477,8 +476,7 @@ static uint32_t getEmergePackagesImpl(FFstrbuf* baseDir)
     return result;
 }
 
-static uint32_t getEmergePackages(FFstrbuf* baseDir, const char* dirname)
-{
+static uint32_t getEmergePackages(FFstrbuf* baseDir, const char* dirname) {
     uint32_t baseDirLength = baseDir->length;
     ffStrbufAppendS(baseDir, dirname);
     ffStrbufAppendC(baseDir, '/');


### PR DESCRIPTION
## Summary

Makes emerge package count detection faster.

## Changes

Instead of listing every package's directory in every category to check if `SIZE` file exist, now it just counts the number of directories in every category folder. This decreases the number of directory listing operations by the number of packages. It's especially noticeable on cold boots.

Documentation of directory: https://wiki.gentoo.org/wiki//var/db/pkg

i7-5500U + SSD with 889 emerge and 11 flatpak user packages installed:
On cold boot: 350 ms -> 30 ms
On regular usage: 3 ms -> 0.9 ms

C2D T7200 + HDD with 438 emerge packages installed:
On cold boot: 2480 ms -> 1000 ms
On regular usage: 1.9 ms -> 0.8 ms

## Checklist

- [x] I have tested my changes locally.
