### PR TITLE
CI: adds Plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,36 @@
+name: Plumber
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: run plumber
+        uses: getplumber/plumber@40bd6b5bb8ff4f0944feacaeb41dea6bce08d62d # v0.4.28
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,20 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: "2.0"
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the niche platform
+      # actions this repo already relies on for its BSD, Solaris and
+      # arch-emulation builds, plus the release helpers.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - cross-platform-actions/action
+        - jirutka/setup-alpine
+        - ncipollo/release-action
+        - pozetroninc/github-action-get-latest-release
+        - uraimo/run-on-arch-action
+        - vmactions/solaris-vm

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![GitHub release (with filter)](https://img.shields.io/github/v/release/fastfetch-cli/fastfetch?logo=github)](https://github.com/fastfetch-cli/fastfetch/releases)
 [![latest packaged version(s)](https://repology.org/badge/latest-versions/fastfetch.svg)](https://repology.org/project/fastfetch/versions)
 [![Packaging status](https://repology.org/badge/tiny-repos/fastfetch.svg)](https://repology.org/project/fastfetch/versions)
+[![Plumber Score](https://score.getplumber.io/github.com/fastfetch-cli/fastfetch.svg)](https://score.getplumber.io/github.com/fastfetch-cli/fastfetch)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/fastfetch-cli/fastfetch)
 [![中文README](https://img.shields.io/badge/%E4%B8%AD%E6%96%87-README-red)](README-cn.md)
 


### PR DESCRIPTION
## Summary

Companion to https://github.com/fastfetch-cli/fastfetch/pull/2492, merge that one first: the check added here flags the unpinned actions, the shared secrets and the missing permission scopes until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to dev/master and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, a secret handed to a workflow that does not need it, that kind of thing. The gate passes at 85 of 100 points, so one small finding does not block your PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the Security tab as SARIF (skipped on PRs from forks, the report stays as a workflow artifact there).
- `.plumber.yaml`: a small overlay that inherits the tool's built-in baseline; the only thing written is what differs for this repo, the niche platform actions your BSD, Solaris and arch-emulation builds rely on are trusted on top of the curated default source list. Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge next to the existing ones.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of the default branch. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I close this PR, the hardening PR stands on its own.

## Related issue (required for new logos for new distros)

Not a logo PR, no related issue.

## Changes

- Add the Plumber workflow, its config overlay and the score badge

## Screenshots

No visual changes.

## Checklist

- [x] I have tested my changes locally.