### PR TITLE
Russian key names: proofreading pass

### DIFF
--- a/src/modules/bluetooth/bluetooth.c
+++ b/src/modules/bluetooth/bluetooth.c
@@ -165,7 +165,7 @@ FFModuleBaseInfo ffBluetoothModuleInfo = {
         .ko = "블루투스",
         .pl = "Bluetooth",
         .pt = "Bluetooth",
-        .ru = "Блютуз",
+        .ru = "Bluetooth",
         .zh_CN = "蓝牙",
         .zh_TW = "藍牙",
     },

--- a/src/modules/bluetoothradio/bluetoothradio.c
+++ b/src/modules/bluetoothradio/bluetoothradio.c
@@ -202,7 +202,7 @@ FFModuleBaseInfo ffBluetoothRadioModuleInfo = {
         .ko = "블루투스 어댑터",
         .pl = "Adapter Bluetooth",
         .pt = "Adaptador Bluetooth",
-        .ru = "Блютуз-адаптер",
+        .ru = "Bluetooth-адаптер",
         .zh_CN = "蓝牙适配器",
         .zh_TW = "藍牙配接器",
     },

--- a/src/modules/chassis/chassis.c
+++ b/src/modules/chassis/chassis.c
@@ -124,7 +124,7 @@ FFModuleBaseInfo ffChassisModuleInfo = {
         .ko = "섀시",
         .pl = "Obudowa",
         .pt = "Chassi",
-        .ru = "Шасси",
+        .ru = "Корпус",
         .zh_CN = "机箱",
         .zh_TW = "機箱",
     },

--- a/src/modules/cpu/cpu.c
+++ b/src/modules/cpu/cpu.c
@@ -265,7 +265,7 @@ FFModuleBaseInfo ffCPUModuleInfo = {
         .ko = "CPU",
         .pl = "CPU",
         .pt = "CPU",
-        .ru = "CPU",
+        .ru = "Процессор",
         .zh_CN = "CPU",
         .zh_TW = "CPU",
     },

--- a/src/modules/cpuusage/cpuusage.c
+++ b/src/modules/cpuusage/cpuusage.c
@@ -193,7 +193,7 @@ FFModuleBaseInfo ffCPUUsageModuleInfo = {
         .ko = "CPU 사용량",
         .pl = "Użycie CPU",
         .pt = "Uso da CPU",
-        .ru = "Использование ЦП",
+        .ru = "Использование процессора",
         .zh_CN = "CPU使用率",
         .zh_TW = "CPU使用率",
     },

--- a/src/modules/de/de.c
+++ b/src/modules/de/de.c
@@ -96,7 +96,7 @@ FFModuleBaseInfo ffDEModuleInfo = {
         .ko = "데스크탑 환경",
         .pl = "Środowisko graficzne",
         .pt = "Ambiente de desktop",
-        .ru = "Рабочая среда",
+        .ru = "Рабочее окружение",
         .zh_CN = "桌面环境",
         .zh_TW = "桌面環境",
     },

--- a/src/modules/diskio/diskio.c
+++ b/src/modules/diskio/diskio.c
@@ -184,7 +184,7 @@ FFModuleBaseInfo ffDiskIOModuleInfo = {
         .ko = "디스크 I/O",
         .pl = "Dysk I/O",
         .pt = "Disco I/O",
-        .ru = "Диск I/O",
+        .ru = "Дисковый I/O",
         .zh_CN = "磁盘 I/O",
         .zh_TW = "磁碟 I/O",
     },

--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -493,7 +493,7 @@ FFModuleBaseInfo ffGPUModuleInfo = {
         .ko = "GPU",
         .pl = "GPU",
         .pt = "GPU",
-        .ru = "GPU",
+        .ru = "Видеокарта",
         .zh_CN = "显卡",
         .zh_TW = "顯卡",
     },

--- a/src/modules/host/host.c
+++ b/src/modules/host/host.c
@@ -150,7 +150,7 @@ FFModuleBaseInfo ffHostModuleInfo = {
         .ko = "호스트",
         .pl = "Host",
         .pt = "Host",
-        .ru = "Хост",
+        .ru = "Модель",
         .zh_CN = "主机",
         .zh_TW = "主機",
     },

--- a/src/modules/initsystem/initsystem.c
+++ b/src/modules/initsystem/initsystem.c
@@ -115,7 +115,7 @@ FFModuleBaseInfo ffInitSystemModuleInfo = {
         .ko = "초기화 시스템",
         .pl = "System init",
         .pt = "Sistema de inicialização",
-        .ru = "Init-система",
+        .ru = "Система инициализации",
         .zh_CN = "Init 系统",
         .zh_TW = "Init 系統",
     },

--- a/src/modules/poweradapter/poweradapter.c
+++ b/src/modules/poweradapter/poweradapter.c
@@ -122,7 +122,7 @@ FFModuleBaseInfo ffPowerAdapterModuleInfo = {
         .ko = "전원 어댑터",
         .pl = "Zasilacz",
         .pt = "Fonte de alimentação",
-        .ru = "Блок питания",
+        .ru = "Адаптер питания",
         .zh_CN = "电源适配器",
         .zh_TW = "電源轉接器",
     },

--- a/src/modules/publicip/publicip.c
+++ b/src/modules/publicip/publicip.c
@@ -122,7 +122,7 @@ FFModuleBaseInfo ffPublicIPModuleInfo = {
         .ko = "공용 IP",
         .pl = "Publiczne IP",
         .pt = "IP público",
-        .ru = "Публичный IP",
+        .ru = "Внешний IP",
         .zh_CN = "公网 IP",
         .zh_TW = "公網 IP",
     },

--- a/src/modules/swap/swap.c
+++ b/src/modules/swap/swap.c
@@ -196,7 +196,7 @@ FFModuleBaseInfo ffSwapModuleInfo = {
         .ko = "스왑",
         .pl = "Swap",
         .pt = "Swap",
-        .ru = "Своп",
+        .ru = "Подкачка",
         .zh_CN = "交换空间",
         .zh_TW = "交換空間",
     },


### PR DESCRIPTION
Follow-up to #2503. I went through all 75 `.ru` strings one by one as a native speaker. Thirteen needed work, the rest are fine as they are.

The rule I applied is not "Latin vs Cyrillic" — it is what kind of word it is. Proper names and trademarks have no Russian name and are written in Latin script even in Russian-language UIs: Bluetooth, Wi-Fi, Vulkan, OpenGL, OpenCL, BIOS, TPM, DNS, BTRFS, Zpool. Generic words that have long-settled Russian equivalents get translated. Both edges of that line were broken in the current set.

On the Latin side, the two we already agreed on: Bluetooth and Bluetooth Radio were transliterated as "Блютуз". Nobody spells it that way outside of jokes.

On the other side, CPU and GPU are ordinary generic words with settled Russian names, and the same entity was being called three different things: `CPU`, "Кэш процессора", "Использование ЦП". Now it is "Процессор" / "Кэш процессора" / "Использование процессора" (dropped the "ЦП" abbreviation, it is not needed), and GPU is "Видеокарта".

The rest:

- Host: "Хост" meant network host, but the module prints the machine model. Now "Модель".
- Chassis: "Шасси" is a car or rack chassis in Russian. A PC case is "Корпус".
- Power Adapter: "Блок питания" is the PSU inside a desktop, not the laptop brick. Now "Адаптер питания".
- Swap: "Своп" was a transliteration; the standard term is "Подкачка".
- Desktop Environment: "Рабочая среда" reads as "workplace". "Рабочее окружение" is what people actually say.
- Public IP: "Внешний IP" is the normal counterpart to "Локальный IP".
- Init System: "Init-система" was a half-calque, now "Система инициализации".
- Disk I/O: was "Диск I/O" (English word order) while Network I/O was already "Сетевой I/O". Made it "Дисковый I/O" so the pair matches.

I left a few debatable ones alone: "Менеджер загрузки" (Boot Manager), "Иконки" (Icons) and "Пользовательский" (Custom) are all defensible as they stand.

Built it and checked the output live with `--key-language ru`, including the modules that are not in the default preset. Multi-GPU numbering reads correctly as "Видеокарта 1" / "Видеокарта 2". The longest key is now "Использование процессора" at 24 chars vs 19 for the longest English one; with the default `key.width` of 0 there is no column padding at all, and with an explicit narrow width the separating space is still emitted, so nothing collides.

Split into two commits so the Bluetooth part can be taken on its own — and feel free to drop any single line from the second commit if you disagree, they are all independent.
