### PR TITLE
fix: fix memory leak in separator module and replace exit(1) in publicip

### DIFF
--- a/src/detection/publicip/publicip.c
+++ b/src/detection/publicip/publicip.c
@@ -9,8 +9,8 @@ void ffPreparePublicIp(FFPublicIPOptions* options) {
     FFNetworkingState* state = &states[options->ipv6];
     const char** status = &statuses[options->ipv6];
     if (*status != FF_UNINITIALIZED) {
-        fputs("Error: PublicIp module can only be used once due to internal limitations\n", stderr);
-        exit(1);
+        *status = "PublicIp module can only be used once due to internal limitations";
+        return;
     }
 
     state->timeout = options->timeout;
@@ -25,8 +25,8 @@ void ffPreparePublicIp(FFPublicIPOptions* options) {
         uint32_t hostStartIndex = ffStrbufFirstIndexS(&host, "://");
         if (hostStartIndex < host.length) {
             if (hostStartIndex != 4 || !ffStrbufStartsWithIgnCaseS(&host, "http")) {
-                fputs("Error: only http: protocol is supported. Use `Command` module with `curl` if needed\n", stderr);
-                exit(1);
+                *status = "Only http: protocol is supported. Use `Command` module with `curl` if needed";
+                return;
             }
             ffStrbufSubstrAfter(&host, hostStartIndex + (uint32_t) (strlen("://") - 1));
         }

--- a/src/modules/separator/separator.c
+++ b/src/modules/separator/separator.c
@@ -117,6 +117,7 @@ void ffInitSeparatorOptions(FFSeparatorOptions* options) {
 
 void ffDestroySeparatorOptions(FFSeparatorOptions* options) {
     ffStrbufDestroy(&options->string);
+    ffStrbufDestroy(&options->outputColor);
 }
 
 FFModuleBaseInfo ffSeparatorModuleInfo = {


### PR DESCRIPTION
## Summary

### Memory leak in separator module

`ffInitSeparatorOptions` calls `ffStrbufInit(&options->outputColor)` but `ffDestroySeparatorOptions` was missing the corresponding `ffStrbufDestroy`. This leaks memory whenever a user sets a custom output color via JSON config.

**Fix:** Added `ffStrbufDestroy(&options->outputColor)` to `ffDestroySeparatorOptions`.

### Aggressive `exit(1)` in publicip module

`ffPreparePublicIp` had two `exit(1)` calls:
1. When the module is used more than once
2. When an unsupported URL protocol is specified

Both killed the entire process instead of propagating the error properly.

**Fix:** Both `exit(1)` calls are replaced with setting `*status` to an error string and returning. The error is properly propagated through the existing mechanism (`ffDetectPublicIp` already checks `if (*status != nullptr) return *status;`). This matches the pattern already used in the weather module.

## Files changed
- `src/modules/separator/separator.c`: Added missing `ffStrbufDestroy(&options->outputColor)`
- `src/detection/publicip/publicip.c`: Replaced two `exit(1)` calls with proper error propagation