### PR TITLE
support images in zellij

### DIFF
--- a/src/logo/image/image.c
+++ b/src/logo/image/image.c
@@ -996,7 +996,7 @@ bool ffLogoPrintImageIfExists(FFLogoType type, bool printError) {
     }
 
     const char* term = getenv("TERM");
-    if ((term && ffStrEquals(term, "screen")) || getenv("ZELLIJ")) {
+    if (term && ffStrEquals(term, "screen")) {
         if (printError) {
             fputs("Logo: Image logo is not supported in terminal multiplexers\n", stderr);
         }


### PR DESCRIPTION
## Summary
Zellij now supports kitty-image-protocol.
Ref-https://github.com/zellij-org/zellij/commit/0e6e4404027a187f1399a43bf91bdbd13d9636e1


## Checklist

- [x] I have tested my changes locally.
