### PR TITLE
Add repo link to Catnap attribution in examples 13-16

### DIFF
--- a/presets/examples/13.jsonc
+++ b/presets/examples/13.jsonc
@@ -1,4 +1,4 @@
-// Inspired by Catnap
+// Inspired by Catnap (https://github.com/iinsertNameHere/catnap)
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
     "logo": {

--- a/presets/examples/14.jsonc
+++ b/presets/examples/14.jsonc
@@ -1,4 +1,4 @@
-// Inspired by Catnap
+// Inspired by Catnap (https://github.com/iinsertNameHere/catnap)
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
     "logo": {

--- a/presets/examples/15.jsonc
+++ b/presets/examples/15.jsonc
@@ -1,4 +1,4 @@
-// Inspired by Catnap
+// Inspired by Catnap (https://github.com/iinsertNameHere/catnap)
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
     "logo": {

--- a/presets/examples/16.jsonc
+++ b/presets/examples/16.jsonc
@@ -1,4 +1,4 @@
-// Inspired by Catnap
+// Inspired by Catnap (https://github.com/iinsertNameHere/catnap)
 {
     "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
     "logo": {


### PR DESCRIPTION
## Summary
Added a repo link to the existing "Inspired by Catnap" attribution comments in examples 13–16. I'm the author of Catnap, the tool these presets were based on.

## Changes
- Added `(https://github.com/iinsertNameHere/catnap)` to the attribution comment in `presets/examples/13.jsonc`, `14.jsonc`, `15.jsonc`, and `16.jsonc`

## Screenshots
None

## Checklist

- [X] I have tested my changes locally.
