### PR TITLE
GPU (Windows): preserves the generic basic display adapter label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Features:
 * Added new ARM SoCs (CPU, Linux / Android)
 
 Bugfixes:
+* Fixed the default GPU output prefixing the Microsoft Basic Display Adapter label with the hardware vendor. (#2339, GPU, Windows)
 * Fixed I/O rate calculation precision in DiskIO and NetIO, and prevented division by zero. (DiskIO / NetIO)
 * Fixed the fast path of ash version detection. (Shell)
 * Fixed memory usage detection support on x86-32 FreeBSD (Memory, FreeBSD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2172,6 +2172,13 @@ if (BUILD_TESTS)
         PRIVATE libfastfetch
     )
 
+    add_executable(fastfetch-test-gpu
+        tests/gpu.c
+    )
+    target_link_libraries(fastfetch-test-gpu
+        PRIVATE libfastfetch
+    )
+
     enable_testing()
     add_test(NAME test-strbuf COMMAND fastfetch-test-strbuf)
     add_test(NAME test-list COMMAND fastfetch-test-list)
@@ -2179,6 +2186,7 @@ if (BUILD_TESTS)
     add_test(NAME test-color COMMAND fastfetch-test-color)
     add_test(NAME test-duration COMMAND fastfetch-test-duration)
     add_test(NAME test-strutil COMMAND fastfetch-test-strutil)
+    add_test(NAME test-gpu COMMAND fastfetch-test-gpu)
 endif()
 
 ##################

--- a/src/modules/gpu/gpu.c
+++ b/src/modules/gpu/gpu.c
@@ -11,6 +11,15 @@
 
 #include <stdlib.h>
 
+void ffGPUAppendName(const FFGPUResult* gpu, FFstrbuf* output) {
+    // This is a generic driver label rather than a GPU model name.
+    if (gpu->vendor.length > 0 && !ffStrbufStartsWithIgnCase(&gpu->name, &gpu->vendor) && !ffStrbufEqualS(&gpu->name, "Microsoft Basic Display Adapter")) {
+        ffStrbufAppend(output, &gpu->vendor);
+        ffStrbufAppendC(output, ' ');
+    }
+    ffStrbufAppend(output, &gpu->name);
+}
+
 static void printGPUResult(FFGPUOptions* options, uint8_t index, const FFGPUResult* gpu) {
     const char* type;
     switch (gpu->type) {
@@ -32,12 +41,7 @@ static void printGPUResult(FFGPUOptions* options, uint8_t index, const FFGPUResu
 
         FF_STRBUF_AUTO_DESTROY output = ffStrbufCreate();
 
-        if (gpu->vendor.length > 0 && !ffStrbufStartsWithIgnCase(&gpu->name, &gpu->vendor)) {
-            ffStrbufAppend(&output, &gpu->vendor);
-            ffStrbufAppendC(&output, ' ');
-        }
-
-        ffStrbufAppend(&output, &gpu->name);
+        ffGPUAppendName(gpu, &output);
 
         if (gpu->coreCount != FF_GPU_CORE_COUNT_UNSET) {
             ffStrbufAppendF(&output, " (%d)", gpu->coreCount);

--- a/src/modules/gpu/gpu.h
+++ b/src/modules/gpu/gpu.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "option.h"
+#include "detection/gpu/gpu.h"
 
 bool ffPrintGPU(FFGPUOptions* options);
+void ffGPUAppendName(const FFGPUResult* gpu, FFstrbuf* output);
 void ffInitGPUOptions(FFGPUOptions* options);
 void ffDestroyGPUOptions(FFGPUOptions* options);
 

--- a/tests/gpu.c
+++ b/tests/gpu.c
@@ -1,0 +1,39 @@
+#include "modules/gpu/gpu.h"
+
+#include <stdlib.h>
+
+static void verify(const char* vendor, const char* name, const char* expected, int lineNo) {
+    // Supply detected data directly so output tests do not depend on installed GPU drivers.
+    FFGPUResult gpu = {};
+    ffStrbufInitS(&gpu.vendor, vendor);
+    ffStrbufInitS(&gpu.name, name);
+    FF_STRBUF_AUTO_DESTROY output = ffStrbufCreate();
+    ffGPUAppendName(&gpu, &output);
+    if (!ffStrbufEqualS(&output, expected)) {
+        fprintf(stderr, "[%d] Expected \"%s\", got \"%s\"\n", lineNo, expected, output.chars);
+        exit(1);
+    }
+
+    // Rendering must not change the detected values used in JSON and custom formats.
+    if (!ffStrbufEqualS(&gpu.vendor, vendor) || !ffStrbufEqualS(&gpu.name, name)) {
+        fprintf(stderr, "[%d] Detected GPU data changed during rendering\n", lineNo);
+        exit(1);
+    }
+    ffStrbufDestroy(&gpu.vendor);
+    ffStrbufDestroy(&gpu.name);
+}
+
+#define VERIFY(vendor, name, expected) verify((vendor), (name), (expected), __LINE__)
+
+int main(void) {
+    VERIFY("NVIDIA", "Microsoft Basic Display Adapter", "Microsoft Basic Display Adapter");
+    VERIFY("AMD", "Microsoft Basic Display Adapter", "Microsoft Basic Display Adapter");
+    VERIFY("Intel", "Microsoft Basic Display Adapter", "Microsoft Basic Display Adapter");
+    VERIFY("", "Microsoft Basic Display Adapter", "Microsoft Basic Display Adapter");
+    VERIFY("Microsoft", "Microsoft Basic Display Adapter", "Microsoft Basic Display Adapter");
+    VERIFY("NVIDIA", "GeForce RTX 4090", "NVIDIA GeForce RTX 4090");
+    VERIFY("NVIDIA", "NVIDIA GeForce RTX 4090", "NVIDIA GeForce RTX 4090");
+    VERIFY("NVIDIA", "nvidia GeForce RTX 4090", "nvidia GeForce RTX 4090");
+    VERIFY("", "GeForce RTX 4090", "GeForce RTX 4090");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Avoid prefixing the generic `Microsoft Basic Display Adapter` label with the physical GPU vendor in default output. For the data in the issue, the displayed name becomes `Microsoft Basic Display Adapter` instead of `NVIDIA Microsoft Basic Display Adapter`.

## Related issue (required for new logos for new distros)

Fixes #2339.

## Changes

- Keep detected vendor/name data intact for JSON output and custom formats; apply the exact-name exception only when assembling the default display name.
- Extract that small formatter for a driver-independent regression test. Nine cases cover the generic label with NVIDIA/AMD/Intel/Microsoft/empty vendors, normal GPU names, existing case-insensitive prefixes, and preservation of detected values.
- Add an unreleased changelog entry.

## Screenshots

Text output comparison using the issue's GPU data as a fixture:

```text
Before: NVIDIA Microsoft Basic Display Adapter
After:  Microsoft Basic Display Adapter
```

The fixture fails before the fix and passes afterward. It does not depend on changing GPU drivers.

## Validation

Built on Windows with LLVM-MinGW (Clang 23), CMake 4.4.3 and Ninja. All seven CTest executables passed, including the nine GPU fixtures. Full-repository codespell, formatting of changed code, and `git diff --check` passed. Default JSON output parsed successfully (29 module results), and the all-module preset exited successfully. Optional dependencies unavailable on this machine followed normal CMake feature detection.

AI-assisted implementation, independently reviewed by a second coding agent.

## Checklist

- [x] I have tested my changes locally.
