### PR TITLE
L10n: falls back to English when the auto-detected locale is unsupported

### DIFF
--- a/doc/help.json
+++ b/doc/help.json
@@ -588,7 +588,7 @@
         {
             "long": "key-language",
             "desc": "Specify the language used for module keys",
-            "remark": "Leave empty for auto-detection based on the system locale",
+            "remark": "Leave empty for auto-detection based on the system locale. Unsupported locales fall back to English",
             "arg": {
                 "type": "enum",
                 "default": "en",

--- a/src/options/display.c
+++ b/src/options/display.c
@@ -17,7 +17,9 @@
 // @returns offsetof(FFModuleDisplayName, <language>)
 // @see src/common/option.h
 static uint32_t optionParseLanguageString(FFstrbuf* language) {
-    if (language->length == 0) {
+    const bool detected = language->length == 0;
+
+    if (detected) {
 #if !FF_MODULE_DISABLE_LOCALE
         const char* error = ffDetectLocale(language);
         if (__builtin_expect(error != nullptr, false)) {
@@ -52,7 +54,7 @@ static uint32_t optionParseLanguageString(FFstrbuf* language) {
 
     // The language code is expected to be in the format of "en", "en_US", "de", "de_DE", etc.
     // First try to match the full language code, then try to match just the first two characters (the language part).
-    // If no match is found, report a language not supported error.
+    // If no match is found, report a language not supported error, unless the language was auto-detected.
     // en_US -> offsetof(FFModuleDisplayName, en)
     // en -> offsetof(FFModuleDisplayName, en)
     // zh_CN -> offsetof(FFModuleDisplayName, zh_CN)
@@ -85,6 +87,10 @@ static uint32_t optionParseLanguageString(FFstrbuf* language) {
 #pragma GCC diagnostic pop
 
 error:
+    // The user asked for the system locale, not for this specific language. Most locales have no
+    // translation, so falling back to English is friendlier than aborting fastfetch entirely.
+    if (detected) return offsetof(FFModuleDisplayName, en);
+
     fprintf(stderr, "Error: Language '%s' is not supported\n", language->chars);
     exit(477);
 }


### PR DESCRIPTION
## Summary

`--key-language` with an empty value, and `"language": null` in the config, mean "use my
system locale". If that locale has no translation, fastfetch printed nothing and exited 477
instead. So one config file works on my machine and aborts on a Dutch or Ukrainian one, and
in any `LC_ALL=POSIX` script or CI job.

```console
$ LC_ALL=uk_UA.UTF-8 fastfetch --key-language ""     # before
Error: Language 'uk_ua' is not supported
$ echo $?
221
$ LC_ALL=uk_UA.UTF-8 fastfetch --key-language ""     # after
OS: CachyOS x86_64
...
```

## Related issue

Follow-up to the second point in https://github.com/fastfetch-cli/fastfetch/issues/2503#issuecomment-3592294927 — you fixed `pt` there, this is the fallback half.

## Changes

- An auto-detected locale that reaches `error:` now returns English instead of `exit(477)`.
- An explicit `--key-language` value still errors, so typos and bare `zh` are still reported.
- Help remark mentions the fallback.

## Testing

CachyOS, x86_64, glibc 2.42, gcc 15. Differential over all 533 locale names glibc ships
(`/usr/share/i18n/locales` + `SUPPORTED`), `--key-language ""`, before vs after:

| | count |
|---|---|
| identical | 179 |
| aborted before, works now | 354 |
| **regressions** | **0** |

Spot checks unchanged: `ru_RU.UTF-8` → `Операционная система`, `pt_BR` → `Sistema operacional`,
`zh_CN`/`zh_TW` → Chinese, `C` → English. Explicit `--key-language zh` / `nl_NL` / `xx` still
exit 221. `"language": null` under `uk_UA.UTF-8` now prints instead of aborting.

## Screenshots

No visual changes for supported locales.

## Checklist

- [x] I have tested my changes locally.
