### PR TITLE
add support for proxmox backup server detection

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -208,7 +208,7 @@ FF_A_UNUSED static bool detectDebianDerived(FFOSResult* result) {
         ffStrbufSetStatic(&result->idLike, "debian");
         return true;
     } else if (access("/usr/bin/pveversion", X_OK) == 0) {
-        ffStrbufSetStatic(&result->id, "pve");
+        ffStrbufSetStatic(&result->id, "proxmox");
         ffStrbufSetStatic(&result->idLike, "debian");
         ffStrbufSetStatic(&result->name, "Proxmox VE");
         ffStrbufClear(&result->versionID);
@@ -220,11 +220,14 @@ FF_A_UNUSED static bool detectDebianDerived(FFOSResult* result) {
                                                           NULL,
                                                       }) == NULL) { // 8.2.2
             ffStrbufTrimRightSpace(&result->versionID);
+            ffStrbufSetStatic(&result->prettyName, "Proxmox VE ");
+            ffStrbufAppend(&result->prettyName, &result->versionID);
+        } else {
+            ffStrbufSetStatic(&result->prettyName, "Proxmox VE");
         }
-        ffStrbufSetF(&result->prettyName, "Proxmox VE %s", result->versionID.chars);
         return true;
     } else if (access("/usr/sbin/proxmox-backup-manager", X_OK) == 0) {
-        ffStrbufSetStatic(&result->id, "pbs");
+        ffStrbufSetStatic(&result->id, "proxmox");
         ffStrbufSetStatic(&result->idLike, "debian");
         ffStrbufSetStatic(&result->name, "Proxmox Backup Server");
         ffStrbufClear(&result->versionID);
@@ -236,8 +239,11 @@ FF_A_UNUSED static bool detectDebianDerived(FFOSResult* result) {
                                                           NULL,
                                                       }) == NULL) {
             ffStrbufTrimRightSpace(&result->versionID);
+            ffStrbufSetStatic(&result->prettyName, "Proxmox Backup Server ");
+            ffStrbufAppend(&result->prettyName, &result->versionID);
+        } else {
+            ffStrbufSetStatic(&result->prettyName, "Proxmox Backup Server");
         }
-        ffStrbufSetF(&result->prettyName, "Proxmox Backup Server %s", result->versionID.chars);
         return true;
     } else if (ffPathExists("/etc/rpi-issue", FF_PATHTYPE_FILE)) {
         // Raspberry Pi OS

--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -223,6 +223,22 @@ FF_A_UNUSED static bool detectDebianDerived(FFOSResult* result) {
         }
         ffStrbufSetF(&result->prettyName, "Proxmox VE %s", result->versionID.chars);
         return true;
+    } else if (access("/usr/sbin/proxmox-backup-manager", X_OK) == 0) {
+        ffStrbufSetStatic(&result->id, "pbs");
+        ffStrbufSetStatic(&result->idLike, "debian");
+        ffStrbufSetStatic(&result->name, "Proxmox Backup Server");
+        ffStrbufClear(&result->versionID);
+        if (ffProcessAppendStdOut(&result->versionID, (char* const[]) {
+                                                          "/usr/bin/dpkg-query",
+                                                          "--showformat=${version}",
+                                                          "--show",
+                                                          "proxmox-backup-server",
+                                                          NULL,
+                                                      }) == NULL) {
+            ffStrbufTrimRightSpace(&result->versionID);
+        }
+        ffStrbufSetF(&result->prettyName, "Proxmox Backup Server %s", result->versionID.chars);
+        return true;
     } else if (ffPathExists("/etc/rpi-issue", FF_PATHTYPE_FILE)) {
         // Raspberry Pi OS
         ffStrbufSetStatic(&result->id, "raspbian");

--- a/src/logo/ascii/p.inc
+++ b/src/logo/ascii/p.inc
@@ -311,7 +311,7 @@ static const FFlogo P[] = {
     #ifdef FASTFETCH_DATATEXT_LOGO_PROXMOX
     // Proxmox
     {
-        .names = { "Proxmox", "pve" },
+        .names = { "Proxmox", "pve", "pbs", "Proxmox Backup Server" },
         .lines = FASTFETCH_DATATEXT_LOGO_PROXMOX,
         .colors = {
             FF_COLOR_FG_WHITE,

--- a/src/logo/ascii/p.inc
+++ b/src/logo/ascii/p.inc
@@ -311,7 +311,7 @@ static const FFlogo P[] = {
     #ifdef FASTFETCH_DATATEXT_LOGO_PROXMOX
     // Proxmox
     {
-        .names = { "Proxmox", "pve", "pbs", "Proxmox Backup Server" },
+        .names = { "Proxmox" },
         .lines = FASTFETCH_DATATEXT_LOGO_PROXMOX,
         .colors = {
             FF_COLOR_FG_WHITE,


### PR DESCRIPTION
## Summary

This patch adds support for proxmox backup server. It uses a check for the binary /usr/sbin/proxmox-backup-manager to read the version via dpkg, similar how its done for pve. It reuses the existing proxmox logo and adds 2 aliases.

## Related issue (required for new logos for new distros)

- Resolves #2005


## Screenshots

<img width="1025" height="784" alt="image" src="https://github.com/user-attachments/assets/e19f7a7f-bdcd-455e-9da7-24c9163bf6b0" />


## Checklist

- [X] I have tested my changes locally.
