### PR TITLE
CI: add loong64 build workflow

### DIFF
--- a/.github/workflows/build-linux-loong64.yml
+++ b/.github/workflows/build-linux-loong64.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: set up QEMU for loong64
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: build in loong64 container
         run: |

--- a/.github/workflows/build-linux-loong64.yml
+++ b/.github/workflows/build-linux-loong64.yml
@@ -1,0 +1,57 @@
+name: Reusable Linux loong64
+
+on:
+  workflow_call:
+
+env:
+  CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v7
+
+      - name: set up QEMU for loong64
+        uses: docker/setup-qemu-action@v4
+
+      - name: build in loong64 container
+        run: |
+          docker run --rm --platform linux/loong64 \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            lcr.loongnix.cn/debian:14 \
+            bash -c '
+              set -e
+              uname -a
+              cat /etc/os-release || true
+
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                cmake make gcc g++ \
+                libvulkan-dev libwayland-dev libxrandr-dev libxcb-randr0-dev \
+                libdconf-dev libdbus-1-dev libmagickcore-dev \
+                libsqlite3-dev librpm-dev \
+                libegl-dev libglx-dev ocl-icd-opencl-dev \
+                libpulse-dev libdrm-dev \
+                libelf-dev libefl-all-dev \
+                liblua5.4-dev \
+                libvdpau-dev libva-dev \
+                rpm
+
+              cmake -DSET_TWEAK=Off -DBUILD_TESTS=On -DCMAKE_INSTALL_PREFIX=/usr .
+              cmake --build . --target package --verbose -j$(nproc)
+              ./fastfetch --list-features
+              time ./fastfetch -c presets/ci.jsonc --stat false
+              time ./fastfetch -c presets/ci.jsonc --format json
+              time ./flashfetch
+              ldd fastfetch
+              ctest --output-on-failure
+            '
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: fastfetch-linux-loong64
+          path: ./fastfetch-*.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,15 @@ jobs:
     uses: ./.github/workflows/build-linux-armv7l.yml
     secrets: inherit
 
+  linux-loong64:
+    needs: no-features-test
+    name: Linux-loong64
+    permissions:
+      security-events: write
+      contents: read
+    uses: ./.github/workflows/build-linux-loong64.yml
+    secrets: inherit
+
   linux-vms:
     needs: no-features-test
     name: Linux-${{ matrix.arch }}
@@ -188,6 +197,7 @@ jobs:
       - linux-hosts
       - linux-i686
       - linux-armv7l
+      - linux-loong64
       - linux-vms
       - musl-amd64
       - macos-hosts


### PR DESCRIPTION
Add reusable workflow for building fastfetch on LoongArch 64-bit architecture using QEMU user-mode emulation + Docker container (lcr.loongnix.cn/debian:14). Integrate into CI pipeline and release dependencies.

## Summary

Add CI build support for the LoongArch 64-bit (loong64) architecture using QEMU user-mode emulation
with `docker/setup-qemu-action@v4` and a Debian 14 container from `lcr.loongnix.cn`.

## Related issue (required for new logos for new distros)

<!--
If this PR adds a new logo, it MUST be linked to an existing "Logo Request" issue and has the requests fulfilled.

Use one of the following formats so GitHub links it properly:
- Closes #1234
- Fixes #1234
- Resolves #1234

PRs that add logos without an associated Logo Request issue will not be accepted.
-->

Closes #2468

## Changes

- Add `.github/workflows/build-linux-loong64.yml` — reusable workflow that builds fastfetch on loong64
  via QEMU emulation + Docker container (`lcr.loongnix.cn/debian:14`)
- Update `.github/workflows/ci.yml`:
  - Add `linux-loong64` job with `Linux-loong64` display name
  - Add `linux-loong64` to release job dependencies

## Implementation details

| Aspect | Choice |
|--------|--------|
| Runner | `ubuntu-24.04` |
| QEMU | `docker/setup-qemu-action@v4` (tonistiigi/binfmt — includes loongarch64) |
| Container | `lcr.loongnix.cn/debian:14` (Loongson official registry) |
| Platform | `linux/loong64` |
| Artifact | `fastfetch-linux-loong64` |

`uraimo/run-on-arch-action` and `multiarch/qemu-user-static` were considered but rejected: the former
does not support `loongarch64`, and the latter lacks loongarch64 binfmt registration.

## Screenshots

<!-- Required if this PR introduces visual changes. -->

## Checklist

- [x] I have tested my changes locally.
