### PR TITLE
OS (Linux): detects Ubuntu Studio installed with core mode

### DIFF
--- a/src/detection/os/os_linux.c
+++ b/src/detection/os/os_linux.c
@@ -92,7 +92,8 @@ static bool parseOsRelease(const char* fileName, FFOSResult* result) {
     }
 
     // xdgConfigDirs contains plasma only
-    if (ffPathExists("/var/lib/dpkg/info/ubuntustudio-desktop.list", FF_PATHTYPE_FILE)) {
+    // `ubuntustudio-desktop-core` is installed on both the full and core installations
+    if (ffPathExists("/var/lib/dpkg/info/ubuntustudio-desktop-core.list", FF_PATHTYPE_FILE)) {
         ffStrbufSetStatic(&result->name, "Ubuntu Studio");
         ffStrbufSetStatic(&result->id, "ubuntu-studio");
         ffStrbufSetStatic(&result->idLike, "ubuntu");


### PR DESCRIPTION
## Summary

Ubuntu Studio installed with the minimal `ubuntustudio-desktop-core` metapackage was being reported as Kubuntu. The detection only looked for `ubuntustudio-desktop.list`, which the core install does not create, so it fell through and the Plasma fallback labeled the system as Kubuntu.

Closes #2485

## Changes

- Also check for `/var/lib/dpkg/info/ubuntustudio-desktop-core.list` when identifying Ubuntu Studio. The full install ships both metapackages while the core install ships only `-core`, so checking either one (instead of replacing) also keeps older releases that predate the split working. In every case it reports "Ubuntu Studio".

## Testing

- Builds cleanly with no new warnings.
- Verified normal detection is unaffected on my machine (Arch Linux, still reports Arch).
- I don't have Ubuntu Studio, and the Ubuntu Studio branch only runs when the OS id is `ubuntu`, so I couldn't exercise that path locally. @rauldipeas confirmed in #2485 that `ubuntustudio-desktop-core.list` is present on both the full and core installs. It would be great if they could build this branch and confirm the output.

## Checklist

- [x] I have tested my changes locally.