### PR TITLE
CI: hardens the workflows (SHA pins, scoped secrets and token permissions)

### DIFF
--- a/.github/workflows/build-dragonfly-amd64.yml
+++ b/.github/workflows/build-dragonfly-amd64.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Start VM
-        uses: cross-platform-actions/action@master
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: dragonflybsd
           version: '6.4.2'
@@ -57,7 +57,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-dragonfly-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-dragonfly-amd64.yml
+++ b/.github/workflows/build-dragonfly-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable DragonFly amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-freebsd-amd64.yml
+++ b/.github/workflows/build-freebsd-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable FreeBSD amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-freebsd-amd64.yml
+++ b/.github/workflows/build-freebsd-amd64.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Start VM
-        uses: cross-platform-actions/action@master
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: freebsd
           version: '15.1'
@@ -58,7 +58,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-freebsd-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-haiku-amd64.yml
+++ b/.github/workflows/build-haiku-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable Haiku amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-haiku-amd64.yml
+++ b/.github/workflows/build-haiku-amd64.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Start VM
-        uses: cross-platform-actions/action@master
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: haiku
           version: 'r1beta5'
@@ -51,7 +51,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-haiku-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-linux-armv7l.yml
+++ b/.github/workflows/build-linux-armv7l.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: run VM
-        uses: uraimo/run-on-arch-action@v3
+        uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
         id: runcmd
         with:
           arch: armv7
@@ -38,7 +38,7 @@ jobs:
             ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-linux-armv7l
           path: ./fastfetch-*.*

--- a/.github/workflows/build-linux-armv7l.yml
+++ b/.github/workflows/build-linux-armv7l.yml
@@ -3,6 +3,9 @@ name: Reusable Linux armv7l
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-linux-hosts.yml
+++ b/.github/workflows/build-linux-hosts.yml
@@ -14,6 +14,10 @@ on:
         description: fastfetch version from linux host build
         value: ${{ jobs.build.outputs.ffversion }}
 
+permissions:
+  security-events: write
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-linux-hosts.yml
+++ b/.github/workflows/build-linux-hosts.yml
@@ -24,7 +24,7 @@ jobs:
       ffversion: ${{ steps.ffversion.outputs.ffversion }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: uname -a
         run: uname -a
@@ -48,7 +48,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: inputs.arch == 'amd64'
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: c
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: perform CodeQL analysis
         if: inputs.arch == 'amd64'
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: list features
         run: ./fastfetch --list-features
@@ -97,7 +97,7 @@ jobs:
           cpack -V
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-linux-${{ inputs.arch }}
           path: ./fastfetch-*.*

--- a/.github/workflows/build-linux-i686.yml
+++ b/.github/workflows/build-linux-i686.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: uname -a
         run: uname -a
@@ -64,7 +64,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-linux-i686
           path: ./fastfetch-*.*

--- a/.github/workflows/build-linux-i686.yml
+++ b/.github/workflows/build-linux-i686.yml
@@ -3,6 +3,9 @@ name: Reusable Linux i686
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-linux-loong64.yml
+++ b/.github/workflows/build-linux-loong64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: set up QEMU for loong64
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -51,7 +51,7 @@ jobs:
             '
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-linux-loong64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-linux-loong64.yml
+++ b/.github/workflows/build-linux-loong64.yml
@@ -3,6 +3,9 @@ name: Reusable Linux loong64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-linux-vms.yml
+++ b/.github/workflows/build-linux-vms.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-linux-vms.yml
+++ b/.github/workflows/build-linux-vms.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: run VM
-        uses: uraimo/run-on-arch-action@v3
+        uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
         id: runcmd
         with:
           arch: ${{ inputs.arch }}
@@ -39,7 +39,7 @@ jobs:
             ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-linux-${{ inputs.arch }}
           path: ./fastfetch-*.*

--- a/.github/workflows/build-macos-hosts.yml
+++ b/.github/workflows/build-macos-hosts.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-macos-hosts.yml
+++ b/.github/workflows/build-macos-hosts.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: uname -a
         run: uname -a
@@ -53,7 +53,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-macos-${{ inputs.arch }}
           path: ./fastfetch-*.*

--- a/.github/workflows/build-musl-amd64.yml
+++ b/.github/workflows/build-musl-amd64.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup alpine linux
-        uses: jirutka/setup-alpine@master
+        uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:
           branch: edge
 
@@ -41,7 +41,7 @@ jobs:
         shell: alpine.sh {0}
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-musl-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-musl-amd64.yml
+++ b/.github/workflows/build-musl-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable Musl amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-netbsd-amd64.yml
+++ b/.github/workflows/build-netbsd-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable NetBSD amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-netbsd-amd64.yml
+++ b/.github/workflows/build-netbsd-amd64.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Start VM
-        uses: cross-platform-actions/action@master
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: netbsd
           version: '10.1'
@@ -56,7 +56,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-netbsd-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-no-features-test.yml
+++ b/.github/workflows/build-no-features-test.yml
@@ -3,6 +3,9 @@ name: Reusable No Features Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-no-features-test.yml
+++ b/.github/workflows/build-no-features-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: uname -a
         run: uname -a

--- a/.github/workflows/build-omnios-amd64.yml
+++ b/.github/workflows/build-omnios-amd64.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Start VM
-        uses: cross-platform-actions/action@master
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: omnios
           version: 'r151058'
@@ -61,7 +61,7 @@ jobs:
           cpack -V
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-omnios-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-omnios-amd64.yml
+++ b/.github/workflows/build-omnios-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable OmniOS amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-openbsd-amd64.yml
+++ b/.github/workflows/build-openbsd-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable OpenBSD amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-openbsd-amd64.yml
+++ b/.github/workflows/build-openbsd-amd64.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Start VM
-        uses: cross-platform-actions/action@master
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           operating_system: openbsd
           version: '7.9'
@@ -56,7 +56,7 @@ jobs:
         run: ctest --output-on-failure
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-openbsd-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,17 +13,17 @@ jobs:
     steps:
       - name: get latest release version
         id: get_version_release
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c # v0.8.0
         with:
           repository: ${{ github.repository }}
 
       - name: download artifacts
         if: inputs.ffversion != steps.get_version_release.outputs.release
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: create release
         if: inputs.ffversion != steps.get_version_release.outputs.release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ inputs.ffversion }}
           commit: ${{ github.sha }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: update release body
         if: inputs.ffversion != steps.get_version_release.outputs.release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ inputs.ffversion }}
           commit: ${{ github.sha }}

--- a/.github/workflows/build-solaris-amd64.yml
+++ b/.github/workflows/build-solaris-amd64.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: run VM
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@315163f088b66e55bbcc45928bd224d4973b2312 # v1.3.8
         with:
           usesh: true
           envs: 'CMAKE_BUILD_TYPE'
@@ -37,7 +37,7 @@ jobs:
             cpack -V
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-solaris-amd64
           path: ./fastfetch-*.*

--- a/.github/workflows/build-solaris-amd64.yml
+++ b/.github/workflows/build-solaris-amd64.yml
@@ -3,6 +3,9 @@ name: Reusable Solaris amd64
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-spellcheck.yml
+++ b/.github/workflows/build-spellcheck.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install codespell
         shell: bash

--- a/.github/workflows/build-spellcheck.yml
+++ b/.github/workflows/build-spellcheck.yml
@@ -3,6 +3,9 @@ name: Reusable Spellcheck
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-windows-hosts.yml
+++ b/.github/workflows/build-windows-hosts.yml
@@ -18,6 +18,12 @@ on:
       msys-arch:
         required: true
         type: string
+    secrets:
+      SIGNPATH_API_TOKEN:
+        description: SignPath REST API token used to submit the signing request
+        # Optional so that runs without the secret (pull requests, forks)
+        # still work; the signing step is skipped there anyway.
+        required: false
 
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}

--- a/.github/workflows/build-windows-hosts.yml
+++ b/.github/workflows/build-windows-hosts.yml
@@ -25,6 +25,12 @@ on:
         # still work; the signing step is skipped there anyway.
         required: false
 
+permissions:
+  contents: read
+  # The SignPath action reads job details and downloads the unsigned
+  # artifact with the workflow token.
+  actions: read
+
 env:
   CMAKE_BUILD_TYPE: ${{ vars.CMAKE_BUILD_TYPE || 'RelWithDebInfo' }}
 

--- a/.github/workflows/build-windows-hosts.yml
+++ b/.github/workflows/build-windows-hosts.yml
@@ -30,10 +30,10 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup-msys2
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{ inputs.msystem }}
           update: true
@@ -72,7 +72,7 @@ jobs:
       - if: github.event_name == 'push' && github.repository == 'fastfetch-cli/fastfetch'
         id: upload-unsigned-artifact
         name: upload artifacts for signing
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-windows-${{ inputs.arch }}
           path: |
@@ -82,7 +82,7 @@ jobs:
 
       - if: github.event_name == 'push' && github.repository == 'fastfetch-cli/fastfetch'
         name: submit signing request
-        uses: signpath/github-action-submit-signing-request@v1
+        uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1.3
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ vars.SIGNPATH_ORG_ID }}'
@@ -99,7 +99,7 @@ jobs:
         run: 7z a -t7z -mx9 -bd -y fastfetch-windows-${{ inputs.arch }}.7z LICENSE *.dll fastfetch.exe flashfetch.exe presets
 
       - name: upload true artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fastfetch-windows-${{ inputs.arch }}
           path: ./fastfetch-windows-${{ inputs.arch }}.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-no-features-test.yml
-    secrets: inherit
 
   linux-hosts:
     needs: no-features-test
@@ -34,7 +33,6 @@ jobs:
     with:
       arch: ${{ matrix.arch }}
       runs-on: ${{ matrix.runs-on }}
-    secrets: inherit
 
   linux-i686:
     needs: no-features-test
@@ -43,7 +41,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-linux-i686.yml
-    secrets: inherit
 
   linux-armv7l:
     needs: no-features-test
@@ -52,7 +49,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-linux-armv7l.yml
-    secrets: inherit
 
   linux-loong64:
     needs: no-features-test
@@ -61,7 +57,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-linux-loong64.yml
-    secrets: inherit
 
   linux-vms:
     needs: no-features-test
@@ -78,13 +73,11 @@ jobs:
     uses: ./.github/workflows/build-linux-vms.yml
     with:
       arch: ${{ matrix.arch }}
-    secrets: inherit
 
   musl-amd64:
     needs: no-features-test
     name: Musl-amd64
     uses: ./.github/workflows/build-musl-amd64.yml
-    secrets: inherit
 
   macos-hosts:
     needs: no-features-test
@@ -103,19 +96,16 @@ jobs:
     with:
       arch: ${{ matrix.arch }}
       runs-on: ${{ matrix.runs-on }}
-    secrets: inherit
 
   omnios-amd64:
     needs: no-features-test
     name: OmniOS-amd64
     uses: ./.github/workflows/build-omnios-amd64.yml
-    secrets: inherit
 
   solaris-amd64:
     needs: no-features-test
     name: Solaris-amd64
     uses: ./.github/workflows/build-solaris-amd64.yml
-    secrets: inherit
 
   freebsd-amd64:
     needs: no-features-test
@@ -124,7 +114,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-freebsd-amd64.yml
-    secrets: inherit
 
   openbsd-amd64:
     needs: no-features-test
@@ -133,7 +122,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-openbsd-amd64.yml
-    secrets: inherit
 
   netbsd-amd64:
     needs: no-features-test
@@ -142,7 +130,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-netbsd-amd64.yml
-    secrets: inherit
 
   dragonfly-amd64:
     needs: no-features-test
@@ -151,7 +138,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-dragonfly-amd64.yml
-    secrets: inherit
 
   haiku-amd64:
     if: false # Disabled because the Haiku build is currently broken
@@ -161,7 +147,6 @@ jobs:
       security-events: write
       contents: read
     uses: ./.github/workflows/build-haiku-amd64.yml
-    secrets: inherit
 
   windows-hosts:
     needs: no-features-test
@@ -189,7 +174,8 @@ jobs:
       msystem: ${{ matrix.msystem }}
       msystem-lower: ${{ matrix.msystem-lower }}
       msys-arch: ${{ matrix.msys-arch }}
-    secrets: inherit
+    secrets:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
 
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'fastfetch-cli/fastfetch'
@@ -215,4 +201,3 @@ jobs:
     uses: ./.github/workflows/build-release.yml
     with:
       ffversion: ${{ needs.linux-hosts.outputs.ffversion }}
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
 
 jobs:
   spellcheck:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-spellcheck.yml
 
   no-features-test:
     needs: spellcheck
     name: No-features-test
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-no-features-test.yml
 
@@ -38,7 +39,6 @@ jobs:
     needs: no-features-test
     name: Linux-i686
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-linux-i686.yml
 
@@ -46,7 +46,6 @@ jobs:
     needs: no-features-test
     name: Linux-armv7l
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-linux-armv7l.yml
 
@@ -54,7 +53,6 @@ jobs:
     needs: no-features-test
     name: Linux-loong64
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-linux-loong64.yml
 
@@ -62,7 +60,6 @@ jobs:
     needs: no-features-test
     name: Linux-${{ matrix.arch }}
     permissions:
-      security-events: write
       contents: read
     strategy:
       matrix:
@@ -77,13 +74,14 @@ jobs:
   musl-amd64:
     needs: no-features-test
     name: Musl-amd64
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-musl-amd64.yml
 
   macos-hosts:
     needs: no-features-test
     name: macOS-${{ matrix.arch }}
     permissions:
-      security-events: write
       contents: read
     strategy:
       matrix:
@@ -100,18 +98,21 @@ jobs:
   omnios-amd64:
     needs: no-features-test
     name: OmniOS-amd64
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-omnios-amd64.yml
 
   solaris-amd64:
     needs: no-features-test
     name: Solaris-amd64
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-solaris-amd64.yml
 
   freebsd-amd64:
     needs: no-features-test
     name: FreeBSD-amd64
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-freebsd-amd64.yml
 
@@ -119,7 +120,6 @@ jobs:
     needs: no-features-test
     name: OpenBSD-amd64
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-openbsd-amd64.yml
 
@@ -127,7 +127,6 @@ jobs:
     needs: no-features-test
     name: NetBSD-amd64
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-netbsd-amd64.yml
 
@@ -135,7 +134,6 @@ jobs:
     needs: no-features-test
     name: DragonFly-amd64
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-dragonfly-amd64.yml
 
@@ -144,7 +142,6 @@ jobs:
     needs: no-features-test
     name: Haiku-amd64
     permissions:
-      security-events: write
       contents: read
     uses: ./.github/workflows/build-haiku-amd64.yml
 
@@ -152,8 +149,10 @@ jobs:
     needs: no-features-test
     name: Windows-${{ matrix.arch }}
     permissions:
-      security-events: write
       contents: read
+      # The SignPath action reads job details and downloads the unsigned
+      # artifact with the workflow token.
+      actions: read
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Drive-by CI hardening in three commits, one logical change each, found with the Plumber CLI (https://github.com/getplumber/plumber) and verified on dev.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v1` or a branch like `@master` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code. The spots that matter here: `build-release.yml` creates the GitHub release with the binaries users download, and `build-windows-hosts.yml` holds the SignPath token, so a re-pointed tag in those paths could ship a tampered or wrongly signed release. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). You already pin docker/setup-qemu-action by sha and you bumped action majors by hand before (#808), so this just finishes the job: every sha was resolved from the upstream repo and cross checked against its release tag, and the three `@master` refs (cross-platform-actions, setup-alpine, get-latest-release) are pinned to their latest release tag. The pins stay maintainable with a dependabot config for the `github-actions` ecosystem (the repo has none today, happy to add one here if you want); dependabot and renovate both bump sha pins and keep the version comment in sync.

**Commit 2 drops `secrets: inherit` from all 17 reusable workflow calls.** The only secret any called workflow reads is `SIGNPATH_API_TOKEN` in `build-windows-hosts.yml`, so that one is declared and passed explicitly and nothing else gets the secret set. A compromised step in one of the BSD build VMs now has no signing token in reach. The secret is optional in the called workflow, so fork and PR runs behave exactly as before (the signing step is already guarded to upstream pushes).

**Commit 3 scopes the GITHUB_TOKEN per workflow**, derived from what each job actually does with it: every build workflow declares `contents: read`; `build-linux-hosts.yml` keeps `security-events: write` for its CodeQL upload while the other callers lose that grant (they never upload scanning results); `build-windows-hosts.yml` gets `actions: read`, which the SignPath action documents needing to read job details and fetch the unsigned artifact; `build-release.yml` declares the `contents: write` its caller already grants. Runs that execute PR code now hold a read-only token.

Two heads up:

- If the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v1`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.
- If you would rather not have a third-party action fetching the latest release tag in the release path at all, `pozetroninc/github-action-get-latest-release` can be replaced with a two-line `gh api` step; happy to do that here, kept the change minimal for now.

I will also open a PR which adds the tool to CI so this does not quietly drift back; that one is a bonus, this PR stands on its own.

## Related issue (required for new logos for new distros)

Not a logo PR, no related issue.

## Changes

- Pin all 51 action references across the 19 workflows to full commit SHAs with version comments
- Replace `secrets: inherit` with an explicit, declared `SIGNPATH_API_TOKEN` pass to the one workflow that uses it
- Declare least-privilege `GITHUB_TOKEN` permissions on every workflow, derived from actual token use

## Screenshots

No visual changes.

## Checklist

- [x] I have tested my changes locally.