### PR TITLE
bumped minimum CMake version to 3.21.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.0) # target_link_libraries with OBJECT libs & project homepage url
+cmake_minimum_required(VERSION 3.21.0) # C_STANDARD
 
 project(fastfetch
     VERSION 2.67.1


### PR DESCRIPTION
C_STANDARD 23 was added in 3.21 according to [docs](https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html).

I was getting the following error on an older CMake:

```
CMake Error at /fastfetch-2.67.1/build/CMakeFiles/CMakeTmp/CMakeLists.txt:15 (add_executable):
  C_STANDARD is set to invalid value '23'
```

- [x] I have tested my changes locally.
