### PR TITLE
fix: Disregard GPU with Empty Name

### DIFF
--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -183,6 +183,10 @@ bool ffPrintGPU(FFGPUOptions* options) {
     FF_LIST_AUTO_DESTROY selectedGPUs = ffListCreateA(sizeof(const FFGPUResult*), gpus.length);
 
     FF_LIST_FOR_EACH (FFGPUResult, gpu, gpus) {
+        if (gpu->name.len == 0) {
+            continue;
+        }
+
         if (gpu->type == FF_GPU_TYPE_UNKNOWN && options->hideType == FF_GPU_TYPE_UNKNOWN) {
             continue;
         }


### PR DESCRIPTION
## Summary

- Discarded GPU without names to avoid empty GPU detection

<!-- Briefly describe what this PR does. -->

## Related issue (required for new logos for new distros)

- Closes #2461 

## Changes

- Added if statement that checks if the GPU has a valid name

## Screenshots

<!-- Required if this PR introduces visual changes. -->

## Checklist

- [ ] I have tested my changes locally.
