### PR TITLE
Doc: restore Star History chart in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,15 @@ If you find Fastfetch useful, please consider donating.
 
 * Free code signing provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/)
 * This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it
+
+## Star History
+
+Give us a star to show your support!
+
+<a href="https://star-history.dera.page/#fastfetch-cli/fastfetch&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=fastfetch-cli/fastfetch&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=fastfetch-cli/fastfetch&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=fastfetch-cli/fastfetch&type=Date" />
+  </picture>
+</a>


### PR DESCRIPTION
The Star History chart was removed in 8df0a1c9 (Fixes #2508) because the previous chart was broken due to GitHub stargazer API restrictions. This change restores it at the same location using a working data source that requires no API token, so the chart renders correctly again.