### PR TITLE
Logo (image): also try unsuffixed ImageMagick library names

### DIFF
--- a/src/logo/image/im6.c
+++ b/src/logo/image/im6.c
@@ -15,7 +15,8 @@ FFLogoImageResult ffLogoPrintImageIM6(FFLogoRequestData* requestData) {
     // clang-format off
     FF_LIBRARY_LOAD(imageMagick, FF_LOGO_IMAGE_RESULT_INIT_ERROR,
         "libMagickCore-6.Q16HDRI" FF_LIBRARY_EXTENSION, 8,
-        "libMagickCore-6.Q16" FF_LIBRARY_EXTENSION, 8
+        "libMagickCore-6.Q16" FF_LIBRARY_EXTENSION, 8,
+        "libMagickCore-6" FF_LIBRARY_EXTENSION, 8
     )
     // clang-format on
     FF_LIBRARY_LOAD_SYMBOL_ADDRESS(imageMagick, ffResizeImage, ResizeImage, FF_LOGO_IMAGE_RESULT_INIT_ERROR)

--- a/src/logo/image/im7.c
+++ b/src/logo/image/im7.c
@@ -20,7 +20,8 @@ FFLogoImageResult ffLogoPrintImageIM7(FFLogoRequestData* requestData) {
     #else
     FF_LIBRARY_LOAD(imageMagick, FF_LOGO_IMAGE_RESULT_INIT_ERROR,
         "libMagickCore-7.Q16HDRI" FF_LIBRARY_EXTENSION, 11,
-        "libMagickCore-7.Q16" FF_LIBRARY_EXTENSION, 11
+        "libMagickCore-7.Q16" FF_LIBRARY_EXTENSION, 11,
+        "libMagickCore-7" FF_LIBRARY_EXTENSION, 11
     )
     #endif
     // clang-format on


### PR DESCRIPTION
## Summary

FreeBSD (and other systems that build ImageMagick without encoding the
quantum depth into the library name) install libMagickCore-7.so and
libMagickCore-6.so without a .Q16HDRI / .Q16 suffix.  dlopen currently
only tries the suffixed names, so image logos always fall back to ASCII
art with "Image Magick library not found" even when ImageMagick is
installed.  Append the plain library names as a last resort.

- [x] I have tested my changes locally.
