### PR TITLE
CMake: bump min version to 3.21

### DIFF
--- a/.github/workflows/build-linux-i686.yml
+++ b/.github/workflows/build-linux-i686.yml
@@ -40,7 +40,7 @@ jobs:
         run: cmake --version
 
       - name: configure project
-        run: CC=gcc-13 CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew PKG_CONFIG_PATH=/home/linuxbrew/.linuxbrew/lib/pkgconfig:$PKG_CONFIG_PATH cmake -DCMAKE_C_FLAGS="-m32 -march=i686 -mtune=i686" -DCMAKE_SYSTEM_PROCESSOR_OVERRIDE=i686 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=i386 -GNinja -DSET_TWEAK=Off -DBUILD_TESTS=On -DENABLE_EMBEDDED_PCIIDS=On -DENABLE_EMBEDDED_AMDGPUIDS=On -DCMAKE_INSTALL_PREFIX=/usr .
+        run: CC=gcc-13 CMAKE_PREFIX_PATH=/home/linuxbrew/.linuxbrew PKG_CONFIG_PATH=/home/linuxbrew/.linuxbrew/lib/pkgconfig:$PKG_CONFIG_PATH cmake -DCMAKE_C_FLAGS="-m32 -march=i686 -mtune=i686" -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=5.10.0 -DCMAKE_SYSTEM_PROCESSOR=i686 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=i386 -GNinja -DSET_TWEAK=Off -DBUILD_TESTS=On -DENABLE_EMBEDDED_PCIIDS=On -DENABLE_EMBEDDED_AMDGPUIDS=On -DCMAKE_INSTALL_PREFIX=/usr .
 
       - name: build project
         run: cmake --build . --target package --verbose -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.0) # Don't change before we investigate why #2553 happens
+cmake_minimum_required(VERSION 3.21.0) # C_STANDARD C17 and C23
 
 project(fastfetch
     VERSION 2.68.1
@@ -9,9 +9,6 @@ project(fastfetch
 
 set(PROJECT_LICENSE "MIT license")
 
-if(DEFINED CMAKE_SYSTEM_PROCESSOR_OVERRIDE) # Used by github actions for i686 build
-    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR_OVERRIDE} CACHE INTERNAL "")
-endif()
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" CMAKE_SYSTEM_PROCESSOR)
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     set(CMAKE_SYSTEM_PROCESSOR "amd64")


### PR DESCRIPTION
C_STANDARD C17 and C23 were only introduced in CMake 3.21

CMake older than `3.21` give the `C_STANDARD is set to invalid value '23'` error.

## Checklist

- [x] I have tested my changes locally.

Also tested the workflow in my fork:

<img width="740" height="330" alt="workflow creates *-i686 packages" src="https://github.com/user-attachments/assets/89289d22-1fc1-46a8-acf3-55d3ff85a781" />

## Notes

Between versions `3.12` and `3.21` the [CMAKE_SYSTEM_PROCESSOR](https://cmake.org/cmake/help/v3.21/variable/CMAKE_SYSTEM_PROCESSOR.html) variable added:

> When cross-compiling, a [CMAKE_TOOLCHAIN_FILE](https://cmake.org/cmake/help/v3.21/variable/CMAKE_TOOLCHAIN_FILE.html#variable:CMAKE_TOOLCHAIN_FILE) should set the `CMAKE_SYSTEM_PROCESSOR` variable to match target architecture that it specifies (via [CMAKE_<LANG>_COMPILER](https://cmake.org/cmake/help/v3.21/variable/CMAKE_LANG_COMPILER.html#variable:CMAKE_%3CLANG%3E_COMPILER) and perhaps [CMAKE_<LANG>_COMPILER_TARGET](https://cmake.org/cmake/help/v3.21/variable/CMAKE_LANG_COMPILER_TARGET.html#variable:CMAKE_%3CLANG%3E_COMPILER_TARGET)).

So by that text it seems that `CMAKE_TOOLCHAIN_FILE` is required, however, the page for [CMAKE_SYSTEM_NAME](https://cmake.org/cmake/help/v3.21/variable/CMAKE_SYSTEM_NAME.html) specifies:

> `CMAKE_SYSTEM_NAME` may be set explicitly when first configuring a new build tree in order to enable [cross compiling](https://cmake.org/cmake/help/v3.21/manual/cmake-toolchains.7.html#cross-compiling-toolchain). In this case the [CMAKE_SYSTEM_VERSION](https://cmake.org/cmake/help/v3.21/variable/CMAKE_SYSTEM_VERSION.html#variable:CMAKE_SYSTEM_VERSION) variable must also be set explicitly.

Which I take it as using `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_VERSION` being enough to enable cross-compilation? I tested exactly this (added them to the workflow) and it seems to have resolved the issue, cross-compilation works and produces `*-i686` artifacts, and this is the least intrusive change. However, the text about `CMAKE_SYSTEM_NAME` enabling cross-compilation was present even in `3.12`, so I honestly don't know why it worked before without it, and why it works now with it. It may be better to also follow the instruction to use `CMAKE_TOOLCHAIN_FILE` just in case, though that will require creating the file. Let me know if you do want to do that, or leave it for when/if this becomes an issue again.