### PR TITLE
fix(display): add missing ffStrbufDestroy calls in ffOptionsDestroyDisplay

### DIFF
--- a/src/options/display.c
+++ b/src/options/display.c
@@ -897,6 +897,19 @@ void ffOptionsDestroyDisplay(FFOptionsDisplay* options) {
     ffStrbufDestroy(&options->keyValueSeparator);
     ffStrbufDestroy(&options->barCharElapsed);
     ffStrbufDestroy(&options->barCharTotal);
+    ffStrbufDestroy(&options->barBorderLeft);
+    ffStrbufDestroy(&options->barBorderRight);
+    ffStrbufDestroy(&options->barBorderLeftElapsed);
+    ffStrbufDestroy(&options->barBorderRightElapsed);
+    ffStrbufDestroy(&options->barColorElapsed);
+    ffStrbufDestroy(&options->barColorTotal);
+    ffStrbufDestroy(&options->barColorBorder);
+    ffStrbufDestroy(&options->tempColorGreen);
+    ffStrbufDestroy(&options->tempColorYellow);
+    ffStrbufDestroy(&options->tempColorRed);
+    ffStrbufDestroy(&options->percentColorGreen);
+    ffStrbufDestroy(&options->percentColorYellow);
+    ffStrbufDestroy(&options->percentColorRed);
     FF_LIST_FOR_EACH (FFstrbuf, item, options->constants) {
         ffStrbufDestroy(item);
     }


### PR DESCRIPTION
## Summary

`ffOptionsDestroyDisplay` was missing `ffStrbufDestroy` calls for 13 `FFstrbuf` fields that are initialized in `ffOptionsInitDisplay`:

- `barBorderLeft`, `barBorderRight`
- `barBorderLeftElapsed`, `barBorderRightElapsed`
- `barColorElapsed`, `barColorTotal`, `barColorBorder`
- `tempColorGreen`, `tempColorYellow`, `tempColorRed`
- `percentColorGreen`, `percentColorYellow`, `percentColorRed`

While some of these are initialized with `ffStrbufInitStatic` (pointing to string literals), they can all be overwritten via JSON config or command-line arguments (the parser calls `ffOptionParseColor` → `ffStrbufSetS` which heap-allocates), causing memory leaks when configured.

**Fix:** Added all 13 missing `ffStrbufDestroy` calls. `ffStrbufDestroy` safely handles both heap-allocated and static-initialized buffers.

## Files changed
- `src/options/display.c`: Added 13 missing `ffStrbufDestroy` calls