### PR TITLE
Add ror package manager detection and RorkOS logo

### DIFF
--- a/src/detection/packages/packages.h
+++ b/src/detection/packages/packages.h
@@ -50,6 +50,7 @@ typedef struct FFPackagesResult {
     uint32_t sorcery;
     uint32_t winget;
     uint32_t xbps;
+    uint32_t ror;
 
     uint32_t all; // Make sure this goes last
 

--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -1,6 +1,7 @@
 #include "packages.h"
 #include "common/io.h"
 #include "common/parsing.h"
+#include "common/processing.h"
 #include "common/properties.h"
 #include "common/settings.h"
 #include "common/strutil.h"
@@ -567,6 +568,12 @@ static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts,
     }
     if (FF_PACKAGES_IS_ENABLED(options, CARDS)) {
         packageCounts->cards += getNumElements(baseDir, "/var/lib/pkg/DB", true);
+    }
+    if (FF_PACKAGES_IS_ENABLED(options, ROR)) {
+        FF_STRBUF_AUTO_DESTROY output = ffStrbufCreate();
+        if (ffProcessAppendStdOut(&output, (char* const[]) { "ror", "count", NULL }) == NULL) {
+            packageCounts->ror += (uint32_t) ffStrbufToUInt(&output, 0);
+        }
     }
 }
 

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -669,7 +669,7 @@ static void parseCommand(FFdata* data, char* key, char* value) {
             enableJsonOutput(data);
         }
     } else if (ffStrEqualsIgnCase(key, "--dynamic-interval")) {
-        instance.state.dynamicInterval = ffOptionParseUInt32(key, value); // seconds to milliseconds
+        instance.state.dynamicInterval = ffOptionParseUInt32(key, value);
     } else {
         return;
     }

--- a/src/logo/ascii/r.inc
+++ b/src/logo/ascii/r.inc
@@ -292,6 +292,22 @@ static const FFlogo R[] = {
         },
     },
     #endif
+    #ifdef FASTFETCH_DATATEXT_LOGO_RORKOS
+    // RorkOS
+    {
+        .names = { "rorkos", "RorkOS" },
+        .lines = FASTFETCH_DATATEXT_LOGO_RORKOS,
+        .colors = {
+            FF_COLOR_FG_WHITE,
+            FF_COLOR_FG_WHITE,
+            FF_COLOR_FG_WHITE,
+            FF_COLOR_FG_WHITE,
+            FF_COLOR_FG_WHITE,
+        },
+        .colorKeys = FF_COLOR_FG_WHITE,
+        .colorTitle = FF_COLOR_FG_WHITE,
+    },
+    #endif
     // LAST
     {},
 };

--- a/src/logo/ascii/r/rorkos.txt
+++ b/src/logo/ascii/r/rorkos.txt
@@ -1,0 +1,24 @@
+            .ooo.    $2.gggggggggggg$1.                
+            ooooo  $2.gggggggggggggggg$1.              
+            ooooo $2.ggggg$3rrrrrrrr$2gggggg$1.            
+            ooooo$2.gggg$3rrrrrrrrrrrr$2ggggg            
+            oooo$2gggg$3rrrrr$4@@@@@$3rrrr$2gggg            
+            oooo$2gggg$3rrrr$4@@@@@@@$3rrr$2gggg            
+            oooo$2gggg$3rrrr$4@@@@@@@$3rrr$2gggg            
+            oooo$2gggg$3rrrr$4@@@@@$3rrrrr$2gggg            
+            ooooo$2.ggggg$3rrrrrrrrrrr$2gggg$1`            
+            ooooo $2 gggggg$3rrrrrrr$2ggggg$1`             
+            ooooo$5WW$2 gggggggggggggggg$1`              
+            ooooo$5WWWW $2`aaaaaaaaaa`$1                 
+            ooooo$5WWWWW                             
+            ooooo$5WWWWWWW                           
+            ooooo  $5WWWWWWW                         
+            ooooo    $5WWWWWWW                       
+            ooooo     $5WWWWWWWW                     
+            ooooo       $5WWWWWWWW                   
+            ooooo         $5WWWWWWW                  
+            ooooo           $5WWWWWWW                
+            ooooo             $5WWWWWWW              
+            ooooo               $5WWWWWWW$1`           
+            ooooo                $5WWWWWWW           
+            `ooo`                 $5`WWWW`           

--- a/src/modules/packages/option.h
+++ b/src/modules/packages/option.h
@@ -41,6 +41,7 @@ typedef enum FF_A_PACKED FFPackagesFlags {
     FF_PACKAGES_FLAG_CARDS_BIT = UINT64_C(1) << 34U,
     FF_PACKAGES_FLAG_PORG_BIT = UINT64_C(1) << 35U,
     FF_PACKAGES_FLAG_INSTALLRELEASE_BIT = UINT64_C(1) << 36U,
+    FF_PACKAGES_FLAG_ROR_BIT = UINT64_C(1) << 37U,
     FF_PACKAGES_FLAG_FORCE_UNSIGNED = UINT64_MAX,
 } FFPackagesFlags;
 static_assert(sizeof(FFPackagesFlags) == sizeof(uint64_t), "");

--- a/src/modules/packages/packages.c
+++ b/src/modules/packages/packages.c
@@ -121,6 +121,7 @@ bool ffPrintPackages(FFPackagesOptions* options) {
         FF_PRINT_PACKAGE(pkgsrc)
         FF_PRINT_PACKAGE(pkgtool)
         FF_PRINT_PACKAGE(porg)
+        FF_PRINT_PACKAGE(ror)
         FF_PRINT_PACKAGE(rpm)
         if (options->combined) {
             FF_PRINT_PACKAGE_ALL(scoop);
@@ -185,6 +186,7 @@ bool ffPrintPackages(FFPackagesOptions* options) {
                 FF_ARG(counts.pkgsrc, "pkgsrc"),
                 FF_ARG(counts.pkgtool, "pkgtool"),
                 FF_ARG(counts.porg, "porg"),
+                FF_ARG(counts.ror, "ror"),
                 FF_ARG(counts.rpm, "rpm"),
                 FF_ARG(counts.scoopGlobal, "scoop-global"),
                 FF_ARG(counts.scoopUser, "scoop-user"),
@@ -333,6 +335,7 @@ void ffParsePackagesJsonObject(FFPackagesOptions* options, yyjson_val* module) {
                         case 'R':
                             if (false)
                                 ;
+                            FF_TEST_PACKAGE_NAME(ROR)
                             FF_TEST_PACKAGE_NAME(RPM)
                             break;
                         case 'S':
@@ -413,6 +416,7 @@ void ffGeneratePackagesJsonConfig(FFPackagesOptions* options, yyjson_mut_doc* do
     FF_TEST_PACKAGE_NAME(PKGSRC)
     FF_TEST_PACKAGE_NAME(PKGTOOL)
     FF_TEST_PACKAGE_NAME(PORG)
+    FF_TEST_PACKAGE_NAME(ROR)
     FF_TEST_PACKAGE_NAME(RPM)
     FF_TEST_PACKAGE_NAME(SCOOP)
     FF_TEST_PACKAGE_NAME(SNAP)
@@ -481,6 +485,7 @@ bool ffGeneratePackagesJsonResult(FFPackagesOptions* options, yyjson_mut_doc* do
     FF_APPEND_PACKAGE_COUNT(pkgsrc)
     FF_APPEND_PACKAGE_COUNT(pkgtool)
     FF_APPEND_PACKAGE_COUNT(porg)
+    FF_APPEND_PACKAGE_COUNT(ror)
     FF_APPEND_PACKAGE_COUNT(rpm)
     FF_APPEND_PACKAGE_COUNT(scoopGlobal)
     FF_APPEND_PACKAGE_COUNT(scoopUser)
@@ -558,6 +563,7 @@ FFModuleBaseInfo ffPackagesModuleInfo = {
         { "Number of pkgsrc packages", "pkgsrc" },
         { "Number of pkgtool packages", "pkgtool" },
         { "Number of porg packages", "porg" },
+        { "Number of ror packages", "ror" },
         { "Number of rpm packages", "rpm" },
         { "Number of scoop-global packages", "scoop-global" },
         { "Number of scoop-user packages", "scoop-user" },


### PR DESCRIPTION
This PR adds two features:

1. **RorkOS logo** - An ASCII art logo (wolf design) that displays automatically when the OS ID is `rorkos` (from `/etc/os-release`).

2. **ror package manager detection** - Adds support for the `ror` package manager (https://codeberg.org/RorkOS/ror). Detection works by running `ror count` and parsing the output.

**Files changed:**
- `src/logo/ascii/r/rorkos.txt` - ASCII art logo
- `src/logo/ascii/r.inc` - Logo registration with names `rorkos` and `RorkOS`
- `src/detection/packages/packages.h` - Added `ror` field to `FFPackagesResult`
- `src/detection/packages/packages_linux.c` - ror detection via `ror count`
- `src/modules/packages/option.h` - Added `ROR_BIT` flag
- `src/modules/packages/packages.c` - Added ror to text, JSON, and config output