### PR TITLE
fix(weather): fix memory leak and replace aggressive exit(1) with proper error handling

### DIFF
--- a/src/detection/weather/weather.c
+++ b/src/detection/weather/weather.c
@@ -7,8 +7,8 @@ static const char* status = FF_UNITIALIZED;
 
 void ffPrepareWeather(FFWeatherOptions* options) {
     if (status != FF_UNITIALIZED) {
-        fputs("Error: Weather module can only be used once due to internal limitations\n", stderr);
-        exit(1);
+        status = "Weather module can only be used once due to internal limitations";
+        return;
     }
 
     state.timeout = options->timeout;

--- a/src/modules/weather/weather.c
+++ b/src/modules/weather/weather.c
@@ -87,6 +87,7 @@ void ffInitWeatherOptions(FFWeatherOptions* options) {
 void ffDestroyWeatherOptions(FFWeatherOptions* options) {
     ffOptionDestroyModuleArg(&options->moduleArgs);
 
+    ffStrbufDestroy(&options->location);
     ffStrbufDestroy(&options->outputFormat);
 }
 


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the weather module:

### 1. Memory leak in `ffDestroyWeatherOptions`

`ffInitWeatherOptions` calls `ffStrbufInit(&options->location)` but `ffDestroyWeatherOptions` was missing the corresponding `ffStrbufDestroy(&options->location)`. This leaks memory whenever a user sets a location via JSON config.

**Fix:** Added `ffStrbufDestroy(&options->location)` to `ffDestroyWeatherOptions`.

### 2. Aggressive `exit(1)` in `ffPrepareWeather`

When the weather module was called more than once, `ffPrepareWeather` called `exit(1)`, killing the entire process. This is overly aggressive for a library function.

**Fix:** Instead of `exit(1)`, the function now sets `status` to an error string and returns. The error is properly propagated through the existing error mechanism (`ffDetectWeather` already checks `if (status != nullptr) return status;`).

## Files changed
- `src/modules/weather/weather.c`: Added missing `ffStrbufDestroy(&options->location)`
- `src/detection/weather/weather.c`: Replaced `exit(1)` with proper error propagation