### PR TITLE
Memory (FreeBSD): fixing disk cache fetching

### DIFF
--- a/src/detection/memory/memory_bsd.c
+++ b/src/detection/memory/memory_bsd.c
@@ -8,9 +8,10 @@ const char* ffDetectMemory(FFMemoryResult* ram) {
     }
 
     // vm.stats.vm.* are int values
-    int32_t pagesFree = ffSysctlGetInt("vm.stats.vm.v_free_count", 0) + ffSysctlGetInt("vm.stats.vm.v_inactive_count", 0) + ffSysctlGetInt("vm.stats.vm.v_cache_count", 0);
+    int32_t pagesFree = ffSysctlGetInt("vm.stats.vm.v_free_count", 0) + ffSysctlGetInt("vm.stats.vm.v_inactive_count", 0);
+    int64_t bytesCache = ffSysctlGetInt64("vfs.bufspace", 0) + (ffSysctlGetInt64("kstat.zfs.misc.arcstats.size", 0) - ffSysctlGetInt64("kstat.zfs.misc.arcstats.c_min", 0));
 
-    ram->bytesUsed = ram->bytesTotal - (uint64_t) pagesFree * instance.state.platform.sysinfo.pageSize;
+    ram->bytesUsed = ram->bytesTotal - (uint64_t) pagesFree * instance.state.platform.sysinfo.pageSize - (uint64_t) bytesCache;
 
     return NULL;
 }


### PR DESCRIPTION
## Summary

Memory fetching for FreeBSD was using `vm.stats.vm.v_cache_count` as cache, but FreeBSD's kernel doesn't have cache pages since version 12. The value is still there for compatibility, but it returns always 0.

## Changes

- using filesystem buffer cache and ARC cache: `vfs.bufspace` tracks the bytes used to buffer the filesystem addressing for other filesystems than ZFS, and ARC tracks buffers AND cache for ZFS, which bypasses bufspace entirely. I also decrease the minimum ARC cache, since that's arguably non retrievable memory. The results now are more aligned with how other monitoring tools track memory. In fact, I submitted PRs for [btop](https://github.com/aristocratos/btop/pull/1728) and [htop](https://github.com/htop-dev/htop/pull/2033) to fix similar issues.

## Checklist

- [x] I have tested my changes locally
