### PR TITLE
TerminalFont (Alacritty): fix font size never being parsed from config

### DIFF
--- a/src/detection/terminalfont/terminalfont.c
+++ b/src/detection/terminalfont/terminalfont.c
@@ -23,13 +23,13 @@ static void detectAlacritty(FFTerminalFontResult* terminalFont) {
         };
 
         // alacritty parses config files in this order
-        if (ffParsePropFileConfigValues("alacritty/alacritty.toml", 2, fontQueryToml)) {
+        if (ffParsePropFileConfigValues("alacritty/alacritty.toml", 3, fontQueryToml)) {
             break;
         }
-        if (ffParsePropFileConfigValues("alacritty.toml", 2, fontQueryToml)) {
+        if (ffParsePropFileConfigValues("alacritty.toml", 3, fontQueryToml)) {
             break;
         }
-        if (ffParsePropFileConfigValues(".alacritty.toml", 2, fontQueryToml)) {
+        if (ffParsePropFileConfigValues(".alacritty.toml", 3, fontQueryToml)) {
             break;
         }
     } while (false);


### PR DESCRIPTION
## Summary

`detectAlacritty()` passes `numQueries = 2` to `ffParsePropFileConfigValues()`, but `fontQueryToml` has three entries. `{ "size =", &fontSize }` sits at index 2 and is never queried, so `fontSize` stays empty and the hardcoded `11.25` fallback is used for every Alacritty user.

Introduced in dd30c82b83667ce45d71fb4d32b5b0c2cb727e19, which added `{ "family =", &fontFamily }` to the middle of the array without bumping the count, and shipped in 2.67.0. **It fails silently** — the family is still correct and only the size is wrong, so there is no error to notice.

## Testing

Fedora 43, Alacritty 0.17.0, `~/.config/alacritty/alacritty.toml`:

| `size =` in config | before | after |
|---|---|---|
| `20` | `JetBrainsMono Nerd Font (11.25pt, Regular)` | `JetBrainsMono Nerd Font (20pt, Regular)` |
| `13.5` | `JetBrainsMono Nerd Font (11.25pt, Regular)` | `JetBrainsMono Nerd Font (13.5pt, Regular)` |

Both sizes were checked against the actual rendered window, not just the reported string.

## Related issue (required for new logos for new distros)

N/A — no existing report; found while investigating #2348.

## Changes

- Pass `3` instead of `2` as `numQueries` for all three Alacritty config paths, so `size =` is actually queried.

## Screenshots

No visual changes — the fix only corrects the reported value.

## Checklist

- [x] I have tested my changes locally.
