### PR TITLE
Packages (pkgsrc): add dynamic prefix discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,6 +617,7 @@ if(LINUX)
         src/detection/os/os_linux.c
         src/detection/packages/packages_linux.c
         src/detection/packages/packages_nix.c
+        src/detection/packages/packages_pkgsrc.c
         src/detection/poweradapter/poweradapter_linux.c
         src/detection/processes/processes_linux.c
         src/detection/gtk_qt/qt.c
@@ -692,6 +693,7 @@ elseif(ANDROID)
         src/detection/os/os_android.c
         src/detection/packages/packages_linux.c
         src/detection/packages/packages_nix.c
+        src/detection/packages/packages_pkgsrc.c
         src/detection/poweradapter/poweradapter_nosupport.c
         src/detection/processes/processes_linux.c
         src/detection/sound/sound_linux.c
@@ -869,6 +871,7 @@ elseif(NetBSD)
         src/detection/opengl/opengl_linux.c
         src/detection/os/os_nbsd.c
         src/detection/packages/packages_nbsd.c
+        src/detection/packages/packages_pkgsrc.c
         src/detection/poweradapter/poweradapter_nosupport.c
         src/detection/processes/processes_nbsd.c
         src/detection/gtk_qt/qt.c
@@ -1024,6 +1027,7 @@ elseif(APPLE)
         src/detection/os/os_apple.m
         src/detection/packages/packages_apple.c
         src/detection/packages/packages_nix.c
+        src/detection/packages/packages_pkgsrc.c
         src/detection/poweradapter/poweradapter_apple.c
         src/detection/processes/processes_bsd.c
         src/detection/sound/sound_apple.c
@@ -1197,6 +1201,7 @@ elseif(SunOS)
         src/detection/opengl/opengl_linux.c
         src/detection/os/os_sunos.c
         src/detection/packages/packages_sunos.c
+        src/detection/packages/packages_pkgsrc.c
         src/detection/poweradapter/poweradapter_nosupport.c
         src/detection/processes/processes_linux.c
         src/detection/gtk_qt/qt.c
@@ -1345,6 +1350,7 @@ elseif(GNU)
         src/detection/os/os_linux.c
         src/detection/packages/packages_linux.c
         src/detection/packages/packages_nix.c
+        src/detection/packages/packages_pkgsrc.c
         src/detection/poweradapter/poweradapter_nosupport.c
         src/detection/processes/processes_linux.c
         src/detection/gtk_qt/qt.c

--- a/src/detection/packages/packages.h
+++ b/src/detection/packages/packages.h
@@ -72,3 +72,6 @@ uint32_t ffPackagesGetNix(FFstrbuf* baseDir, const char* dirname);
 #ifndef _WIN32
 uint32_t ffPackagesGetNumElements(const char* dirname, bool isdir);
 #endif
+#if defined(__linux__) || defined(__NetBSD__) || defined(__sun) || defined(__APPLE__)
+uint32_t ffPackagesGetPkgsrc(FFstrbuf* baseDir);
+#endif

--- a/src/detection/packages/packages_apple.c
+++ b/src/detection/packages/packages_apple.c
@@ -53,4 +53,8 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) 
         ffStrbufSet(&baseDir, &instance.state.platform.homeDir);
         result->nixUser = ffPackagesGetNix(&baseDir, "/.nix-profile");
     }
+    if (FF_PACKAGES_IS_ENABLED(options, PKGSRC)) {
+        ffStrbufSetS(&baseDir, FASTFETCH_TARGET_DIR_ROOT);
+        result->pkgsrc = ffPackagesGetPkgsrc(&baseDir);
+    }
 }

--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -560,7 +560,7 @@ static void getPackageCounts(FFstrbuf* baseDir, FFPackagesResult* packageCounts,
         packageCounts->pisi += getNumElements(baseDir, "/var/lib/pisi/package", true);
     }
     if (FF_PACKAGES_IS_ENABLED(options, PKGSRC)) {
-        packageCounts->pkgsrc += getNumElements(baseDir, "/usr/pkg/pkgdb", DT_DIR);
+        packageCounts->pkgsrc += ffPackagesGetPkgsrc(baseDir);
     }
     if (FF_PACKAGES_IS_ENABLED(options, MOSS)) {
         packageCounts->moss += getSQLite3Int(baseDir, "/.moss/db/state", "SELECT COUNT(*) FROM state_selections WHERE state_id = (SELECT MAX(id) FROM state)", "moss");

--- a/src/detection/packages/packages_nbsd.c
+++ b/src/detection/packages/packages_nbsd.c
@@ -1,9 +1,8 @@
 #include "packages.h"
 
-#include "common/io.h"
-
 void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) {
     if (FF_PACKAGES_IS_ENABLED(options, PKGSRC)) {
-        result->pkgsrc = ffPackagesGetNumElements(FASTFETCH_TARGET_DIR_ROOT "/usr/pkg/pkgdb", true);
+        FF_STRBUF_AUTO_DESTROY baseDir = ffStrbufCreateStatic(FASTFETCH_TARGET_DIR_ROOT);
+        result->pkgsrc = ffPackagesGetPkgsrc(&baseDir);
     }
 }

--- a/src/detection/packages/packages_pkgsrc.c
+++ b/src/detection/packages/packages_pkgsrc.c
@@ -1,0 +1,34 @@
+#include "packages.h"
+#include "common/io.h"
+#include "common/path.h"
+#include "common/properties.h"
+
+uint32_t ffPackagesGetPkgsrc(FFstrbuf* baseDir) {
+    uint32_t baseDirLength = baseDir->length;
+    FF_STRBUF_AUTO_DESTROY pkginPath = ffStrbufCreate();
+
+    if (ffFindExecutableInPath("pkgin", &pkginPath) != NULL) {
+        ffStrbufSubstrBefore(baseDir, baseDirLength);
+        return 0;
+    }
+
+    ffStrbufSubstrBeforeLastC(&pkginPath, '/'); // remove /pkgin
+    ffStrbufSubstrBeforeLastC(&pkginPath, '/'); // remove /bin
+
+    FF_STRBUF_AUTO_DESTROY mkconf = ffStrbufCreateCopy(&pkginPath);
+    ffStrbufAppendS(&mkconf, "/etc/mk.conf");
+
+    FF_STRBUF_AUTO_DESTROY dbdir = ffStrbufCreate();
+    ffParsePropFile(mkconf.chars, "PKG_DBDIR=", &dbdir);
+
+    if (dbdir.length > 0) {
+        ffStrbufAppendS(baseDir, dbdir.chars);
+    } else {
+        ffStrbufAppendF(baseDir, "%s/pkgdb", pkginPath.chars);
+    }
+
+    uint32_t result = ffPackagesGetNumElements(baseDir->chars, true);
+    ffStrbufSubstrBefore(baseDir, baseDirLength);
+    
+    return result;
+}

--- a/src/detection/packages/packages_pkgsrc.c
+++ b/src/detection/packages/packages_pkgsrc.c
@@ -1,5 +1,4 @@
 #include "packages.h"
-#include "common/io.h"
 #include "common/path.h"
 #include "common/properties.h"
 
@@ -8,27 +7,28 @@ uint32_t ffPackagesGetPkgsrc(FFstrbuf* baseDir) {
     FF_STRBUF_AUTO_DESTROY pkginPath = ffStrbufCreate();
 
     if (ffFindExecutableInPath("pkgin", &pkginPath) != NULL) {
-        ffStrbufSubstrBefore(baseDir, baseDirLength);
         return 0;
     }
 
     ffStrbufSubstrBeforeLastC(&pkginPath, '/'); // remove /pkgin
     ffStrbufSubstrBeforeLastC(&pkginPath, '/'); // remove /bin
+    uint32_t pkginPathLength = pkginPath.length;
 
-    FF_STRBUF_AUTO_DESTROY mkconf = ffStrbufCreateCopy(&pkginPath);
-    ffStrbufAppendS(&mkconf, "/etc/mk.conf");
+    ffStrbufAppendS(&pkginPath, "/etc/mk.conf");
 
     FF_STRBUF_AUTO_DESTROY dbdir = ffStrbufCreate();
-    ffParsePropFile(mkconf.chars, "PKG_DBDIR=", &dbdir);
+    ffParsePropFile(pkginPath.chars, "PKG_DBDIR=", &dbdir);
+    ffStrbufSubstrBefore(&pkginPath, pkginPathLength); // remove /etc/mk.conf
 
     if (dbdir.length > 0) {
-        ffStrbufAppendS(baseDir, dbdir.chars);
+        ffStrbufAppend(baseDir, &dbdir);
     } else {
-        ffStrbufAppendF(baseDir, "%s/pkgdb", pkginPath.chars);
+        ffStrbufAppend(baseDir, &pkginPath);
+        ffStrbufAppendS(baseDir, "/pkgdb");
     }
 
     uint32_t result = ffPackagesGetNumElements(baseDir->chars, true);
     ffStrbufSubstrBefore(baseDir, baseDirLength);
-    
+
     return result;
 }

--- a/src/detection/packages/packages_sunos.c
+++ b/src/detection/packages/packages_sunos.c
@@ -12,6 +12,7 @@ void ffDetectPackagesImpl(FFPackagesResult* result, FFPackagesOptions* options) 
         }
     }
     if (FF_PACKAGES_IS_ENABLED(options, PKGSRC)) {
-        result->pkgsrc = ffPackagesGetNumElements(FASTFETCH_TARGET_DIR_ROOT "/usr/pkg/pkgdb", true);
+        FF_STRBUF_AUTO_DESTROY baseDir = ffStrbufCreateStatic(FASTFETCH_TARGET_DIR_ROOT);
+        result->pkgsrc = ffPackagesGetPkgsrc(&baseDir);
     }
 }


### PR DESCRIPTION
## Summary

Previously pkgsrc detection hardcoded `/usr/pkg/pkgdb`, which missed installations at non-standard prefixes (e.g. `/opt/pkg`) and database directory layouts (e.g. `.pkgdb`).

Now `ffPackagesGetPkgsrc` finds the `pkgin` binary via `PATH`, derives the prefix, reads `<prefix>/etc/mk.conf` for `PKG_DBDIR`, and falls back to `<prefix>/pkgdb`. Analogous to `ffPackagesGetNix`, the function appends to `baseDir` for Bedrock Linux compatibility.

Support added for Linux, NetBSD, SunOS, and macOS.

## Changes

- New `src/detection/packages/packages_pkgsrc.c` — shared helper
- `packages_linux.c` / `packages_apple.c` / `packages_nbsd.c` / `packages_sunos.c` — all four now call `ffPackagesGetPkgsrc`
- `packages.h` — declaration guarded
- `CMakeLists.txt` — includes the new file

## Checklist

- [x] I have tested my changes locally.