### PR TITLE
refactor(FFstrbuf): remove dead code in ffStrbufSubstrBefore

### DIFF
--- a/src/common/impl/FFstrbuf.c
+++ b/src/common/impl/FFstrbuf.c
@@ -410,9 +410,7 @@ bool ffStrbufSubstrBefore(FFstrbuf* strbuf, uint32_t index) {
 
     if (strbuf->allocated == 0) {
         // static string
-        if (index < strbuf->length) {
-            ffStrbufInitNS(strbuf, index, strbuf->chars);
-        }
+        ffStrbufInitNS(strbuf, index, strbuf->chars);
         return true;
     }
 


### PR DESCRIPTION
## Summary

The function `ffStrbufSubstrBefore` checks `strbuf->length <= index` at the top and returns `false` if true. This means the static string branch's inner `if (index < strbuf->length)` check is **always true** — it's dead code.

**Fix:** Removed the redundant `if` guard, keeping only the `ffStrbufInitNS` call. Behavior is identical.

## Files changed
- `src/common/impl/FFstrbuf.c`: Removed dead code in `ffStrbufSubstrBefore` static string branch