### PR TITLE
CPU (Linux): adds SPARC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Features:
+* Added CPU name and frequency detection support on SPARC. (CPU, Linux)
+
 # 2.68.1
 
 Changes:

--- a/src/detection/cpu/cpu_linux.c
+++ b/src/detection/cpu/cpu_linux.c
@@ -619,6 +619,9 @@ static const char* parseCpuInfo(
             (cpu->name.length == 0 && ffParsePropLine(line, "cpu :", &cpu->name)) ||
 #elif __sh__
             (cpu->name.length == 0 && ffParsePropLine(line, "cpu type :", &cpu->name)) ||
+#elif __sparc__ || __sparc
+            (cpu->name.length == 0 && ffParsePropLine(line, "cpu :", &cpu->name)) ||
+            (cpuMHz->length == 0 && ffParsePropLine(line, "Cpu0ClkTck :", cpuMHz)) ||
 #else
             (cpu->name.length == 0 && ffParsePropLine(line, "model name :", &cpu->name)) ||
             (cpu->name.length == 0 && ffParsePropLine(line, "model :", &cpu->name)) ||
@@ -1101,6 +1104,10 @@ static const char* detectPhysicalCores(FFCPUResult* cpu) {
         if (cpu->name.length) {
             ffStrbufPrependS(&cpu->name, "Machine ");
         }
+    #elif __sparc__ || __sparc
+        // Cpu0ClkTck is in Hz, printed as "%016lx" by sparc64 and "%ld" by sparc32. A 32-bit userland can run
+        // on a 64-bit kernel, so take the base from the width of the value rather than from our own bitness.
+        cpu->frequencyBase = (uint32_t) (strtoull(cpuMHz.chars, nullptr, cpuMHz.length == 16 ? 16 : 10) / 1000000);
     #endif
     }
 


### PR DESCRIPTION
## Summary

`/proc/cpuinfo` on SPARC has no `model name`, `model`, `cpu model`, `hardware` or `processor`
field, so the CPU module prints `Unknown`. The chip name is in the `cpu` field, and the clock
frequency is in `Cpu<n>ClkTck` — in Hz rather than MHz, and in hex on sparc64. SPARC has no
`cpufreq` sysfs, so that field is the only frequency source.

```diff
  # UltraSPARC T4-1 (sun4v)
- CPU: Unknown (64)
+ CPU: UltraSparc T4 (Niagara4) (64) @ 2.85 GHz

  # Sun Fire V240 (sun4u)
- CPU: Unknown (2)
+ CPU: TI UltraSparc IIIi (Jalapeno) (2) @ 1.50 GHz
```

## Related issue

`/proc/cpuinfo` for both machines is in #1529.

## Changes

- `parseCpuInfo()`: under `__sparc__`, read the name from `cpu` and the clock tick from `Cpu0ClkTck`.
- `detectCPUOthers()`: convert that from Hz to MHz. sparc64 prints it as `%016lx` and sparc32 as
  `%ld`; since a 32-bit userland can run on a 64-bit kernel, the base comes from the value's width
  rather than from the build's bitness.

Core counts already work and are unchanged (8/64 on the T4-1, 2/2 on the V240). sparc32 is untested.

## Checklist

- [x] I have tested my changes locally.
