### PR TITLE
Logo: adds chimera linux small logo

### DIFF
--- a/src/logo/ascii/c.inc
+++ b/src/logo/ascii/c.inc
@@ -232,6 +232,21 @@ static const FFlogo C[] = {
         .colorTitle = FF_COLOR_FG_RED,
     },
     #endif
+    #ifdef FASTFETCH_DATATEXT_LOGO_CHIMERA_LINUX_SMALL
+    // Chimera_small
+    {
+        .names = { "Chimera_small" },
+        .lines = FASTFETCH_DATATEXT_LOGO_CHIMERA_LINUX_SMALL,
+        .colors = {
+            FF_COLOR_FG_RED,
+            FF_COLOR_FG_MAGENTA,
+            FF_COLOR_FG_BLUE,
+            FF_COLOR_FG_RED,
+        },
+        .colorKeys = FF_COLOR_FG_MAGENTA,
+        .colorTitle = FF_COLOR_FG_RED,
+    },
+    #endif
     #ifdef FASTFETCH_DATATEXT_LOGO_CHONKYSEALOS
     // ChonkySealOS
     {

--- a/src/logo/ascii/c.inc
+++ b/src/logo/ascii/c.inc
@@ -237,6 +237,7 @@ static const FFlogo C[] = {
     {
         .names = { "Chimera_small" },
         .lines = FASTFETCH_DATATEXT_LOGO_CHIMERA_LINUX_SMALL,
+        .type = FF_LOGO_LINE_TYPE_SMALL_BIT,
         .colors = {
             FF_COLOR_FG_RED,
             FF_COLOR_FG_MAGENTA,

--- a/src/logo/ascii/c/chimera_linux_small.txt
+++ b/src/logo/ascii/c/chimera_linux_small.txt
@@ -1,0 +1,7 @@
+$3XXXXX $1I:
+$3XXX' $1,I;
+$3XX $1,f""'.,,,,
+$2,, $1I:   ;P"""
+$2XX $1`t...f' $4jj
+$2XXX. $1`"' $4.XXX
+$2OOOOOC $4lXXXXX


### PR DESCRIPTION
## Summary

Added Chimera_small logo.

## Related issue (required for new logos for new distros)

## Changes

- Added small ASCII art version for Chimera Linux

## Screenshots

<img width="902" height="806" alt="image" src="https://github.com/user-attachments/assets/67f2e87f-80b6-4de6-b6f6-6ddde6243b78" />

## Checklist

- [ ] I have tested my changes locally.
