### PR TITLE
Add proper TidalShell version support to fastfetch

### DIFF
--- a/src/detection/terminalshell/terminalshell.c
+++ b/src/detection/terminalshell/terminalshell.c
@@ -307,7 +307,7 @@ bool fftsGetShellVersion(FFstrbuf* exe, const char* exeName, FFstrbuf* version) 
         return getExeVersionGeneral(exe, version); // brush 0.2.23 (git:2835487)
     }
     if (ffStrEqualsIgnCase(exeName, "tidalshell")) {
-        return getShellVersionTidalshell(exe, version); // brush 0.2.23 (git:2835487)
+        return getShellVersionTidalshell(exe, version);
     }
 #ifdef _WIN32
     if (ffStrEqualsIgnCase(exeName, "powershell") || ffStrEqualsIgnCase(exeName, "powershell_ise")) {

--- a/src/detection/terminalshell/terminalshell.c
+++ b/src/detection/terminalshell/terminalshell.c
@@ -242,15 +242,13 @@ static bool getShellVersionZsh(FFstrbuf* exe, FFstrbuf* version) {
 
 static bool getShellVersionTidalshell(FFstrbuf* exe, FFstrbuf* version)
 {
-    if (!ffProcessAppendStdOut(version, (char* const[]){
-        exe->chars,
-        "-v",
-        NULL
-    })) return false;
+    if (ffProcessAppendStdOut(version, (char* const[]){ exe->chars, "-v", NULL }) != NULL)
+        return false;
     ffStrbufTrimRightSpace(version);
     ffStrbufSubstrBeforeFirstC(version, '-');
     return true;
 }
+
 
 #ifdef _WIN32
 static bool getShellVersionWinPowerShell(FFstrbuf* exe, FFstrbuf* version) {

--- a/src/detection/terminalshell/terminalshell.c
+++ b/src/detection/terminalshell/terminalshell.c
@@ -240,6 +240,18 @@ static bool getShellVersionZsh(FFstrbuf* exe, FFstrbuf* version) {
     return getExeVersionGeneral(exe, version); // zsh 5.9 (arm-apple-darwin21.3.0)
 }
 
+static bool getShellVersionTidalshell(FFstrbuf* exe, FFstrbuf* version)
+{
+    if (!ffProcessAppendStdOut(version, (char* const[]){
+        exe->chars,
+        "-v",
+        NULL
+    })) return false;
+    ffStrbufTrimRightSpace(version);
+    ffStrbufSubstrBeforeFirstC(version, '-');
+    return true;
+}
+
 #ifdef _WIN32
 static bool getShellVersionWinPowerShell(FFstrbuf* exe, FFstrbuf* version) {
     const char* env = getenv("POWERSHELL_VERSION");
@@ -296,7 +308,9 @@ bool fftsGetShellVersion(FFstrbuf* exe, const char* exeName, FFstrbuf* version) 
     if (ffStrEqualsIgnCase(exeName, "brush")) {
         return getExeVersionGeneral(exe, version); // brush 0.2.23 (git:2835487)
     }
-
+    if (ffStrEqualsIgnCase(exeName, "tidalshell")) {
+        return getShellVersionTidalshell(exe, version); // brush 0.2.23 (git:2835487)
+    }
 #ifdef _WIN32
     if (ffStrEqualsIgnCase(exeName, "powershell") || ffStrEqualsIgnCase(exeName, "powershell_ise")) {
         return getShellVersionWinPowerShell(exe, version);

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -107,6 +107,7 @@ static pid_t getTerminalInfo(FFTerminalResult* result, pid_t pid) {
             ffStrbufEqualS(&result->processName, "chezmoi") || // #762
             ffStrbufEqualS(&result->processName, "proot") ||
             ffStrbufEqualS(&result->processName, "script") ||
+            ffStrbufEqualS(&result->processName, "tidalshell") ||
 #ifdef __linux__
             ffStrbufStartsWithS(&result->processName, "Relay(") ||   // Unknown process in WSL2
             ffStrbufStartsWithS(&result->processName, "flatpak-") || // #707

--- a/src/detection/terminalshell/terminalshell_linux.c
+++ b/src/detection/terminalshell/terminalshell_linux.c
@@ -289,6 +289,8 @@ static void setShellInfoDetails(FFShellResult* result) {
         ffStrbufInitStatic(&result->prettyName, "Oils");
     } else if (ffStrbufEqualS(&result->processName, "busybox")) {
         ffStrbufInitStatic(&result->prettyName, "ash");
+    } else if (ffStrbufEqualS(&result->processName, "tidalshell")) {
+        ffStrbufInitStatic(&result->prettyName, "TidalShell");
     } else {
         // https://github.com/fastfetch-cli/fastfetch/discussions/280#discussioncomment-3831734
         ffStrbufInitS(&result->prettyName, result->exeName);

--- a/src/detection/terminalshell/terminalshell_windows.c
+++ b/src/detection/terminalshell/terminalshell_windows.c
@@ -95,6 +95,8 @@ static void setShellInfoDetails(FFShellResult* result) {
         ffStrbufSetS(&result->prettyName, "Windows Explorer");
     } else if (ffStrbufIgnCaseEqualS(&result->prettyName, "busybox")) {
         ffStrbufInitStatic(&result->prettyName, "ash");
+    } else if (ffStrbufIgnCaseEqualS(&result->prettyName, "tidalshell")) {
+        ffStrbufSetS(&result->prettyName, "TidalShell");
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds native version detection and proper process tree handling for **TidalShell** (https://github.com). 

## Changes

- **`terminalshell.c`**: Added `getShellVersionTidalshell` helper. It invokes `tidalshell -v` (introduced in TidalShell 0.2-Nightly), trims trailing spaces, and isolates the numeric version by stripping out build tags (e.g., `-Nightly`).
- **`terminalshell_linux.c`**: Added `tidalshell` to the known shells ignore array inside `getTerminalInfo`. This prevents Fastfetch from misidentifying the shell as a terminal emulator on Linux systems.
- **`terminalshell_windows.c`**: Added proper case mapping in `setShellInfoDetails` so the UI cleanly displays `TidalShell`.

## Checklist

- [ ] I have tested my changes locally.

## Notes for Reviewers

I'm primarily a C# & PowerShell developer. I do not have a local C/C++ compilation environment set up for fastfetch, therefore **these changes have NOT been tested locally yet**.

Please review my code. as I stated, I am not primarily a C/C++ developer. I am not as experienced in it.
I do not know if my code is efficient nor if it meets fastfetch quality standards.
